### PR TITLE
Add support for \cal

### DIFF
--- a/docs/support_table.md
+++ b/docs/support_table.md
@@ -198,7 +198,7 @@ table td {
 |Symbol/Function |  Rendered   | Source or Comment|
 |:---------------|:------------|:-----------------|
 |\C|<span style="color:firebrick;">Not supported</span>|[Deprecated](https://en.wikipedia.org/wiki/Help:Displaying_a_formula#Deprecated_syntax)|
-|\cal|<span style="color:firebrick;">Not supported</span>|See `\mathcal`
+|\cal|$\cal AaBb123$|`\cal AaBb123`|
 |\cancel|$\cancel{5}$|`\cancel{5}`|
 |\cancelto|<span style="color:firebrick;">Not supported</span>||
 |\Cap|$\Cap$||

--- a/docs/supported.md
+++ b/docs/supported.md
@@ -538,7 +538,8 @@ For color definition, KaTeX color functions will accept the standard HTML [pred
 |$\mathsf{Ab0}$ `\mathsf{Ab0}`  |$\textmd{Ab0}$ `\textmd{Ab0}`  |$\frak{Ab0}$ `\frak{Ab0}`
 |$\textsf{Ab0}$ `\textsf{Ab0}`  |$\mathtt{Ab0}$ `\mathtt{Ab0}`  |$\mathfrak{Ab0}$ `\mathfrak{Ab0}`
 |$\sf Ab0$ `\sf Ab0`            |$\texttt{Ab0}$ `\texttt{Ab0}`  |$\mathcal{AB0}$ `\mathcal{AB0}`
-|                               |$\tt Ab0$ `\tt Ab0`            |$\mathscr{AB}$ `\mathscr{AB}`
+|                               |$\tt Ab0$ `\tt Ab0`            |$\cal AB0$ `\cal AB0`
+|                               |                               |$\mathscr{AB}$ `\mathscr{AB}`
 
 One can stack font family, font weight, and font shape by using the `\textXX` versions of the font functions. So `\textsf{\textbf{H}}` will produce $\textsf{\textbf{H}}$. The other versions do not stack, e.g., `\mathsf{\mathbf{H}}` will produce $\mathsf{\mathbf{H}}$.
 

--- a/src/functions/font.js
+++ b/src/functions/font.js
@@ -95,7 +95,7 @@ defineFunction({
 // Old font changing functions
 defineFunction({
     type: "font",
-    names: ["\\rm", "\\sf", "\\tt", "\\bf", "\\it"],
+    names: ["\\rm", "\\sf", "\\tt", "\\bf", "\\it", "\\cal"],
     props: {
         numArgs: 0,
         allowedInText: true,

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -1601,6 +1601,15 @@ describe("A font parser", function() {
         const built = getBuilt`a\boldsymbol{}b\boldsymbol{=}c\boldsymbol{+}d\boldsymbol{++}e\boldsymbol{xyz}f`;
         expect(built).toMatchSnapshot();
     });
+
+    it("old-style fonts work like new-style fonts", () => {
+        expect`\rm xyz`.toParseLike`\mathrm{xyz}`;
+        expect`\sf xyz`.toParseLike`\mathsf{xyz}`;
+        expect`\tt xyz`.toParseLike`\mathtt{xyz}`;
+        expect`\bf xyz`.toParseLike`\mathbf{xyz}`;
+        expect`\it xyz`.toParseLike`\mathit{xyz}`;
+        expect`\cal xyz`.toParseLike`\mathcal{xyz}`;
+    });
 });
 
 describe("A \\pmb builder", function() {


### PR DESCRIPTION
Fix #2115 by adding \cal to list of old-style font commands. (Surprisingly tiny change!)
Add tests for all old-style font commands.

Example with tester:
```latex
\mathcal{ABC} ABC \cal ABC \rm ABC
```
![image](https://user-images.githubusercontent.com/2218736/66523633-6161dc80-eabe-11e9-8061-a16b7f19ee84.png)
