### PR TITLE
Added set theory and logic symbols

### DIFF
--- a/src/symbols.js
+++ b/src/symbols.js
@@ -112,6 +112,36 @@ var symbols = {
             group: "textord",
             replace: "\u03a9"
         },
+        "\\neg": {
+            font: "main",
+            group: "textord",
+            replace: "\u00ac"
+        },
+        "\\lnot": {
+            font: "main",
+            group: "textord",
+            replace: "\u00ac"
+        },
+        "\\top": {
+            font: "main",
+            group: "textord",
+            replace: "\u22a4"
+        },
+        "\\bot": {
+            font: "main",
+            group: "textord",
+            replace: "\u22a5"
+        },
+        "\\emptyset": {
+            font: "main",
+            group: "textord",
+            replace: "\u2205"
+        },
+        "\\varnothing": {
+            font: "ams",
+            group: "textord",
+            replace: "\u2205"
+        },
         "\\alpha": {
             font: "main",
             group: "mathord",
@@ -301,6 +331,41 @@ var symbols = {
             group: "bin",
             replace: "\u00d7"
         },
+        "\\cap": {
+            font: "main",
+            group: "bin",
+            replace: "\u2229"
+        },
+        "\\cup": {
+            font: "main",
+            group: "bin",
+            replace: "\u222a"
+        },
+        "\\setminus": {
+            font: "main",
+            group: "bin",
+            replace: "\u2216"
+        },
+        "\\land": {
+            font: "main",
+            group: "bin",
+            replace: "\u2227"
+        },
+        "\\lor": {
+            font: "main",
+            group: "bin",
+            replace: "\u2228"
+        },
+        "\\wedge": {
+            font: "main",
+            group: "bin",
+            replace: "\u2227"
+        },
+        "\\vee": {
+            font: "main",
+            group: "bin",
+            replace: "\u2228"
+        },
         "\\surd": {
             font: "main",
             group: "textord",
@@ -395,6 +460,46 @@ var symbols = {
             font: "main",
             group: "rel",
             replace: "\u2208"
+        },
+        "\\notin": {
+            font: "main",
+            group: "rel",
+            replace: "\u2209"
+        },
+        "\\subset": {
+            font: "main",
+            group: "rel",
+            replace: "\u2282"
+        },
+        "\\supset": {
+            font: "main",
+            group: "rel",
+            replace: "\u2283"
+        },
+        "\\subseteq": {
+            font: "main",
+            group: "rel",
+            replace: "\u2286"
+        },
+        "\\supseteq": {
+            font: "main",
+            group: "rel",
+            replace: "\u2287"
+        },
+        "\\nsubseteq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2288"
+        },
+        "\\nsupseteq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2289"
+        },
+        "\\models": {
+            font: "main",
+            group: "rel",
+            replace: "\u22a8"
         },
         "\\leftarrow": {
             font: "main",


### PR DESCRIPTION
\subset, \supset, \subseteq, \supseteq, \cap, \cup, \setminus

\neg, \lnot, \top, \bot, \emptyset, \varnothing, \land, \lor,
\wedge, \vee, \notin, \nsubseteq, \nsupseteq, \models

Did not add \forall, \exists and arrows as I see there are already pull requests for those.

Resolves #52 and #62 ( with pull request #58 )
