### PR TITLE
Remove redundant style attribute from .op-symbol

### DIFF
--- a/src/functions/op.js
+++ b/src/functions/op.js
@@ -226,7 +226,6 @@ export const htmlBuilder: HtmlBuilderSupSub<"op"> = (grp, options) => {
             ["mop", "op-limits"], [finalGroup], options);
     } else {
         if (baseShift) {
-            base.style.position = "relative";
             base.style.top = baseShift + "em";
         }
 


### PR DESCRIPTION
`!hasLimits` implies that `base` is not a `supsub`. Non-zero `baseShift` then further implies that it's a symbol and has the `op-symbol` class (line 70).

The `op-symbol` class already has `position: relative` set in the stylesheet.