### PR TITLE
Fix license typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## License
 
-KaTeX is licenced under the [MIT License](http://opensource.org/licenses/MIT).
+KaTeX is licensed under the [MIT License](http://opensource.org/licenses/MIT).


### PR DESCRIPTION
The word `licence` is used only as a noun (and only in British English) so it should be `licensed` in the README.
