### PR TITLE
Remove unclosed TODO comment in autorender documentation

### DIFF
--- a/docs/autorender.md
+++ b/docs/autorender.md
@@ -43,7 +43,6 @@ For example:
 </script>
 ```
 
-<!-- TODO: uncomment when releasing a new version
 ECMAScript module is also available:
 ```html
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.2/dist/katex.min.css" integrity="sha384-yFRtMMDnQtDRO8rLpMIKrtPCD5jdktao2TV19YiZYWMDkUR5GQZR/NOVTdquEx1j" crossorigin="anonymous">


### PR DESCRIPTION
Resolves issues #1944 and #1978, which point out that the documentation for the KaTeX autorender extension is missing some important material about delimiters.

This occurred because an unclosed TODO comment has prevented a large section of file `autorender.md` from being displayed. 

The TODO comment said that it should be uncommented "when releasing a new version." Since that comment was written, version 0.10.2 has been released. I take that to fulfill the requirement, so this PR simply removes the TODO. @ylemkimon If I have been too hasty, please let me know.