### PR TITLE
Link to Netlify on front page

### DIFF
--- a/website/pages/index.html
+++ b/website/pages/index.html
@@ -126,6 +126,7 @@
         Created by <a href="https://github.com/xymostech">Emily Eisenberg</a> and <a href="https://sophiebits.com/">Sophie Alpert</a>
         <br><a href="https://github.com/KaTeX/KaTeX/blob/master/LICENSE">MIT License</a> · Built from the hard work of <a href="https://github.com/KaTeX/KaTeX/graphs/contributors">many contributors</a>
         <br>Cross-browser testing via <a href="https://www.browserstack.com"><img src="/img/browserstack-logo.svg" alt="Browserstack"></a>
+        <br>This site is powered by <a href="https://www.netlify.com">Netlify</a>
       </span>
     </div></div>
 


### PR DESCRIPTION
Netlify's [Open Source Policy](https://www.netlify.com/legal/open-source-policy/) requires (and it seems like a good idea to do) the following:
> Must feature a link to our service on your main page, or all internal pages. You have two options:
> * We have premade badges for your convenience, or
> * You may create your own link, which should read “This site is powered by Netlify”, and include a link back to our home page.

I tried both and found that the latter fit best with our existing footer styling.

Once this is merged, we can [apply for an open source exemption](https://opensource-form.netlify.com/) to the limit we've come close to hitting in the past. (I just got notification that we're halfway there for the month, given the recent activity.) @kevinbarabash You could apply, or I can apply on your behalf. Let me know your preference.