### PR TITLE
Reword unicode test comments

### DIFF
--- a/test/unicode-spec.js
+++ b/test/unicode-spec.js
@@ -7,7 +7,7 @@ import {scriptFromCodepoint, supportedCodepoint} from "../src/unicodeScripts";
 import {strictSettings, nonstrictSettings} from "./helpers";
 
 describe("unicode", function() {
-    it("should parse Latin-1 inside \\text{}", function() {
+    it("should build Latin-1 inside \\text{}", function() {
         expect`\text{ÀÁÂÃÄÅÈÉÊËÌÍÎÏÑÒÓÔÕÖÙÚÛÜÝàáâãäåèéêëìíîïñòóôõöùúûüýÿÆÇÐØÞßæçðøþ}`
             .toBuild();
     });
@@ -19,24 +19,24 @@ describe("unicode", function() {
         }
     });
 
-    it("should parse Latin-1 outside \\text{}", function() {
+    it("should build Latin-1 outside \\text{}", function() {
         expect`ÀÁÂÃÄÅÈÉÊËÌÍÎÏÑÒÓÔÕÖÙÚÛÜÝàáâãäåèéêëìíîïñòóôõöùúûüýÿÇÐÞçðþ`
             .toBuild(nonstrictSettings);
     });
 
-    it("should parse all lower case Greek letters", function() {
+    it("should build all lower case Greek letters", function() {
         expect`αβγδεϵζηθϑικλμνξοπϖρϱςστυφϕχψω`.toBuild();
     });
 
-    it("should parse math upper case Greek letters", function() {
+    it("should build math upper case Greek letters", function() {
         expect`ΓΔΘΛΞΠΣΥΦΨΩ`.toBuild();
     });
 
-    it("should parse Cyrillic inside \\text{}", function() {
+    it("should build Cyrillic inside \\text{}", function() {
         expect`\text{БГДЖЗЙЛФЦШЫЮЯ}`.toBuild();
     });
 
-    it("should parse Cyrillic outside \\text{}", function() {
+    it("should build Cyrillic outside \\text{}", function() {
         expect`БГДЖЗЙЛФЦШЫЮЯ`.toBuild(nonstrictSettings);
     });
 
@@ -44,12 +44,12 @@ describe("unicode", function() {
         expect`БГДЖЗЙЛФЦШЫЮЯ`.not.toParse(strictSettings);
     });
 
-    it("should parse CJK inside \\text{}", function() {
+    it("should build CJK inside \\text{}", function() {
         expect`\text{私はバナナです}`.toBuild();
         expect`\text{여보세요}`.toBuild();
     });
 
-    it("should parse CJK outside \\text{}", function() {
+    it("should build CJK outside \\text{}", function() {
         expect`私はバナナです`.toBuild(nonstrictSettings);
         expect`여보세요`.toBuild(nonstrictSettings);
     });
@@ -59,11 +59,11 @@ describe("unicode", function() {
         expect`여보세요`.not.toParse(strictSettings);
     });
 
-    it("should parse Devangari inside \\text{}", function() {
+    it("should build Devangari inside \\text{}", function() {
         expect`\text{नमस्ते}`.toBuild();
     });
 
-    it("should parse Devangari outside \\text{}", function() {
+    it("should build Devangari outside \\text{}", function() {
         expect`नमस्ते`.toBuild(nonstrictSettings);
     });
 
@@ -71,11 +71,11 @@ describe("unicode", function() {
         expect`नमस्ते`.not.toParse(strictSettings);
     });
 
-    it("should parse Georgian inside \\text{}", function() {
+    it("should build Georgian inside \\text{}", function() {
         expect`\text{გამარჯობა}`.toBuild();
     });
 
-    it("should parse Georgian outside \\text{}", function() {
+    it("should build Georgian outside \\text{}", function() {
         expect`გამარჯობა`.toBuild(nonstrictSettings);
     });
 
@@ -83,7 +83,7 @@ describe("unicode", function() {
         expect`გამარჯობა`.not.toParse(strictSettings);
     });
 
-    it("should parse extended Latin characters inside \\text{}", function() {
+    it("should build extended Latin characters inside \\text{}", function() {
         expect`\text{ěščřžůřťďňőİı}`.toBuild();
     });
 


### PR DESCRIPTION
This minor typographical patch implements [some comments](https://github.com/KaTeX/KaTeX/pull/2065#pullrequestreview-310559275) made by @kevinbarabash on #2065, which ended up getting replaced by #2040, which got merged but without those comments implemented (despite sharing the relevant changes).