### PR TITLE
Update API language on auto-render script

### DIFF
--- a/website/versioned_docs/version-0.10.0/autorender.md
+++ b/website/versioned_docs/version-0.10.0/autorender.md
@@ -57,7 +57,7 @@ nodes inside this element and render the math in them.
 
 `options` is an optional object argument that can have the same keys as [the
 object passed to `katex.render`](https://github.com/KaTeX/KaTeX/#rendering-options),
-in addition to two auto-render-specific keys:
+in addition to several auto-render-specific keys:
 
 - `delimiters`: This is a list of delimiters to look for math. Each delimiter
   has three properties:

--- a/website/versioned_docs/version-0.10.1/autorender.md
+++ b/website/versioned_docs/version-0.10.1/autorender.md
@@ -70,7 +70,7 @@ nodes inside this element and render the math in them.
 
 `options` is an optional object argument that can have the same keys as [the
 object passed to `katex.render`](https://github.com/KaTeX/KaTeX/#rendering-options),
-in addition to two auto-render-specific keys:
+in addition to several auto-render-specific keys:
 
 - `delimiters`: This is a list of delimiters to look for math. Each delimiter
   has three properties:

--- a/website/versioned_docs/version-0.10.2/autorender.md
+++ b/website/versioned_docs/version-0.10.2/autorender.md
@@ -70,7 +70,7 @@ nodes inside this element and render the math in them.
 
 `options` is an optional object argument that can have the same keys as [the
 object passed to `katex.render`](https://github.com/KaTeX/KaTeX/#rendering-options),
-in addition to two auto-render-specific keys:
+in addition to several auto-render-specific keys:
 
 - `delimiters`: This is a list of delimiters to look for math. Each delimiter
   has three properties:

--- a/website/versioned_docs/version-0.11.0/autorender.md
+++ b/website/versioned_docs/version-0.11.0/autorender.md
@@ -69,7 +69,7 @@ nodes inside this element and render the math in them.
 
 `options` is an optional object argument that can have the same keys as [the
 object passed to `katex.render`](https://github.com/KaTeX/KaTeX/#rendering-options),
-in addition to two auto-render-specific keys:
+in addition to several auto-render-specific keys:
 
 - `delimiters`: This is a list of delimiters to look for math. Each delimiter
   has three properties:

--- a/website/versioned_docs/version-0.11.1/autorender.md
+++ b/website/versioned_docs/version-0.11.1/autorender.md
@@ -69,7 +69,7 @@ nodes inside this element and render the math in them.
 
 `options` is an optional object argument that can have the same keys as [the
 object passed to `katex.render`](https://github.com/KaTeX/KaTeX/#rendering-options),
-in addition to two auto-render-specific keys:
+in addition to several auto-render-specific keys:
 
 - `delimiters`: This is a list of delimiters to look for math. Each delimiter
   has three properties:


### PR DESCRIPTION
I noticed that the docs said there were "two auto-render-specific keys" and then proceeded to list 5 extra keys that could be passed. :) I updated the language in all of the versions of docs because they were all incorrect.

I changed them all to say "several" so that this doesn't accidentally get out of date again when another key is added in the future, but I'm happy to change it to say "five"/"four" in the different versions if that seems better.

Also 👋 