### PR TITLE
Prevent inadvertent tall delimiters in MathML

### DIFF
--- a/src/functions/symbolsOp.js
+++ b/src/functions/symbolsOp.js
@@ -23,6 +23,10 @@ defineFunctionBuilders({
             }
         } else if (group.family === "punct") {
             node.setAttribute("separator", "true");
+        } else if (group.family === "open" || group.family === "close") {
+            // Delims built here should not stretch vertically.
+            // See delimsizing.js for stretchy delims.
+            node.setAttribute("stretchy", "false");
         }
         return node;
     },


### PR DESCRIPTION
In MathML, `<mo>` elements that contain a fence character will stretch vertically if adjacent elements are tall. This can give poor results, as I found in this expression:
![badDelims](https://user-images.githubusercontent.com/16403058/56464793-f30d4e80-63a5-11e9-817d-25cb178bb376.PNG)

This PR will prevent such inadvertent stretchiness in delimiters that are not prefixed with `\left` or `\right`, as in this example:
![fixed](https://user-images.githubusercontent.com/16403058/56464811-2a7bfb00-63a6-11e9-8a54-9c9241cdb127.PNG)

The PR still enables stretchiness when  `\left` or `\right` are present, as in:
![goodTall](https://user-images.githubusercontent.com/16403058/56464819-4384ac00-63a6-11e9-9c0b-fdc7b58949b4.PNG)