### PR TITLE
Fix \boxed inherited color

### DIFF
--- a/src/katex.less
+++ b/src/katex.less
@@ -547,6 +547,7 @@
     .fcolorbox {
         box-sizing: border-box;
         border: 0.04em solid;         // \fboxrule = 0.4pt
+        border-color: inherit;
     }
 
     .cancel-pad {


### PR DESCRIPTION
Fixes #2128. A page whose underlying HTML defines `color: green` will then display `\boxed` thus:
![colorBox](https://user-images.githubusercontent.com/16403058/67115683-a6a79d80-f193-11e9-889a-1816c8c189bd.png)

The screenshotter tests already cover `\color{magenta}{\boxed{F}}\boxed{F=mg}` and I could not think of any good way to test a setting of the outer page. So I have no other tests to offer.