### PR TITLE
Document \def doesn't support delimiters (#2288)

### DIFF
--- a/docs/supported.md
+++ b/docs/supported.md
@@ -309,6 +309,7 @@ Direct Input: $∀ ∴ ∁ ∵ ∃ ∣ ∈ ∉ ∋ ⊂ ⊃ ∧ ∨ ↦ → ← �
 Macros can also be defined in the KaTeX [rendering options](options.md).
 
 Macros accept up to nine arguments: #1, #2, etc.
+Delimiters (such as `\def\add#1+#2{#1\oplus#2}`) are not currently supported.
 
 `\gdef`, `\xdef`, `\global\def`, `\global\edef`, `\global\let`, and `\global\futurelet` will persist between math expressions.
 


### PR DESCRIPTION
`\def` has never supported delimiters, but I don't think we mention it anywhere, which recently led to #2288.  Added mention to function support documentation.

See https://deploy-preview-2289--katex.netlify.app/docs/next/supported.html#macros