### PR TITLE
added support for \cssId

### DIFF
--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -106,7 +106,7 @@ Lexer.prototype._innerLex = function(pos, normals, ignoreWhitespace) {
 
     throw new ParseError("Unexpected character: '" + input[0] +
         "'", this, pos);
-}
+};
 
 // A regex to match a CSS color (like #ffffff or BlueViolet)
 var cssColor = /^(#[a-z0-9]+|[a-z]+)/i;
@@ -128,6 +128,27 @@ Lexer.prototype._innerLexColor = function(pos) {
         return new LexResult("color", match[0], pos + match[0].length);
     } else {
         throw new ParseError("Invalid color", this, pos);
+    }
+};
+
+var cssIdRegex = /^([a-z\-\_][a-z0-9\-\_]*)/i;
+
+/**
+ * This function lexes a CSS id.
+ */
+Lexer.prototype._innerLexCssId = function(pos) {
+    var input = this._input.slice(pos);
+
+    // Ignore whitespace
+    var whitespace = input.match(whitespaceRegex)[0];
+    pos += whitespace.length;
+    input = input.slice(whitespace.length);
+
+    var match;
+    if ((match = input.match(cssIdRegex))) {
+        return new LexResult("cssId", match[0], pos + match[0].length);
+    } else {
+        throw new ParseError("Invalid id", this, pos);
     }
 };
 
