### PR TITLE
Protect fraction bars from CSS border-color

### DIFF
--- a/src/katex.less
+++ b/src/katex.less
@@ -17,6 +17,9 @@
     // Prevent a rendering bug that misplaces \vec in Chrome.
     text-rendering: auto;
 
+    // Insulate fraction bars and rules from CSS that sets border-color.
+    border-color: currentColor;
+
     // Prevent background resetting on elements in Windows's high-contrast
     // mode, while still allowing background/foreground setting on root .katex
     * { -ms-high-contrast-adjust: none !important; }
@@ -570,7 +573,6 @@
     .fcolorbox {
         box-sizing: border-box;
         border: 0.04em solid;         // \fboxrule = 0.4pt
-        border-color: inherit;
     }
 
     .cancel-pad {


### PR DESCRIPTION
The default color of KaTeX fraction bars and rules should match the text color. This PR insulates KaTeX from external CSS that sets a `border-color` value.  Fixes #2236.