### PR TITLE
Enable empty environment

### DIFF
--- a/src/environments/array.js
+++ b/src/environments/array.js
@@ -435,7 +435,7 @@ const mathmlBuilder: MathMLBuilder<"array"> = function(group, options) {
     let menclose = "";
     let align = "";
 
-    if (group.cols) {
+    if (group.cols && group.cols.length > 0) {
         // Find column alignment, column spacing, and  vertical lines.
         const cols = group.cols;
         let columnLines = "";

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -1247,6 +1247,10 @@ describe("A begin/end parser", function() {
         expect`\begin{array}{cc}a&b\\c&d\end{array}`.toParse();
     });
 
+    it("should parse and build an empty environment", function() {
+        expect`\begin{aligned}\end{aligned}`.toBuild();
+    });
+
     it("should parse an environment with hlines", function() {
         expect`\begin{matrix}\hline a&b\\ \hline c&d\end{matrix}`.toParse();
         expect`\begin{matrix}\hdashline a&b\\ \hdashline c&d\end{matrix}`.toParse();


### PR DESCRIPTION
Prevent a build error when an environment has no contents. Fixes #2255.