### PR TITLE
Upgrade minimum development Node version to v8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,11 @@ version: 2.1
 executors:
   firefox:
     docker:
-      - image: circleci/node:6
+      - image: circleci/node:8
       - image: selenium/standalone-firefox:2.48.2
   chrome:
     docker:
-      - image: circleci/node:6
+      - image: circleci/node:8
       - image: selenium/standalone-chrome:2.48.2
         environment:
           # workaround for https://github.com/SeleniumHQ/docker-selenium/issues/87
@@ -74,7 +74,7 @@ commands:
 jobs:
   test:
     docker:
-      - image: circleci/node:6
+      - image: circleci/node:8
     steps:
       - run:
           name: Check whether the build is running on the main repository

--- a/docs/node.md
+++ b/docs/node.md
@@ -22,7 +22,7 @@ yarn global add katex
 ```
 
 ### Building from Source
-To build you will need Git, Node.js 6.9 or later, and Yarn.
+To build you will need Git, Node.js 8 or later, and Yarn.
 
 Clone a copy of the GitHub source repository:
 ```bash


### PR DESCRIPTION
Node v6 will reach its end-of-life by April 2019.