### PR TITLE
Set MathML of \boldsymbol{textord} to bold, not bold-italic

### DIFF
--- a/src/buildMathML.js
+++ b/src/buildMathML.js
@@ -93,7 +93,7 @@ export const getVariant = function(
     if (font === "mathit") {
         return "italic";
     } else if (font === "boldsymbol") {
-        return "bold-italic";
+        return group.type === "textord" ? "mathbf" : "bold-italic";
     } else if (font === "mathbf") {
         return "bold";
     } else if (font === "mathbb") {

--- a/src/buildMathML.js
+++ b/src/buildMathML.js
@@ -93,7 +93,7 @@ export const getVariant = function(
     if (font === "mathit") {
         return "italic";
     } else if (font === "boldsymbol") {
-        return group.type === "textord" ? "mathbf" : "bold-italic";
+        return group.type === "textord" ? "bold" : "bold-italic";
     } else if (font === "mathbf") {
         return "bold";
     } else if (font === "mathbb") {

--- a/test/__snapshots__/mathml-spec.js.snap
+++ b/test/__snapshots__/mathml-spec.js.snap
@@ -407,7 +407,7 @@ exports[`A MathML builder should render boldsymbol with the correct mathvariants
           <mi mathvariant="bold-italic">
             x
           </mi>
-          <mn mathvariant="bold-italic">
+          <mn mathvariant="bold">
             2
           </mn>
           <mi mathvariant="bold-italic">
@@ -416,10 +416,10 @@ exports[`A MathML builder should render boldsymbol with the correct mathvariants
           <mi mathvariant="bold-italic">
             ω
           </mi>
-          <mi mathvariant="bold-italic">
+          <mi mathvariant="bold">
             Ω
           </mi>
-          <mi mathvariant="bold-italic">
+          <mi mathvariant="bold">
             ı
           </mi>
           <mo mathvariant="bold-italic">


### PR DESCRIPTION
Revise MathML in a way that aligns with the HTML in PR #2290.