### PR TITLE
Remove keyVals ParseNode type

### DIFF
--- a/contrib/render-a11y-string/render-a11y-string.js
+++ b/contrib/render-a11y-string/render-a11y-string.js
@@ -555,10 +555,6 @@ const handleObject = (
             throw new Error("KaTeX-a11y: array not implemented yet");
         }
 
-        case "keyVals": {
-            throw new Error("KaTeX-a11y: keyVals not implemented yet");
-        }
-
         case "raw": {
             throw new Error("KaTeX-a11y: raw not implemented yet");
         }

--- a/src/parseNode.js
+++ b/src/parseNode.js
@@ -53,12 +53,6 @@ type ParseNodeTypes = {
         loc?: ?SourceLocation,
         color: string,
     |},
-    "keyVals": {|
-        type: "keyVals",
-        mode: Mode,
-        loc?: ?SourceLocation,
-        keyVals: string,
-    |},
     // To avoid requiring run-time type assertions, this more carefully captures
     // the requirements on the fields per the op.js htmlBuilder logic:
     // - `body` and `value` are NEVER set simultanouesly.


### PR DESCRIPTION
Resolves #2063.

`keyVals` was introduced as a ParseNode type for the `\includeGraphics` function. It became unnecessary when @ylemkimon upgraded the parser.