### PR TITLE
Fix \sqrt SVG path

### DIFF
--- a/src/svgGeometry.js
+++ b/src/svgGeometry.js
@@ -39,7 +39,7 @@ c5.3,-9.3,12,-14,20,-14
 H400000v${40 + extraViniculum}H845.2724
 s-225.272,467,-225.272,467s-235,486,-235,486c-2.7,4.7,-9,7,-19,7
 c-6,0,-10,-1,-12,-3s-194,-422,-194,-422s-65,47,-65,47z
-Ml${834 + extraViniculum} ${hLinePad}h400000v${40 + extraViniculum}h-400000z`;
+M${834 + extraViniculum} ${hLinePad}h400000v${40 + extraViniculum}h-400000z`;
 };
 
 const sqrtSize1 = function(extraViniculum: number, hLinePad: number): string {


### PR DESCRIPTION
A stray character has somehow made it into one of the SVG paths. This PR deletes it.

Firefox is somehow able to work around this error and display the SVG correctly. Judging by the screenshotter, Chrome can do so as well. But I get an error from Opera, and the stray character should come out just for general good code health.