### PR TITLE
Fix ApplyFunction character

### DIFF
--- a/src/functions/mclass.js
+++ b/src/functions/mclass.js
@@ -99,6 +99,7 @@ defineFunction({
             mode: baseArg.mode,
             limits: true,
             alwaysHandleSupSub: true,
+            parentIsSupSub: false,
             symbol: false,
             suppressBaseShift: funcName !== "\\stackrel",
             body: ordargument(baseArg),

--- a/src/functions/op.js
+++ b/src/functions/op.js
@@ -252,15 +252,19 @@ const mathmlBuilder: MathMLBuilder<"op"> = (group, options) => {
         // operator's name.
         // TODO(emily): Add a space in the middle of some of these
         // operators, like \limsup.
-        node = new mathMLTree.MathNode(
-            "mi", [new mathMLTree.TextNode(group.name.slice(1))]);
+        if (group.parentIsSupSub) {
+            node = new mathMLTree.MathNode(
+                "mo", [new mathMLTree.TextNode(group.name.slice(1))]);
+        } else {
+            node = new mathMLTree.MathNode(
+                "mi", [new mathMLTree.TextNode(group.name.slice(1))]);
+            // Append an <mo>&ApplyFunction;</mo>.
+            // ref: https://www.w3.org/TR/REC-MathML/chap3_2.html#sec3.2.4
+            const operator = new mathMLTree.MathNode("mo",
+                [mml.makeText("\u2061", "text")]);
 
-        // Append an <mo>&ApplyFunction;</mo>.
-        // ref: https://www.w3.org/TR/REC-MathML/chap3_2.html#sec3.2.4
-        const operator = new mathMLTree.MathNode("mo",
-            [mml.makeText("\u2061", "text")]);
-
-        return mathMLTree.newDocumentFragment([node, operator]);
+            return mathMLTree.newDocumentFragment([node, operator]);
+        }
     }
 
     return node;
@@ -302,6 +306,7 @@ defineFunction({
             type: "op",
             mode: parser.mode,
             limits: true,
+            parentIsSupSub: false,
             symbol: true,
             name: fName,
         };
@@ -324,6 +329,7 @@ defineFunction({
             type: "op",
             mode: parser.mode,
             limits: false,
+            parentIsSupSub: false,
             symbol: false,
             body: ordargument(body),
         };
@@ -363,6 +369,7 @@ defineFunction({
             type: "op",
             mode: parser.mode,
             limits: false,
+            parentIsSupSub: false,
             symbol: false,
             name: funcName,
         };
@@ -385,6 +392,7 @@ defineFunction({
             type: "op",
             mode: parser.mode,
             limits: true,
+            parentIsSupSub: false,
             symbol: false,
             name: funcName,
         };
@@ -412,6 +420,7 @@ defineFunction({
             type: "op",
             mode: parser.mode,
             limits: false,
+            parentIsSupSub: false,
             symbol: true,
             name: fName,
         };

--- a/src/functions/supsub.js
+++ b/src/functions/supsub.js
@@ -201,6 +201,10 @@ defineFunctionBuilders({
             }
         }
 
+        if (group.base && group.base.type === "op") {
+            group.base.parentIsSupSub = true;
+        }
+
         const children = [mml.buildGroup(group.base, options)];
 
         if (group.sub) {

--- a/src/parseNode.js
+++ b/src/parseNode.js
@@ -66,6 +66,7 @@ type ParseNodeTypes = {
         limits: boolean,
         alwaysHandleSupSub?: boolean,
         suppressBaseShift?: boolean,
+        parentIsSupSub: boolean,
         symbol: boolean,
         name: string,
         body?: void,
@@ -76,6 +77,7 @@ type ParseNodeTypes = {
         limits: boolean,
         alwaysHandleSupSub?: boolean,
         suppressBaseShift?: boolean,
+        parentIsSupSub: boolean,
         symbol: false,  // If 'symbol' is true, `body` *must* be set.
         name?: void,
         body: AnyParseNode[],


### PR DESCRIPTION
First, some background: In version 3.0 of W3C's MathML spec, they recommend placement of an invisible character, `&ApplyFunction;` (U+2061) between a function name and the function's argument. Ref: [MathML spec section 3.2.5.5](https://www.w3.org/TR/MathML3/chapter3.html#presm.invisibleops) This is done for accessibility reasons. The invisible character gives a hint to a screen reader that it should say something like "f of x" instead of "f times x".  

KaTeX does insert that character, but it did so incorrectly for functions with a subscript, such as `\lim_y x`. 

This PR revises the code such that the invisible character is omitted for any function name with a subscript. This matches MathJax behavior.  When the invisible character is omitted the function name gets a `<mo>` tag instead of a `<mi>` tag. This also matches MathJax behavior.

@ylemkimon Thank you for the expedited review on PR #1886. I ask for expedited review on this PR as well. It is also a prerequisite for `\operatorname*`.