### PR TITLE
Replace greenkeeper badge with dependabot badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CircleCI](https://circleci.com/gh/KaTeX/KaTeX.svg?style=shield)](https://circleci.com/gh/KaTeX/KaTeX)
 [![codecov](https://codecov.io/gh/KaTeX/KaTeX/branch/master/graph/badge.svg)](https://codecov.io/gh/KaTeX/KaTeX)
 [![Join the chat at https://gitter.im/KaTeX/KaTeX](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/KaTeX/KaTeX?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Greenkeeper badge](https://badges.greenkeeper.io/KaTeX/KaTeX.svg)](https://greenkeeper.io/)
+[![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=KaTeX/KaTeX)](https://dependabot.com)
 [![jsDelivr](https://data.jsdelivr.com/v1/package/npm/katex/badge?style=rounded)](https://www.jsdelivr.com/package/npm/katex)
 ![](https://img.badgesize.io/KaTeX/KaTeX/v0.10.2/dist/katex.min.js?compression=gzip)
 


### PR DESCRIPTION
The badge will look like:
<img width="182" alt="Screen Shot 2019-07-08 at 11 30 14 PM" src="https://user-images.githubusercontent.com/1044413/60857389-5bffa800-a1d8-11e9-90c1-db9109e1fec9.png">

This is the last thing that needs to be changed before we can close #1858.