@@ -185,6 +206,8 @@ Lexer.prototype.lex = function(pos, mode) {
         return this._innerLex(pos, textNormals, false);
     } else if (mode === "color") {
         return this._innerLexColor(pos);
+    } else if (mode === "cssId") {
+        return this._innerLexCssId(pos);
     } else if (mode === "size") {
         return this._innerLexSize(pos);
     } else if (mode === "whitespace") {

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -428,7 +428,7 @@ Parser.prototype.parseFunction = function(pos, mode) {
  * @return {?ParseFuncOrArgument}
  */
 Parser.prototype.parseSpecialGroup = function(pos, mode, outerMode) {
-    if (mode === "color" || mode === "size") {
+    if (mode === "color" || mode === "size" || mode === "cssId") {
         // color and size modes are special because they should have braces and
         // should only lex a single symbol inside
         var openBrace = this.lexer.lex(pos, outerMode);

--- a/src/buildCommon.js
+++ b/src/buildCommon.js
@@ -105,6 +105,22 @@ var makeSpan = function(classes, children, color) {
     return span;
 };
 
+// TODO: combine with makeSpan and make third param be an options dictionary?
+/**
+ * Makes a span with the given list of classes, list of children, and id.
+ */
+var makeSpanWithId = function(classes, children, id) {
+    var span = new domTree.span(classes, children);
+
+    sizeElementFromChildren(span);
+
+    if (id) {
+        span.id = id;
+    }
+
+    return span;
+};
+
 /**
  * Makes a document fragment with the given list of children.
  */
@@ -264,6 +280,7 @@ module.exports = {
     mathit: mathit,
     mathrm: mathrm,
     makeSpan: makeSpan,
+    makeSpanWithId: makeSpanWithId,
     makeFragment: makeFragment,
     makeVList: makeVList
 };

--- a/src/buildTree.js
+++ b/src/buildTree.js
@@ -81,6 +81,8 @@ var getTypeOfGroup = function(group) {
         return getTypeOfGroup(group.value);
     } else if (group.type === "color") {
         return getTypeOfGroup(group.value.value);
+    } else if (group.type === "cssId") {
+        return getTypeOfGroup(group.value.value);
     } else if (group.type === "sizing") {
         return getTypeOfGroup(group.value.value);
     } else if (group.type === "styling") {
@@ -127,6 +129,12 @@ var getBaseElem = function(group) {
             return group;
         }
     } else if (group.type === "color") {
+        if (group.value.value.length === 1) {
+            return getBaseElem(group.value.value[0]);
+        } else {
+            return group;
+        }
+    } else if (group.type === "cssId") {
         if (group.value.value.length === 1) {
             return getBaseElem(group.value.value[0]);
         } else {
@@ -243,6 +251,27 @@ var groupTypes = {
         // elements will be able to directly interact with their neighbors. For
         // example, `\color{red}{2 +} 3` has the same spacing as `2 + 3`
         return new buildCommon.makeFragment(elements);
+    },
+
+    cssId: function(group, options, prev) {
+        var elements = buildExpression(
+            group.value.value,
+            options,
+            prev
+        );
+
+        if (elements.length === 1) {
+            elements[0].id = group.value.id;
+            return elements[0];
+        } else {
+            var classes = [];
+            if (elements.length > 1) {
+                var lastChild = elements[elements.length - 1];
+                classes = lastChild.classes.slice(0);
+            }
+            classes.push(options.style.cls());
+            return buildCommon.makeSpanWithId(classes, elements, group.value.id);
+        }
     },
 
     supsub: function(group, options, prev) {

--- a/src/domTree.js
+++ b/src/domTree.js
@@ -58,6 +58,10 @@ span.prototype.toNode = function() {
         span.appendChild(this.children[i].toNode());
     }
 
+    if (this.id) {
+        span.setAttribute("id", this.id);
+    }
+
     return span;
 };
 
@@ -72,6 +76,10 @@ span.prototype.toMarkup = function() {
         markup += " class=\"";
         markup += utils.escape(createClass(this.classes));
         markup += "\"";
+    }
+
+    if (this.id) {
+        markup += " id=\"" + this.id + "\"";
     }
 
     var styles = "";
@@ -182,6 +190,10 @@ symbolNode.prototype.toNode = function() {
         }
     }
 
+    if (this.id) {
+        span.setAttribute("id", this.id);
+    }
+
     if (span) {
         span.appendChild(node);
         return span;
@@ -205,6 +217,10 @@ symbolNode.prototype.toMarkup = function() {
         markup += " class=\"";
         markup += utils.escape(createClass(this.classes));
         markup += "\"";
+    }
+
+    if (this.id) {
+        markup += " id=\"" + this.id + "\"";
     }
 
     var styles = "";

--- a/src/functions.js
+++ b/src/functions.js
@@ -118,6 +118,26 @@ var functions = {
         }
     },
 
+    "\\cssId": {
+        numArgs: 2,
+        argTypes: ["cssId", "original"],
+        handler: function(func, id, body) {
+            // Normalize the different kinds of bodies (see \text above)
+            var inner;
+            if (body.type === "ordgroup") {
+                inner = body.value;
+            } else {
+                inner = [body];
+            }
+
+            return {
+                type: "cssId",
+                id: id.value,
+                value: inner
+            };
+        }
+    },
+
     // An overline
     "\\overline": {
         numArgs: 1,

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -586,6 +586,93 @@ describe("A color parser", function() {
     });
 });
 
+describe("A cssId parser", function () {
+    var cssIdExpressionWithGroup = "\\cssId{_id_1-a}{1+2}";
+    var cssIdExpressionWithAtom = "\\cssId{id_1-a}\\frac{1}{x}";
+    var badCssIdExpression = "\\cssId{\\theta}{1+2}";
+
+    it("should not fail", function () {
+        expect(cssIdExpressionWithGroup).toParse();
+        expect(cssIdExpressionWithAtom).toParse();
+    });
+
+    it("should build a cssId node", function () {
+        var node = parseTree(cssIdExpressionWithGroup)[0];
+
+        expect(node.type).toMatch("cssId");
+        expect(node.value.id).toMatch("_id_1-a");
+        expect(node.value.value).toBeDefined();
+    });
+
+    it("should parse a group body", function () {
+        var node = parseTree(cssIdExpressionWithGroup)[0];
+
+        var inner = node.value.value;
+        expect(inner.length).toBe(3);
+        expect(inner[0].type).toMatch("textord");
+        expect(inner[1].type).toMatch("bin");
+        expect(inner[2].type).toMatch("textord");
+    });
+
+    it("should parse an atom body", function () {
+        var node = parseTree(cssIdExpressionWithAtom)[0];
+
+        var inner = node.value.value;
+        expect(inner.length).toBe(1);
+        expect(inner[0].type).toMatch("frac");
+    });
+
+    it("should not parse a id", function () {
+        expect(badCssIdExpression).toNotParse();
+    });
+});
+
+describe("A cssId tree-builder", function () {
+    it("should render a number with an id", function () {
+        var tree = parseTree("\\cssId{id1}{1}");
+        var markup = buildTree(tree).toMarkup();
+        expect(markup.indexOf('id="id1"')).not.toBe(-1);
+    });
+
+    it("should render a symbol with an id", function () {
+        var tree = parseTree("\\cssId{id1}\\pi");
+        var markup = buildTree(tree).toMarkup();
+        expect(markup.indexOf('id="id1"')).not.toBe(-1);
+    });
+
+    it("should render a variable with an id", function () {
+        var tree = parseTree("\\cssId{id1}x");
+        var markup = buildTree(tree).toMarkup();
+        expect(markup.indexOf('id="id1"')).not.toBe(-1);
+    });
+
+    it("should render an operator with an id", function () {
+        var tree = parseTree("\\cssId{id1}+");
+        var markup = buildTree(tree).toMarkup();
+        expect(markup.indexOf('id="id1"')).not.toBe(-1);
+    });
+
+    it("should render a relationship with an id", function () {
+        var tree = parseTree("\\cssId{id1}>");
+        var markup = buildTree(tree).toMarkup();
+        expect(markup.indexOf('id="id1"')).not.toBe(-1);
+    });
+
+    it("should render the numerator and denomator with different ids", function () {
+        var tree = parseTree("\\frac{\\cssId{numer}{x}}{\\cssId{denom}{x+1}}");
+        var markup = buildTree(tree).toMarkup();
+        expect(markup.indexOf('id="numer"')).not.toBe(-1);
+        expect(markup.indexOf('id="denom"')).not.toBe(-1);
+    });
+
+    it("should render a function with unique id and not its children", function () {
+        var tree = parseTree("\\cssId{id1}{\\frac{x}{x+1}}");
+        var markup = buildTree(tree).toMarkup();
+        var matches = markup.match(/id="id1"/g);
+        expect(matches.length).toBe(1);
+    });
+});
+
 describe("A tie parser", function() {
     var mathTie = "a~b";
     var textTie = "\\text{a~ b}";


### PR DESCRIPTION
Partially addresses issue https://github.com/Khan/KaTeX/issues/90 by adding `\cssId{id}{math}` command.

Examples:
- `\cssId{id_1}\theta`
- `\cssId{id_2}\frac{x}{y}`
- `\frac{\cssId{denom}x}{\cssId{denom}y}`
- `\cssId{first_sum}{1+2}+3` (creates a `<span>` around `1+2` and produces the correct spacing)
