### PR TITLE
Add catcode to Lexer, move comment parsing back to Lexer

### DIFF
--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -94,7 +94,7 @@ export default class Lexer implements LexerInterface {
         let text = match[2] || " ";
 
         if (this.catcode[text] === 14) { // comment character
-            const nlIndex = input.indexOf('\n', pos);
+            const nlIndex = input.indexOf('\n', this.tokenRegex.lastIndex);
             if (nlIndex === -1) {
                 this.tokenRegex.lastIndex = input.length; // EOF
                 this.settings.reportNonstrict("commentAtEnd",

--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -60,20 +60,20 @@ export default class Lexer implements LexerInterface {
     settings: Settings;
     tokenRegex: RegExp;
     // category codes, only supports comment characters (14) for now
-    catcode: {[string]: number};
+    catcodes: {[string]: number};
 
     constructor(input: string, settings: Settings) {
         // Separate accents from characters
         this.input = input;
         this.settings = settings;
         this.tokenRegex = new RegExp(tokenRegexString, 'g');
-        this.catcode = {
+        this.catcodes = {
             "%": 14, // comment character
         };
     }
 
     setCatcode(char: string, code: number) {
-        this.catcode[char] = code;
+        this.catcodes[char] = code;
     }
 
     /**
@@ -93,7 +93,7 @@ export default class Lexer implements LexerInterface {
         }
         let text = match[2] || " ";
 
-        if (this.catcode[text] === 14) { // comment character
+        if (this.catcodes[text] === 14) { // comment character
             const nlIndex = input.indexOf('\n', this.tokenRegex.lastIndex);
             if (nlIndex === -1) {
                 this.tokenRegex.lastIndex = input.length; // EOF

--- a/src/MacroExpander.js
+++ b/src/MacroExpander.js
@@ -50,7 +50,7 @@ export default class MacroExpander implements MacroContextInterface {
      * (with existing macros etc.).
      */
     feed(input: string) {
-        this.lexer = new Lexer(input);
+        this.lexer = new Lexer(input, this.settings);
     }
 
     /**
@@ -314,7 +314,7 @@ export default class MacroExpander implements MacroContextInterface {
                     ++numArgs;
                 }
             }
-            const bodyLexer = new Lexer(expansion);
+            const bodyLexer = new Lexer(expansion, this.settings);
             const tokens = [];
             let tok = bodyLexer.lex();
             while (tok.text !== "EOF") {
@@ -343,4 +343,3 @@ export default class MacroExpander implements MacroContextInterface {
             implicitCommands.hasOwnProperty(name);
     }
 }
-

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -507,9 +507,6 @@ export default class Parser {
             }
             (isOptional ? optArgs : args).push(arg);
         }
-        if (funcData.argTypes && funcData.argTypes.indexOf("url") !== -1) {
-            this.gullet.lexer.setCatcode("%", 13);
-        }
 
         return {args, optArgs};
     }

--- a/src/SourceLocation.js
+++ b/src/SourceLocation.js
@@ -17,10 +17,6 @@ export default class SourceLocation {
         this.end = end;
     }
 
-    getSource(): string {
-        return this.lexer.input.slice(this.start, this.end);
-    }
-
     /**
      * Merges two `SourceLocation`s from location providers, given they are
      * provided in order of appearance.

--- a/src/functions/font.js
+++ b/src/functions/font.js
@@ -99,7 +99,6 @@ defineFunction({
     },
     handler: ({parser, funcName, breakOnTokenText}, args) => {
         const {mode} = parser;
-        parser.consumeSpaces();
         const body = parser.parseExpression(true, breakOnTokenText);
         const style = `math${funcName.slice(1)}`;
 

--- a/src/functions/sizing.js
+++ b/src/functions/sizing.js
@@ -61,7 +61,6 @@ defineFunction({
         allowedInText: true,
     },
     handler: ({breakOnTokenText, funcName, parser}, args) => {
-        parser.consumeSpaces();
         const body = parser.parseExpression(false, breakOnTokenText);
 
         return {

--- a/src/functions/styling.js
+++ b/src/functions/styling.js
@@ -25,7 +25,6 @@ defineFunction({
     },
     handler({breakOnTokenText, funcName, parser}, args) {
         // parse out the implicit body
-        parser.consumeSpaces();
         const body = parser.parseExpression(true, breakOnTokenText);
 
         // TODO: Refactor to avoid duplicating styleMap in multiple places (e.g.


### PR DESCRIPTION
Fixes #1779. I've mimicked category codes in Lexer and moved comment parsing back to the Lexer.

- Fix parsing a comment before a sup/subscript argument
- Fix parsing a comment before an expression
- Fix parsing a comment before or between \hline
- Fix parsing a comment in the macro definition
- Fix parsing a comment including a command sequence