### PR TITLE
Improve MathML for \overset, \stackrel, and \underset

### DIFF
--- a/src/functions/supsub.js
+++ b/src/functions/supsub.js
@@ -217,7 +217,7 @@ defineFunctionBuilders({
         } else if (!group.sub) {
             const base = group.base;
             if (base && base.type === "op" && base.limits &&
-               (options.style === Style.DISPLAY || base.alwaysHandleSupSub)) {
+                (options.style === Style.DISPLAY || base.alwaysHandleSupSub)) {
                 nodeType = "mover";
             } else {
                 nodeType = "msup";
@@ -225,7 +225,7 @@ defineFunctionBuilders({
         } else if (!group.sup) {
             const base = group.base;
             if (base && base.type === "op" && base.limits &&
-            (options.style === Style.DISPLAY || base.alwaysHandleSupSub)) {
+                (options.style === Style.DISPLAY || base.alwaysHandleSupSub)) {
                 nodeType = "munder";
             } else {
                 nodeType = "msub";

--- a/src/functions/supsub.js
+++ b/src/functions/supsub.js
@@ -217,7 +217,7 @@ defineFunctionBuilders({
         } else if (!group.sub) {
             const base = group.base;
             if (base && base.type === "op" && base.limits &&
-                options.style === Style.DISPLAY) {
+               (options.style === Style.DISPLAY || base.alwaysHandleSupSub)) {
                 nodeType = "mover";
             } else {
                 nodeType = "msup";
@@ -225,7 +225,7 @@ defineFunctionBuilders({
         } else if (!group.sup) {
             const base = group.base;
             if (base && base.type === "op" && base.limits &&
-                options.style === Style.DISPLAY) {
+            (options.style === Style.DISPLAY || base.alwaysHandleSupSub)) {
                 nodeType = "munder";
             } else {
                 nodeType = "msub";

--- a/test/__snapshots__/mathml-spec.js.snap
+++ b/test/__snapshots__/mathml-spec.js.snap
@@ -344,7 +344,7 @@ exports[`A MathML builder should output \\limsup_{x \\rightarrow \\infty} correc
 <math>
   <semantics>
     <mrow>
-      <msub>
+      <munder>
         <mo>
           <mi mathvariant="normal">
             lim sup
@@ -364,7 +364,7 @@ exports[`A MathML builder should output \\limsup_{x \\rightarrow \\infty} correc
             ∞
           </mi>
         </mrow>
-      </msub>
+      </munder>
     </mrow>
     <annotation encoding="application/x-tex">
       \\limsup_{x \\rightarrow \\infty}


### PR DESCRIPTION
This PR edits the MathML part of `supsub.js`. In the section that chooses whether to use `msup` or `mover`, the code now uses the same criteria as is used for HTML. `supsub.js` then correctly picks `mover` for `\overset` and `\stackrel` and it correctly picks `munder` for `\underset`.

The jest test has brought to light an error in `\limsup`. It should not be defined as always having `\limits` Instead, it should be defined with `\operatorname*` in place of `\operatorname`. In order to fix `\limsup`, I first have to create `\operatorname*`. And `@flow` is making `\operatorname*`  difficult.

I request expedited review on this PR. After it has been merged into master, I'll go back in, create `\operatorname*`, and fix the snapshot for `\limsup`.