### PR TITLE
Improve MathML for \smallint

### DIFF
--- a/src/functions/op.js
+++ b/src/functions/op.js
@@ -14,6 +14,11 @@ import * as mml from "../buildMathML";
 import type {HtmlBuilderSupSub, MathMLBuilder} from "../defineFunction";
 import type {ParseNode} from "../parseNode";
 
+// Most operators have a large successor symbol, but these don't.
+const noSuccessor = [
+    "\\smallint",
+];
+
 // NOTE: Unlike most `htmlBuilder`s, this one handles not only "op", but also
 // "supsub" since some of them (like \int) can affect super/subscripting.
 export const htmlBuilder: HtmlBuilderSupSub<"op"> = (grp, options) => {
@@ -36,11 +41,6 @@ export const htmlBuilder: HtmlBuilderSupSub<"op"> = (grp, options) => {
     }
 
     const style = options.style;
-
-    // Most operators have a large successor symbol, but these don't.
-    const noSuccessor = [
-        "\\smallint",
-    ];
 
     let large = false;
     if (style.size === Style.DISPLAY.size &&
@@ -237,12 +237,13 @@ export const htmlBuilder: HtmlBuilderSupSub<"op"> = (grp, options) => {
 const mathmlBuilder: MathMLBuilder<"op"> = (group, options) => {
     let node;
 
-    // TODO(emily): handle big operators using the `largeop` attribute
-
     if (group.symbol) {
         // This is a symbol. Just add the symbol.
         node = new mathMLTree.MathNode(
             "mo", [mml.makeText(group.name, group.mode)]);
+        if (utils.contains(noSuccessor, group.name)) {
+            node.setAttribute("largeop", "false");
+        }
     } else if (group.body) {
         // This is an operator with children. Add them.
         node = new mathMLTree.MathNode(


### PR DESCRIPTION
This PR makes `\smallint` small in `\displaystyle`.

The limits for `\smallint` should be shown alongside the symbol, not above and below, even in `\displaystyle`. KaTeX renders this incorrectly, both in HTML and in MathML. ~~I'd like to fix the limits in this PR, but I need access to some code in `supsub.js`.  So this PR is blocked by PR #1899.~~ 

On second thought, this is a good stand alone PR. Feel free to review it at any time. I'll just do the limits in another PR.
