### PR TITLE
Wide Unicode character support in math mode

### DIFF
--- a/src/fontMetrics.js
+++ b/src/fontMetrics.js
@@ -225,7 +225,7 @@ export function getCharacterMetrics(
         metrics = metricMap[font][ch];
     }
 
-    if (!metrics && mode === 'text') {
+    if (!metrics) {
         // We don't typically have font metrics for Asian scripts.
         // But since we support them in text mode, we need to return
         // some sort of metrics.

--- a/test/unicode-spec.js
+++ b/test/unicode-spec.js
@@ -9,7 +9,7 @@ import {strictSettings, nonstrictSettings} from "./helpers";
 describe("unicode", function() {
     it("should parse Latin-1 inside \\text{}", function() {
         expect`\text{ÀÁÂÃÄÅÈÉÊËÌÍÎÏÑÒÓÔÕÖÙÚÛÜÝàáâãäåèéêëìíîïñòóôõöùúûüýÿÆÇÐØÞßæçðøþ}`
-            .toParse();
+            .toBuild();
     });
 
     it("should not parse Latin-1 outside \\text{} with strict", function() {
@@ -21,19 +21,23 @@ describe("unicode", function() {
 
     it("should parse Latin-1 outside \\text{}", function() {
         expect`ÀÁÂÃÄÅÈÉÊËÌÍÎÏÑÒÓÔÕÖÙÚÛÜÝàáâãäåèéêëìíîïñòóôõöùúûüýÿÇÐÞçðþ`
-            .toParse(nonstrictSettings);
+            .toBuild(nonstrictSettings);
     });
 
     it("should parse all lower case Greek letters", function() {
-        expect`αβγδεϵζηθϑικλμνξοπϖρϱςστυφϕχψω`.toParse();
+        expect`αβγδεϵζηθϑικλμνξοπϖρϱςστυφϕχψω`.toBuild();
     });
 
     it("should parse math upper case Greek letters", function() {
-        expect`ΓΔΘΛΞΠΣΥΦΨΩ`.toParse();
+        expect`ΓΔΘΛΞΠΣΥΦΨΩ`.toBuild();
     });
 
     it("should parse Cyrillic inside \\text{}", function() {
-        expect`\text{БГДЖЗЙЛФЦШЫЮЯ}`.toParse();
+        expect`\text{БГДЖЗЙЛФЦШЫЮЯ}`.toBuild();
+    });
+
+    it("should parse Cyrillic outside \\text{}", function() {
+        expect`БГДЖЗЙЛФЦШЫЮЯ`.toBuild(nonstrictSettings);
     });
 
     it("should not parse Cyrillic outside \\text{} with strict", function() {
@@ -41,8 +45,13 @@ describe("unicode", function() {
     });
 
     it("should parse CJK inside \\text{}", function() {
-        expect`\text{私はバナナです}`.toParse();
-        expect`\text{여보세요}`.toParse();
+        expect`\text{私はバナナです}`.toBuild();
+        expect`\text{여보세요}`.toBuild();
+    });
+
+    it("should parse CJK outside \\text{}", function() {
+        expect`私はバナナです`.toBuild(nonstrictSettings);
+        expect`여보세요`.toBuild(nonstrictSettings);
     });
 
     it("should not parse CJK outside \\text{} with strict", function() {
@@ -51,7 +60,11 @@ describe("unicode", function() {
     });
 
     it("should parse Devangari inside \\text{}", function() {
-        expect`\text{नमस्ते}`.toParse();
+        expect`\text{नमस्ते}`.toBuild();
+    });
+
+    it("should parse Devangari outside \\text{}", function() {
+        expect`नमस्ते`.toBuild(nonstrictSettings);
     });
 
     it("should not parse Devangari outside \\text{} with strict", function() {
@@ -59,7 +72,11 @@ describe("unicode", function() {
     });
 
     it("should parse Georgian inside \\text{}", function() {
-        expect`\text{გამარჯობა}`.toParse();
+        expect`\text{გამარჯობა}`.toBuild();
+    });
+
+    it("should parse Georgian outside \\text{}", function() {
+        expect`გამარჯობა`.toBuild(nonstrictSettings);
     });
 
     it("should not parse Georgian outside \\text{} with strict", function() {
@@ -67,7 +84,7 @@ describe("unicode", function() {
     });
 
     it("should parse extended Latin characters inside \\text{}", function() {
-        expect`\text{ěščřžůřťďňőİı}`.toParse();
+        expect`\text{ěščřžůřťďňőİı}`.toBuild();
     });
 
     it("should not parse extended Latin outside \\text{} with strict", function() {


### PR DESCRIPTION
Improve #2031 by rendering all supported Unicode text characters (via supportedCodepoints) in math mode in addition to existing text mode support (using metrics of letter M as usual).  Also fix #1817.

This is a replacement/alternative to #2040 and #2032. I just implemented @ronkok's [suggested one-line change](https://github.com/KaTeX/KaTeX/pull/2040#issuecomment-511919654), and copied over the tests from #2040.

Same screenshots:

```latex
F_e=\dfrac{可改进部分占用时间}{\text{MMM}改进前总时间}\\
F_e=\dfrac{\text{M}可改进部分占用时间}{改进前总时间}
```

![image](https://user-images.githubusercontent.com/2218736/62397671-7d885100-b544-11e9-93f0-4e9a7bac8302.png)

Without the Ms, we get the same vertical layout:

![image](https://user-images.githubusercontent.com/2218736/62397706-9c86e300-b544-11e9-856f-448ec2710b00.png)

Without this PR:

![image](https://user-images.githubusercontent.com/2218736/61189550-fa6a8e00-a65c-11e9-8823-68a20927e236.png)