### PR TITLE
Improve more coloneq relations

### DIFF
--- a/src/macros.js
+++ b/src/macros.js
@@ -727,36 +727,49 @@ defineMacro("\\coloneqq", "\\html@mathml{" +
     "\\mathrel{\\vcentcolon\\mathrel{\\mkern-1.2mu}=}}" +
     "{\\mathop{\\char\"2254}}"); // ≔
 // \providecommand*\Coloneqq{\dblcolon\mathrel{\mkern-1.2mu}=}
-defineMacro("\\Coloneqq", "\\mathrel{\\dblcolon\\mathrel{\\mkern-1.2mu}=}");
+defineMacro("\\Coloneqq", "\\html@mathml{" +
+    "\\mathrel{\\dblcolon\\mathrel{\\mkern-1.2mu}=}}" +
+    "{\\mathop{\\char\"2237\\char\"3d}}");
 // \providecommand*\coloneq{\vcentcolon\mathrel{\mkern-1.2mu}\mathrel{-}}
-defineMacro("\\coloneq",
-    "\\mathrel{\\vcentcolon\\mathrel{\\mkern-1.2mu}\\mathrel{-}}");
+defineMacro("\\coloneq", "\\html@mathml{" +
+    "\\mathrel{\\vcentcolon\\mathrel{\\mkern-1.2mu}\\mathrel{-}}}" +
+    "{\\mathop{\\char\"3a\\char\"2212}}");
 // \providecommand*\Coloneq{\dblcolon\mathrel{\mkern-1.2mu}\mathrel{-}}
-defineMacro("\\Coloneq",
-    "\\mathrel{\\dblcolon\\mathrel{\\mkern-1.2mu}\\mathrel{-}}");
+defineMacro("\\Coloneq", "\\html@mathml{" +
+    "\\mathrel{\\dblcolon\\mathrel{\\mkern-1.2mu}\\mathrel{-}}}" +
+    "{\\mathop{\\char\"2237\\char\"2212}}");
 // \providecommand*\eqqcolon{=\mathrel{\mkern-1.2mu}\vcentcolon}
 defineMacro("\\eqqcolon", "\\html@mathml{" +
     "\\mathrel{=\\mathrel{\\mkern-1.2mu}\\vcentcolon}}" +
     "{\\mathop{\\char\"2255}}"); // ≕
 // \providecommand*\Eqqcolon{=\mathrel{\mkern-1.2mu}\dblcolon}
-defineMacro("\\Eqqcolon", "\\mathrel{=\\mathrel{\\mkern-1.2mu}\\dblcolon}");
+defineMacro("\\Eqqcolon", "\\html@mathml{" +
+    "\\mathrel{=\\mathrel{\\mkern-1.2mu}\\dblcolon}}" +
+    "{\\mathop{\\char\"3d\\char\"2237}}");
 // \providecommand*\eqcolon{\mathrel{-}\mathrel{\mkern-1.2mu}\vcentcolon}
 defineMacro("\\eqcolon", "\\html@mathml{" +
     "\\mathrel{\\mathrel{-}\\mathrel{\\mkern-1.2mu}\\vcentcolon}}" +
     "{\\mathop{\\char\"2239}}");
 // \providecommand*\Eqcolon{\mathrel{-}\mathrel{\mkern-1.2mu}\dblcolon}
-defineMacro("\\Eqcolon",
-    "\\mathrel{\\mathrel{-}\\mathrel{\\mkern-1.2mu}\\dblcolon}");
+defineMacro("\\Eqcolon", "\\html@mathml{" +
+    "\\mathrel{\\mathrel{-}\\mathrel{\\mkern-1.2mu}\\dblcolon}}" +
+    "{\\mathop{\\char\"2212\\char\"2237}}");
 // \providecommand*\colonapprox{\vcentcolon\mathrel{\mkern-1.2mu}\approx}
-defineMacro("\\colonapprox",
-    "\\mathrel{\\vcentcolon\\mathrel{\\mkern-1.2mu}\\approx}");
+defineMacro("\\colonapprox", "\\html@mathml{" +
+    "\\mathrel{\\vcentcolon\\mathrel{\\mkern-1.2mu}\\approx}}" +
+    "{\\mathop{\\char\"3a\\char\"2248}}");
 // \providecommand*\Colonapprox{\dblcolon\mathrel{\mkern-1.2mu}\approx}
-defineMacro("\\Colonapprox",
-    "\\mathrel{\\dblcolon\\mathrel{\\mkern-1.2mu}\\approx}");
+defineMacro("\\Colonapprox", "\\html@mathml{" +
+    "\\mathrel{\\dblcolon\\mathrel{\\mkern-1.2mu}\\approx}}" +
+    "{\\mathop{\\char\"2237\\char\"2248}}");
 // \providecommand*\colonsim{\vcentcolon\mathrel{\mkern-1.2mu}\sim}
-defineMacro("\\colonsim", "\\mathrel{\\vcentcolon\\mathrel{\\mkern-1.2mu}\\sim}");
+defineMacro("\\colonsim", "\\html@mathml{" +
+    "\\mathrel{\\vcentcolon\\mathrel{\\mkern-1.2mu}\\sim}}" +
+    "{\\mathop{\\char\"3a\\char\"223c}}");
 // \providecommand*\Colonsim{\dblcolon\mathrel{\mkern-1.2mu}\sim}
-defineMacro("\\Colonsim", "\\mathrel{\\dblcolon\\mathrel{\\mkern-1.2mu}\\sim}");
+defineMacro("\\Colonsim", "\\html@mathml{" +
+    "\\mathrel{\\dblcolon\\mathrel{\\mkern-1.2mu}\\sim}}" +
+    "{\\mathop{\\char\"2237\\char\"223c}}");
 
 // Some Unicode characters are implemented with macros to mathtools functions.
 defineMacro("\u2237", "\\dblcolon");  // ::


### PR DESCRIPTION
This is similar in effect to PR #1886, in that it improves the MathML for nine more symbols in the colonequals series. It uses a ligature instead of a single Unicode code point. In Firefox, they look pretty good!