### PR TITLE
Improve MathML for \tag

### DIFF
--- a/src/functions/tag.js
+++ b/src/functions/tag.js
@@ -4,21 +4,22 @@ import mathMLTree from "../mathMLTree";
 
 import * as mml from "../buildMathML";
 
+const pad = () => {
+    const padNode = new mathMLTree.MathNode("mtd", []);
+    padNode.setAttribute("width", "50%");
+    return padNode;
+}
+
 defineFunctionBuilders({
     type: "tag",
     mathmlBuilder(group, options) {
-        const pad = new mathMLTree.MathNode("mtd", []);
-        pad.setAttribute("width", "50%");
-        const pad2 = new mathMLTree.MathNode("mtd", []);
-        pad2.setAttribute("width", "50%");
-
         const table = new mathMLTree.MathNode("mtable", [
             new mathMLTree.MathNode("mtr", [
-                pad,
+                pad(),
                 new mathMLTree.MathNode("mtd", [
                     mml.buildExpressionRow(group.body, options),
                 ]),
-                pad2,
+                pad(),
                 new mathMLTree.MathNode("mtd", [
                     mml.buildExpressionRow(group.tag, options),
                 ]),
@@ -26,6 +27,14 @@ defineFunctionBuilders({
         ]);
         table.setAttribute("width", "100%");
         return table;
+
+        // TODO: Left-aligned tags.
+        // Currently, the group and options passed here do not contain
+        // enough info to set tag alignment. `leqno` is in Settings but it is
+        // not passed to Options. On the HTML side, leqno is
+        // set by a CSS class applied in buildTree.js. That would have worked
+        // in MathML if browsers supported <mlabeledtr>. Since they don't, we
+        // need to rewrite the way this function is called.
     },
 });
 

--- a/src/functions/tag.js
+++ b/src/functions/tag.js
@@ -9,6 +9,8 @@ defineFunctionBuilders({
     mathmlBuilder(group, options) {
         const pad = new mathMLTree.MathNode("mtd", []);
         pad.setAttribute("width", "50%");
+        const pad2 = new mathMLTree.MathNode("mtd", []);
+        pad2.setAttribute("width", "50%");
 
         const table = new mathMLTree.MathNode("mtable", [
             new mathMLTree.MathNode("mtr", [
@@ -16,7 +18,7 @@ defineFunctionBuilders({
                 new mathMLTree.MathNode("mtd", [
                     mml.buildExpressionRow(group.body, options),
                 ]),
-                pad,
+                pad2,
                 new mathMLTree.MathNode("mtd", [
                     mml.buildExpressionRow(group.tag, options),
                 ]),

--- a/src/functions/tag.js
+++ b/src/functions/tag.js
@@ -7,17 +7,22 @@ import * as mml from "../buildMathML";
 defineFunctionBuilders({
     type: "tag",
     mathmlBuilder(group, options) {
+        const pad = new mathMLTree.MathNode("mtd", []);
+        pad.setAttribute("width", "50%");
+
         const table = new mathMLTree.MathNode("mtable", [
-            new mathMLTree.MathNode("mlabeledtr", [
-                new mathMLTree.MathNode("mtd", [
-                    mml.buildExpressionRow(group.tag, options),
-                ]),
+            new mathMLTree.MathNode("mtr", [
+                pad,
                 new mathMLTree.MathNode("mtd", [
                     mml.buildExpressionRow(group.body, options),
                 ]),
+                pad,
+                new mathMLTree.MathNode("mtd", [
+                    mml.buildExpressionRow(group.tag, options),
+                ]),
             ]),
         ]);
-        table.setAttribute("side", "right");
+        table.setAttribute("width", "100%");
         return table;
     },
 });

--- a/src/functions/tag.js
+++ b/src/functions/tag.js
@@ -8,7 +8,7 @@ const pad = () => {
     const padNode = new mathMLTree.MathNode("mtd", []);
     padNode.setAttribute("width", "50%");
     return padNode;
-}
+};
 
 defineFunctionBuilders({
     type: "tag",

--- a/test/__snapshots__/mathml-spec.js.snap
+++ b/test/__snapshots__/mathml-spec.js.snap
@@ -774,12 +774,9 @@ exports[`A MathML builder tags use <mlabeledtr> 1`] = `
 
 <math>
   <semantics>
-    <mtable side="right">
-      <mlabeledtr>
-        <mtd>
-          <mtext>
-            (hi)
-          </mtext>
+    <mtable width="100%">
+      <mtr>
+        <mtd width="50%">
         </mtd>
         <mtd>
           <mrow>
@@ -799,7 +796,14 @@ exports[`A MathML builder tags use <mlabeledtr> 1`] = `
             </msup>
           </mrow>
         </mtd>
-      </mlabeledtr>
+        <mtd width="50%">
+        </mtd>
+        <mtd>
+          <mtext>
+            (hi)
+          </mtext>
+        </mtd>
+      </mtr>
     </mtable>
     <annotation encoding="application/x-tex">
       \\tag{hi} x+y^2


### PR DESCRIPTION
Contrary to what is stated on MDN, Firefox does not actually support `<mlabeledtr>`. Furthermore, `<mlabeledtr>` is explicitly omitted from the [project scope](https://mathml.igalia.com/project/) of the Chromium MathML project.  So this PR revises `\tag` in a way that will actually render.