### PR TITLE
disable \includegraphics until trust settings is merged

### DIFF
--- a/docs/support_table.md
+++ b/docs/support_table.md
@@ -479,7 +479,6 @@ table td {
 |\impliedby|$P\impliedby Q$|`P\impliedby Q`|
 |\implies|$P\implies Q$|`P\implies Q`|
 |\in|$\in$||
-|\includegraphics|$\includegraphics[height=0.8em, totalheight=0.9em, width=0.9em, alt=KA logo]{https://cdn.kastatic.org/images/apple-touch-icon-57x57-precomposed.new.png}$|`\includegraphics[height=0.8em, totalheight=0.9em, width=0.9em, alt=KA logo]{https://cdn.kastatic.org/images/apple-touch-icon-57x57-precomposed.new.png}`|
 |\inf|$\inf$||
 |\infin|$\infin$||
 |\infty|$\infty$||

--- a/docs/supported.md
+++ b/docs/supported.md
@@ -104,10 +104,6 @@ The `{array}` environment does not yet support `\cline` or `\multicolumn`.
 |:----------------|:-------------------|
 | $\href{https://katex.org/}{\KaTeX}$ | `\href{https://katex.org/}{\KaTeX}` |
 | $\url{https://katex.org/}$ | `\url{https://katex.org/}` |
-| $\includegraphics[height=0.8em, totalheight=0.9em, width=0.9em, alt=KA logo]{https://cdn.kastatic.org/images/apple-touch-icon-57x57-precomposed.new.png}$ | `\includegraphics[height=0.8em, totalheight=0.9em, width=0.9em, alt=KA logo]{https://cdn.kastatic.org/images/apple-touch-icon-57x57-precomposed.new.png}` |
-
-`\includegraphics` supports`height`, `width`, `totalheight`, and `alt` in it's first argument. `height` is required.
-
 
 ## Letters and Unicode
 

--- a/src/functions.js
+++ b/src/functions.js
@@ -21,7 +21,8 @@ import "./functions/genfrac";
 import "./functions/horizBrace";
 import "./functions/href";
 import "./functions/htmlmathml";
-import "./functions/includegraphics";
+// Disabled until https://github.com/KaTeX/KaTeX/pull/1794 is merged.
+// import "./functions/includegraphics";
 import "./functions/kern";
 import "./functions/lap";
 import "./functions/math";

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -1987,7 +1987,8 @@ describe("A MathML font tree-builder", function() {
     });
 });
 
-describe("An includegraphics builder", function() {
+// Disabled until https://github.com/KaTeX/KaTeX/pull/1794 is merged.
+describe.skip("An includegraphics builder", function() {
     const img = "\\includegraphics[height=0.9em, totalheight=0.9em, width=0.9em, alt=KA logo]{https://cdn.kastatic.org/images/apple-touch-icon-57x57-precomposed.new.png}";
     it("should not fail", function() {
         expect(img).toBuild();

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -2719,7 +2719,8 @@ describe("A raw text parser", function() {
         // Unicode combining character. So this is a test that the parser will catch a bad string.
         expect("\\includegraphics[\u030aheight=0.8em, totalheight=0.9em, width=0.9em]{" + "https://cdn.kastatic.org/images/apple-touch-icon-57x57-precomposed.new.png}").not.toParse();
     });
-    it("should return null for a omitted optional string", function() {
+    // Disabled until https://github.com/KaTeX/KaTeX/pull/1794 is merged.
+    it.skip("should return null for a omitted optional string", function() {
         expect("\\includegraphics{https://cdn.kastatic.org/images/apple-touch-icon-57x57-precomposed.new.png}").toParse();
     });
 });

--- a/test/screenshotter/ss_data.yaml
+++ b/test/screenshotter/ss_data.yaml
@@ -138,13 +138,14 @@ GroupMacros:
         \endExp: \egroup
     tex: \startExp a+b\endExp
 HorizontalBraces: \overbrace{\displaystyle{\oint_S{\vec E\cdot\hat n\,\mathrm d a}}}^\text{emf} = \underbrace{\frac{q_{\text{enc}}}{\varepsilon_0}}_{\text{charge}}
-Includegraphics: |
-    \def\logo{\includegraphics[height=0.8em, totalheight=0.9em, width=0.9em, alt=KA logo]{https://cdn.kastatic.org/images/apple-touch-icon-57x57-precomposed.new.png}}
-    \def\logoB{\includegraphics[height=0.4em, totalheight=0.9em, width=0.9em, alt=KA logo]{https://cdn.kastatic.org/images/apple-touch-icon-57x57-precomposed.new.png}}
-    \begin{array}{l}
-        \underline{A\logo} + \sqrt{\logo} + \tfrac{A\logo}{\logo}\\[1em]
-        \underline{A\logoB} + \sqrt{x\logoB} + \tfrac{A\logoB}{\logoB}
-    \end{array}
+# Disabled until https://github.com/KaTeX/KaTeX/pull/1794 is merged.
+# Includegraphics: |
+#     \def\logo{\includegraphics[height=0.8em, totalheight=0.9em, width=0.9em, alt=KA logo]{https://cdn.kastatic.org/images/apple-touch-icon-57x57-precomposed.new.png}}
+#     \def\logoB{\includegraphics[height=0.4em, totalheight=0.9em, width=0.9em, alt=KA logo]{https://cdn.kastatic.org/images/apple-touch-icon-57x57-precomposed.new.png}}
+#     \begin{array}{l}
+#         \underline{A\logo} + \sqrt{\logo} + \tfrac{A\logo}{\logo}\\[1em]
+#         \underline{A\logoB} + \sqrt{x\logoB} + \tfrac{A\logoB}{\logoB}
+#     \end{array}
 Integrands: |
     \begin{array}{l}
         \displaystyle \int + \oint + \iint + \oiint_i^n \\[0.6em]


### PR DESCRIPTION
This is only temporary and I thought that simply disabling the this function would be easier that removing it and adding it back in later.