### PR TITLE
auto-render: do not touch text nodes w/o formulas

### DIFF
--- a/contrib/auto-render/auto-render.js
+++ b/contrib/auto-render/auto-render.js
@@ -19,6 +19,13 @@ const splitWithDelimiters = function(text, delimiters) {
  */
 const renderMathInText = function(text, optionsCopy) {
     const data = splitWithDelimiters(text, optionsCopy.delimiters);
+    if (data.length === 1 && data[0].type === 'text') {
+        // There is no formula in the text.
+        // Let's return null which means there is no need to replace
+        // the current text node with a new one.
+        return null;
+    }
+
     const fragment = document.createDocumentFragment();
 
     for (let i = 0; i < data.length; i++) {
@@ -60,8 +67,10 @@ const renderElem = function(elem, optionsCopy) {
         if (childNode.nodeType === 3) {
             // Text node
             const frag = renderMathInText(childNode.textContent, optionsCopy);
-            i += frag.childNodes.length - 1;
-            elem.replaceChild(frag, childNode);
+            if (frag) {
+                i += frag.childNodes.length - 1;
+                elem.replaceChild(frag, childNode);
+            }
         } else if (childNode.nodeType === 1) {
             // Element node
             const className = ' ' + childNode.className + ' ';


### PR DESCRIPTION
Currently `renderMathInElement` replaces all text nodes w/o formula(s) with new ones, which don't really need to be recreated. This PR fixes this.

Example:
```html
<div>
  <p>foo bar</p>
  <p>\( x = \pm\sqrt{a^2 + b^2} \)</p>
</div>
```

In this DOM fragment there are 5 text nodes: `"↵  "`, `"foo bar"`, `"↵  "`, `"\( x = \pm\sqrt{a^2 + b^2} \)"`, `"↵"`. Currently `renderMathInElement(div)` processes and replaces all of them, but I expect that only text nodes with formula(s) should be modified. E.g. text node `"foo bar"` is replaced with new text node with the same content "foo bar".

Why I dig into it?
auto-render somehow breaks ember.js rendering in my application in some specific cases because all text nodes are replaced (= new references), not only text nodes with formula(s).

Also, it seems like this PR gives a tiny performance boost (I tested dev build only, ~25 samples): 
![image](https://user-images.githubusercontent.com/4932134/68815078-3f024680-069c-11ea-9a53-071c9721c1f9.png)

