### PR TITLE
Allow \includegraphics to omit the optional argument

### DIFF
--- a/src/Parser.js
+++ b/src/Parser.js
@@ -533,7 +533,7 @@ export default class Parser {
             case "raw": {
                 if (optional && this.nextToken.text === "{") {
                     return null;
-                }        
+                }
                 const token = this.parseStringGroup("raw", optional, true);
                 if (token) {
                     return {

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -531,6 +531,9 @@ export default class Parser {
             case "text":
                 return this.parseGroup(name, optional, greediness, undefined, type);
             case "raw": {
+                if (optional && this.nextToken.text === "{") {
+                    return null;
+                }        
                 const token = this.parseStringGroup("raw", optional, true);
                 if (token) {
                     return {

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -2687,6 +2687,9 @@ describe("A raw text parser", function() {
         // Unicode combining character. So this is a test that the parser will catch a bad string.
         expect("\\includegraphics[\u030aheight=0.8em, totalheight=0.9em, width=0.9em]{" + "https://cdn.kastatic.org/images/apple-touch-icon-57x57-precomposed.new.png}").not.toParse();
     });
+    it("should return null for a omitted optional string", function() {
+        expect("\\includegraphics{https://cdn.kastatic.org/images/apple-touch-icon-57x57-precomposed.new.png}").toParse();
+    });
 });
 
 


### PR DESCRIPTION
Fixes issue #1795.