### PR TITLE
Test for duplicate symbols/macros

### DIFF
--- a/test/dup-spec.js
+++ b/test/dup-spec.js
@@ -1,10 +1,20 @@
+/* global expect: false */
+/* global it: false */
+/* global describe: false */
+
 import symbols from '../src/symbols.js';
 import macros from '../src/macros.js';
 
 describe("Symbols and macros", () => {
-    for (let macro in macros) {
+    for (const macro in macros) {
+        if (!macros.hasOwnProperty(macro)) {
+            continue;
+        }
         it(`macro ${macro} should not shadow a symbol`, () => {
-            for (let kind in symbols) {
+            for (const kind in symbols) {
+                if (!symbols.hasOwnProperty(kind)) {
+                    continue;
+                }
                 expect(symbols[kind][macro]).toBeFalsy();
             }
         });

--- a/test/dup-spec.js
+++ b/test/dup-spec.js
@@ -1,0 +1,12 @@
+import symbols from '../src/symbols.js';
+import macros from '../src/macros.js';
+
+describe("Symbols and macros", () => {
+    for (let macro in macros) {
+        it(`macro ${macro} should not shadow a symbol`, () => {
+            for (let kind in symbols) {
+                expect(symbols[kind][macro]).toBeFalsy();
+            }
+        });
+    }
+});


### PR DESCRIPTION
We've had a few cases where we accidentally include the same symbol or macro definition in both `macros.js` and `symbols.js`.  This new test automatically detects these scenarios during Jest testing.

As a test, I reversed [these changes](https://github.com/KaTeX/KaTeX/pull/1954/files) and I got the following errors:

```
  ● Symbols and macros › macro \llbracket should not shadow a symbol

    expect(received).toBeFalsy()

    Received: {"font": "main", "group": "open", "replace": "⟦"}

       6 |         it(`macro ${macro} should not shadow a symbol`, () => {
       7 |             for (let kind in symbols) {
    >  8 |                 expect(symbols[kind][macro]).toBeFalsy();
         |                                              ^
       9 |             }
      10 |         });
      11 |     }

      at Object.toBeFalsy (test/redundancy-spec.js:8:46)

  ● Symbols and macros › macro \rrbracket should not shadow a symbol

    expect(received).toBeFalsy()

    Received: {"font": "main", "group": "close", "replace": "⟧"}

       6 |         it(`macro ${macro} should not shadow a symbol`, () => {
       7 |             for (let kind in symbols) {
    >  8 |                 expect(symbols[kind][macro]).toBeFalsy();
         |                                              ^
       9 |             }
      10 |         });
      11 |     }

      at Object.toBeFalsy (test/redundancy-spec.js:8:46)

  ● Symbols and macros › macro ⟦ should not shadow a symbol

    expect(received).toBeFalsy()

    Received: {"font": "main", "group": "open", "replace": "⟦"}

       6 |         it(`macro ${macro} should not shadow a symbol`, () => {
       7 |             for (let kind in symbols) {
    >  8 |                 expect(symbols[kind][macro]).toBeFalsy();
         |                                              ^
       9 |             }
      10 |         });
      11 |     }

      at Object.toBeFalsy (test/redundancy-spec.js:8:46)

  ● Symbols and macros › macro ⟧ should not shadow a symbol

    expect(received).toBeFalsy()

    Received: {"font": "main", "group": "close", "replace": "⟧"}

       6 |         it(`macro ${macro} should not shadow a symbol`, () => {
       7 |             for (let kind in symbols) {
    >  8 |                 expect(symbols[kind][macro]).toBeFalsy();
         |                                              ^
       9 |             }
      10 |         });
      11 |     }

      at Object.toBeFalsy (test/redundancy-spec.js:8:46)
```