### PR TITLE
auto-render: add "option" to ignoredTags

### DIFF
--- a/contrib/auto-render/auto-render.js
+++ b/contrib/auto-render/auto-render.js
@@ -115,7 +115,7 @@ const renderMathInElement = function(elem, options) {
         {left: "\\[", right: "\\]", display: true},
     ];
     optionsCopy.ignoredTags = optionsCopy.ignoredTags || [
-        "script", "noscript", "style", "textarea", "pre", "code",
+        "script", "noscript", "style", "textarea", "pre", "code", "option",
     ];
     optionsCopy.ignoredClasses = optionsCopy.ignoredClasses || [];
     optionsCopy.errorCallback = optionsCopy.errorCallback || console.error;

--- a/docs/autorender.md
+++ b/docs/autorender.md
@@ -90,7 +90,7 @@ in addition to two auto-render-specific keys:
 
 - `ignoredTags`: This is a list of DOM node types to ignore when recursing
   through. The default value is
-  `["script", "noscript", "style", "textarea", "pre", "code"]`.
+  `["script", "noscript", "style", "textarea", "pre", "code", "option"]`.
 
 - `ignoredClasses`: This is a list of DOM node class names to ignore when
   recursing through. By default, this value is not set.


### PR DESCRIPTION
We should ignore `<option>` by default, because it's a Text node, it can't contain html.

Currently `renderMathInElement` transforms `<select><option>Hello $x+y$</option></select>` ![image](https://user-images.githubusercontent.com/4932134/71356486-39095a80-25a4-11ea-9fa3-77359bd4b22b.png) into invalid html
```html
<select>
  <option>Hello <span><span class="katex">...</span></span></option>
</select>
```
![image](https://user-images.githubusercontent.com/4932134/71356446-137c5100-25a4-11ea-84ba-932fb47fe599.png)
