### PR TITLE
Improve MathML for \limits

### DIFF
--- a/src/functions/op.js
+++ b/src/functions/op.js
@@ -261,7 +261,7 @@ const mathmlBuilder: MathMLBuilder<"op"> = (group, options) => {
         if (group.parentIsSupSub) {
             node = new mathMLTree.MathNode("mo", [node, operator]);
         } else {
-            return mathMLTree.newDocumentFragment([node, operator]);
+            node = mathMLTree.newDocumentFragment([node, operator]);
         }
     }
 

--- a/src/functions/op.js
+++ b/src/functions/op.js
@@ -252,17 +252,15 @@ const mathmlBuilder: MathMLBuilder<"op"> = (group, options) => {
         // operator's name.
         // TODO(emily): Add a space in the middle of some of these
         // operators, like \limsup.
+        node = new mathMLTree.MathNode(
+            "mi", [new mathMLTree.TextNode(group.name.slice(1))]);
+        // Append an <mo>&ApplyFunction;</mo>.
+        // ref: https://www.w3.org/TR/REC-MathML/chap3_2.html#sec3.2.4
+        const operator = new mathMLTree.MathNode("mo",
+            [mml.makeText("\u2061", "text")]);
         if (group.parentIsSupSub) {
-            node = new mathMLTree.MathNode(
-                "mo", [new mathMLTree.TextNode(group.name.slice(1))]);
+            node = new mathMLTree.MathNode("mo", [node, operator]);
         } else {
-            node = new mathMLTree.MathNode(
-                "mi", [new mathMLTree.TextNode(group.name.slice(1))]);
-            // Append an <mo>&ApplyFunction;</mo>.
-            // ref: https://www.w3.org/TR/REC-MathML/chap3_2.html#sec3.2.4
-            const operator = new mathMLTree.MathNode("mo",
-                [mml.makeText("\u2061", "text")]);
-
             return mathMLTree.newDocumentFragment([node, operator]);
         }
     }


### PR DESCRIPTION
PR #1890 revised the treatment of `\limits` to match the MathJax behavior. It turns out that the MathJax behavior does not render properly in Firefox. It may be a Firefox bug because the MathML looks okay to me. An expression like `\lim\limits_y x` returns MathML of `<munder><mo>lim</mo><mi>y</mi></munder>`. And yet Firefox's renders it like a subscript. This picture is how Firefox renders `\lim x
\lim_y x
\lim\limits_y x`

![limits](https://user-images.githubusercontent.com/16403058/54869654-16b68800-4d59-11e9-9be9-1239e517b06b.PNG)

This PR modifies the MathML to `<munder><mo><mi>lim</mi><mo>⁡</mo></mo><mi>y</mi></munder>`. The inner `<mo>` contains the invisible ApplyFunction character. Such a change causes Firefox to render the same example as:
![limits-2](https://user-images.githubusercontent.com/16403058/54869687-76149800-4d59-11e9-9047-36335fedf86e.PNG)
