### PR TITLE
\fbox inherits default color

### DIFF
--- a/src/katex.less
+++ b/src/katex.less
@@ -542,14 +542,10 @@
         padding: 0 0.3em 0 0.3em;      // \fboxsep = 3pt
     }
 
-    .fbox {
-        box-sizing: border-box;
-        border: 0.04em solid black;   // \fboxrule = 0.4pt
-    }
-
+    .fbox,
     .fcolorbox {
         box-sizing: border-box;
-        border: 0.04em solid;   // \fboxrule = 0.4pt
+        border: 0.04em solid;         // \fboxrule = 0.4pt
     }
 
     .cancel-pad {


### PR DESCRIPTION
Merge `.fbox` and `.fcolorbox` rules to inherit default color, instead of forcing `black`.

We no longer have any explicit `black` in CSS!

Fix #1772.

Here's a screenshot where I manually modified the default color:

![image](https://user-images.githubusercontent.com/2218736/52527108-15416c80-2c91-11e9-8852-718c195d0e9e.png)
