### PR TITLE
:book: Add vue-katex to 3rd party libraries

### DIFF
--- a/docs/libs.md
+++ b/docs/libs.md
@@ -29,6 +29,9 @@ These libraries are maintained by third-parties.
 
 - [katex-ruby](https://github.com/glebm/katex-ruby): Provides server-side rendering and integration with popular Ruby web frameworks (Rails, Hanami, and anything that uses Sprockets).
 
+### Vue
+- [vue-katex](https://github.com/lucpotage/vue-katex): Vue plugin to render TeX expressions using KaTeX.
+
 ### AsciiMath
 
 If you want to render math written in [AsciiMath](http://asciimath.org/),


### PR DESCRIPTION
[vue-katex](https://github.com/lucpotage/vue-katex) is a 3rd party library that allows KaTeX to be used inside of Vue.js applications.