### PR TITLE
Add symbol double square brackets

### DIFF
--- a/docs/support_table.md
+++ b/docs/support_table.md
@@ -570,6 +570,7 @@ table td {
 |\limsup|$\limsup$||
 |\ll|$\ll$||
 |\llap|${=}\llap{/\,}$|`{=}\llap{/\,}`|
+|\llbracket|$\llbracket$||
 |\llcorner|$\llcorner$||
 |\Lleftarrow|$\Lleftarrow$||
 |\lll|$\lll$||
@@ -877,6 +878,7 @@ table td {
 |\rotatebox|<span style="color:firebrick;">Not supported</span>|[Issue #681](https://github.com/KaTeX/KaTeX/issues/681)|
 |\rparen|$\rparen$||
 |\rq|$\rq$||
+|\rrbracket|$\rrbracket$||
 |\Rrightarrow|$\Rrightarrow$||
 |\Rsh|$\Rsh$||
 |\rtimes|$\rtimes$||

--- a/docs/supported.md
+++ b/docs/supported.md
@@ -56,7 +56,7 @@ See also [letters](#letters)
 |$\vert$ <code>&#124;</code> |$\vert$ `\vert` |$┌ ┐$ `┌ ┐`|$\ulcorner \urcorner$ `\ulcorner`<br>$~~~~$`\urcorner`  |$\Downarrow$ `\Downarrow`
 |$\Vert$ <code>&#92;&#124;</code> |$\Vert$ `\Vert` |$└ ┘$ `└ ┘`|$\llcorner \lrcorner$ `\llcorner`<br>$~~~~$`\lrcorner`  |$\Updownarrow$ `\Updownarrow`
 |$\lvert~\rvert$ `\lvert`<br>$~~~~$`\rvert`|$\lVert~\rVert$ `\lVert`<br>$~~~~~$`\rVert` |`\left.`|  `\right.` |$\backslash$ `\backslash`
-|$\lang~\rang$ `\lang`<br>$~~~~$`\rang`|$\lt~\gt$ `\lt \gt`|$⟦~⟧$ `⟦ ⟧`|
+|$\lang~\rang$ `\lang`<br>$~~~~$`\rang`|$\lt~\gt$ `\lt \gt`|$⟦~⟧$ `⟦ ⟧`|$\llbracket~\rrbracket$ `\llbracket`<br>$~~~~$`\rrbracket`|
 
 **Delimiter Sizing**
 

--- a/src/macros.js
+++ b/src/macros.js
@@ -834,13 +834,20 @@ defineMacro("\\varsupsetneq", "\\html@mathml{\\@varsupsetneq}{⊋}");
 defineMacro("\\varsupsetneqq", "\\html@mathml{\\@varsupsetneqq}{⫌}");
 
 //////////////////////////////////////////////////////////////////////
-// semantic
+// stmaryrd and semantic
 
-// The semantic package renders the next two items by calling a glyph from the
-// bbold package. Those glyphs do not exist in the KaTeX fonts. Hence the macros.
+// The stmaryrd and semantic packages render the next four items by calling a
+// glyph. Those glyphs do not exist in the KaTeX fonts. Hence the macros.
 
-defineMacro("\u27e6", "\\mathopen{[\\mkern-3.2mu[}");  // blackboard bold [
-defineMacro("\u27e7", "\\mathclose{]\\mkern-3.2mu]}"); // blackboard bold ]
+defineMacro("\\llbracket", "\\html@mathml{" +
+    "\\mathopen{[\\mkern-3.2mu[}}" +
+    "{\\mathopen{\\char`\u27e6}}");
+defineMacro("\\rrbracket", "\\html@mathml{" +
+    "\\mathclose{]\\mkern-3.2mu]}}" +
+    "{\\mathclose{\\char`\u27e7}}");
+
+defineMacro("\u27e6", "\\llbracket");  // blackboard bold [
+defineMacro("\u27e7", "\\rrbracket"); // blackboard bold ]
 
 // TODO: Create variable sized versions of the last two items. I believe that
 // will require new font glyphs.

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -625,6 +625,8 @@ defineSymbol(math, main, open, "[", "\\lbrack");
 defineSymbol(text, main, textord, "[", "\\lbrack");
 defineSymbol(math, main, close, "]", "\\rbrack");
 defineSymbol(text, main, textord, "]", "\\rbrack");
+defineSymbol(math, main, open, "\u27e6", "\\llbrack", true);
+defineSymbol(math, main, close, "\u27e7", "\\rrbrack", true);
 defineSymbol(math, main, open, "(", "\\lparen");
 defineSymbol(math, main, close, ")", "\\rparen");
 defineSymbol(text, main, textord, "<", "\\textless"); // in T1 fontenc

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -625,8 +625,8 @@ defineSymbol(math, main, open, "[", "\\lbrack");
 defineSymbol(text, main, textord, "[", "\\lbrack");
 defineSymbol(math, main, close, "]", "\\rbrack");
 defineSymbol(text, main, textord, "]", "\\rbrack");
-defineSymbol(math, main, open, "\u27e6", "\\llbrack", true);
-defineSymbol(math, main, close, "\u27e7", "\\rrbrack", true);
+defineSymbol(math, main, open, "\u27e6", "\\llbracket", true);
+defineSymbol(math, main, close, "\u27e7", "\\rrbracket", true);
 defineSymbol(math, main, open, "(", "\\lparen");
 defineSymbol(math, main, close, ")", "\\rparen");
 defineSymbol(text, main, textord, "<", "\\textless"); // in T1 fontenc


### PR DESCRIPTION
I added a symbols for left/right double square brackets, unicode U+27E6 and U+27E7. For the properties I mimicked similar symbols such as floor/ceiling which were already included.

I tested with `yarn start` and got the error `No character metrics for '⟦' in style 'Main-Regular'`. I tried to see if I should address this and found the issues https://github.com/KaTeX/KaTeX/issues/374 and https://github.com/KaTeX/KaTeX/issues/1817 which gave me the impression I could overlook it.

The names `\llbrack` and `\rrbrack` are chosen to be consistent with KaTeX's `\lbrack` and `\rbrack` for single square brackets. They differ slightly from those found in the `stmaryrd` package for LaTeX (see [Double square brackets](https://tex.stackexchange.com/questions/107252/double-square-brackets) @ TeX SE) which uses `\llbracket` and `\rrbracket`.

I would also like to make them into delimiters to work with `\left` and `\right`, but didn't see similar unicode symbols to the upper/lower corner and extension symbols for single square brackets (U+23A1, U+23A2, U+23A3).