### PR TITLE
Change katex import to relative path

### DIFF
--- a/contrib/mhchem/mhchem.js
+++ b/contrib/mhchem/mhchem.js
@@ -49,7 +49,7 @@
 //   - use "" for strings that need to stay untouched
 
 // version: "3.3.0" for MathJax and KaTeX
-
+import katex from "../../dist/katex.mjs";
 
 // Add \ce, \pu, and \tripledash to the KaTeX macros.
 
@@ -66,8 +66,6 @@ katex.__defineMacro("\\pu", function(context) {
 //  a mathematical minus, U+2212. So we need that extra 0.56.
 katex.__defineMacro("\\tripledash", "{\\vphantom{-}\\raisebox{2.56mu}{$\\mkern2mu"
 + "\\tiny\\text{-}\\mkern1mu\\text{-}\\mkern1mu\\text{-}\\mkern2mu$}}");
-
-import katex from "katex";
 
   //
   //  This is the main function for handing the \ce and \pu commands.


### PR DESCRIPTION
In order to use mhchem on the frontend with native modules we need the exact relative path.