### PR TITLE
Mention `\displaystyle` workaround in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ var html = katex.renderToString("c = \\pm\\sqrt{a^2 + b^2}");
 
 Make sure to include the CSS and font files, but there is no need to include the JavaScript.
 
+These APIs default to inline math typesetting; for display math you can prepend `\displaystyle` ([#66](https://github.com/Khan/KaTeX/issues/66)):
+
+```js
+katex.render("\\displaystyle " + formula, element);
+// OR
+var html = katex.renderToString("\\displaystyle " + formula);
+```
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md)


### PR DESCRIPTION
until the question of display math API (#66) is decided either way...

Signed the CLA.
