### PR TITLE
Fix delimiter error message

### DIFF
--- a/src/functions/delimsizing.js
+++ b/src/functions/delimsizing.js
@@ -62,11 +62,12 @@ function checkDelimiter(
     const symDelim = checkSymbolNodeType(delim);
     if (symDelim && utils.contains(delimiters, symDelim.text)) {
         return symDelim;
-    } else {
+    } else if (symDelim) {
         throw new ParseError(
-            "Invalid delimiter: '" +
-            (symDelim ? symDelim.text : JSON.stringify(delim)) +
-            "' after '" + context.funcName + "'", delim);
+            `Invalid delimiter '${symDelim.text}' after '${context.funcName}'`,
+            delim);
+    } else {
+        throw new ParseError(`Invalid delimiter type '${delim.type}'`, delim);
     }
 }
 

--- a/test/errors-spec.js
+++ b/test/errors-spec.js
@@ -250,13 +250,23 @@ describe("functions.js:", function() {
     describe("delimiter functions", function() {
         it("reject invalid opening delimiters", function() {
             expect`\bigl 1 + 2 \bigr`.toFailWithParseError(
-                   "Invalid delimiter: '1' after '\\bigl' at position 7:" +
+                   "Invalid delimiter '1' after '\\bigl' at position 7:" +
                    " \\bigl 1̲ + 2 \\bigr");
         });
         it("reject invalid closing delimiters", function() {
             expect`\bigl(1+2\bigr=3`.toFailWithParseError(
-                   "Invalid delimiter: '=' after '\\bigr' at position 15:" +
+                   "Invalid delimiter '=' after '\\bigr' at position 15:" +
                    " \\bigl(1+2\\bigr=̲3");
+        });
+        it("reject group opening delimiters", function() {
+            expect`\bigl{(}1+2\bigr)3`.toFailWithParseError(
+                   "Invalid delimiter type 'ordgroup' at position 6:" +
+                   " \\bigl{̲(̲}̲1+2\\bigr)3");
+        });
+        it("reject group closing delimiters", function() {
+            expect`\bigl(1+2\bigr{)}3`.toFailWithParseError(
+                   "Invalid delimiter type 'ordgroup' at position 15:" +
+                   " \\bigl(1+2\\bigr{̲)̲}̲3");
         });
     });
 


### PR DESCRIPTION
Avoid "circular structure" error message by avoiding `JSON.stringify` on a parse structure when getting an invalid delimiter type (e.g. ordgroup). Instead, report type of delimiter when it's invalid.  Fixes #2184.