### PR TITLE
Removed semicolon from Parser declaration

### DIFF
--- a/src/Parser.js
+++ b/src/Parser.js
@@ -46,7 +46,7 @@ var ParseError = require("./ParseError");
 function Parser(input) {
     // Make a new lexer
     this.lexer = new Lexer(input);
-};
+}
 
 /**
  * The resulting parse tree nodes of the parse tree.


### PR DESCRIPTION
Hi, I just removed the semicolon from the Parser declaration to keep it consistent with the other declarations that did not have semicolons at the end.

Before:
![unedited_code](https://cloud.githubusercontent.com/assets/8083944/4470427/c4ba293a-4925-11e4-9647-b538e919475a.jpg)

After:
![edited_code](https://cloud.githubusercontent.com/assets/8083944/4470412/8b319586-4925-11e4-8250-7ee17a87b3fa.jpg)
