### PR TITLE
Improve MathML for \not

### DIFF
--- a/src/buildMathML.js
+++ b/src/buildMathML.js
@@ -163,31 +163,6 @@ export const buildExpression = function(
         groups.push(group);
         lastGroup = group;
     }
-
-    // Combine \not with mrels and mords
-    for (let i = (groups.length - 2); i >= 0; i--) {
-        const group = groups[i];
-        if (group instanceof MathNode && group.type === 'mi' &&
-                group.children.length === 1) {
-            const child = group.children[0];
-            if (child instanceof TextNode && child.text === '\u0338') {
-                const nextGroup = groups[i + 1];
-                if (nextGroup instanceof MathNode && (nextGroup.type === 'mo' ||
-                        nextGroup.type === 'mi' || nextGroup.type === 'mn')) {
-                    const nextChild = nextGroup.children[0];
-                    if (nextChild instanceof TextNode) {
-                        if (nextChild.text.length > 0) {
-                            // Overlay with combining character long solidus
-                            nextChild.text = nextChild.text.slice(0, 1) +
-                                "\u0338" + nextChild.text.slice(1);
-                            groups.splice(i, 1);
-                        }
-                    }
-                }
-            }
-        }
-    }
-
     return groups;
 };
 

--- a/src/buildMathML.js
+++ b/src/buildMathML.js
@@ -145,6 +145,19 @@ export const buildExpression = function(
                     lastGroup.children.push(...group.children);
                     continue;
                 }
+            } else if (lastGroup.type === 'mi' && lastGroup.children.length === 1) {
+                const lastChild = lastGroup.children[0];
+                if (lastChild instanceof TextNode && lastChild.text === '\u0338' &&
+                    (group.type === 'mo' || group.type === 'mi' ||
+                        group.type === 'mn')) {
+                    const child = group.children[0];
+                    if (child instanceof TextNode && child.text.length > 0) {
+                        // Overlay with combining character long solidus
+                        child.text = child.text.slice(0, 1) + "\u0338" +
+                            child.text.slice(1);
+                        groups.pop();
+                    }
+                }
             }
         }
         groups.push(group);

--- a/src/buildMathML.js
+++ b/src/buildMathML.js
@@ -151,7 +151,29 @@ export const buildExpression = function(
         lastGroup = group;
     }
 
-    // TODO(kevinb): combine \\not with mrels and mords
+    // Combine \not with mrels and mords
+    for (let i = (groups.length - 2); i >= 0; i--) {
+        const group = groups[i];
+        if (group instanceof MathNode && group.type === 'mi' &&
+                group.children.length === 1) {
+            const child = group.children[0];
+            if (child instanceof TextNode && child.text === '\u0338') {
+                const nextGroup = groups[i + 1];
+                if (nextGroup instanceof MathNode && (nextGroup.type === 'mo' ||
+                        nextGroup.type === 'mi' || nextGroup.type === 'mn')) {
+                    const nextChild = nextGroup.children[0];
+                    if (nextChild instanceof TextNode) {
+                        if (nextChild.text.length > 0) {
+                            // Overlay with combining character long solidus
+                            nextChild.text = nextChild.text.slice(0, 1) +
+                                "\u0338" + nextChild.text.slice(1);
+                            groups.splice(i, 1);
+                        }
+                    }
+                }
+            }
+        }
+    }
 
     return groups;
 };

--- a/src/macros.js
+++ b/src/macros.js
@@ -348,7 +348,8 @@ defineMacro("\\clap", "\\mathclap{\\textrm{#1}}");
 // \DeclareMathSymbol{\not}{\mathrel}{symbols}{"36}
 // It's thus treated like a \mathrel, but defined by a symbol that has zero
 // width but extends to the right.  We use \rlap to get that spacing.
-defineMacro("\\not", '\\mathrel{\\mathrlap\\@not}');
+// For MathML we write U+0338 here. buildMathML.js will then do the overlay.
+defineMacro("\\not", '\\html@mathml{\\mathrel{\\mathrlap\\@not}}{\\char"338}');
 
 // Negated symbols from base/fontmath.ltx:
 // \def\neq{\not=} \let\ne=\neq


### PR DESCRIPTION
This PR resolves a long-standing TODO item by implementing `\not` in MathML. The code employed is similar to the code used for HTML `\not` prior to PR #1497.