### PR TITLE
Set `documentFragment.style` to empty object

### DIFF
--- a/src/domTree.js
+++ b/src/domTree.js
@@ -246,6 +246,7 @@ class documentFragment implements HtmlDomNode {
     height: number;
     depth: number;
     maxFontSize: number;
+    style: CssStyle;          // Never used; needed for satisfying interface.
 
     constructor(children?: HtmlDomNode[]) {
         this.children = children || [];
@@ -253,6 +254,7 @@ class documentFragment implements HtmlDomNode {
         this.height = 0;
         this.depth = 0;
         this.maxFontSize = 0;
+        this.style = {};
     }
 
     hasClass(className: string): boolean {
@@ -261,14 +263,6 @@ class documentFragment implements HtmlDomNode {
 
     tryCombine(sibling: HtmlDomNode): boolean {
         return false;
-    }
-
-    get style(): CssStyle {
-        throw new Error('DocumentFragment does not support style.');
-    }
-
-    set style(_: CssStyle) {
-        throw new Error('DocumentFragment does not support style.');
     }
 
     /**


### PR DESCRIPTION
Fixes #1439.

The `classes` property of `documentFragment` already returns an empty array. 

Removed `style` getter and setter in `documentFragment`, which raises an `Error`. Separately, this removes class property getter and setter polyfill, which is about 10KB. (#1469)