### PR TITLE
chore: enable Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,3 +4,13 @@ tasks:
 
 ports:
   - port: 7936
+
+github:
+  # https://www.gitpod.io/docs/prebuilds/#configure-prebuilds
+  prebuilds:
+    pullRequestsFromForks: true
+
+vscode:
+  extensions:
+    - dbaeumer.vscode-eslint@2.1.5:9Wg0Glx/TwD8ElFBg+FKcQ==
+    - flowtype.flow-for-vscode@1.5.0:AwOT6wgHTF43loZQCAUMLA==

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+tasks:
+  - init: yarn install
+    command: yarn start --sockPort 443
+
+ports:
+  - port: 7936

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "javascript.validate.enable": false
+}

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=KaTeX/KaTeX)](https://dependabot.com)
 [![jsDelivr](https://data.jsdelivr.com/v1/package/npm/katex/badge?style=rounded)](https://www.jsdelivr.com/package/npm/katex)
 ![](https://img.badgesize.io/KaTeX/KaTeX/v0.12.0/dist/katex.min.js?compression=gzip)
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/KaTeX/KaTeX)
 
 KaTeX is a fast, easy-to-use JavaScript library for TeX math rendering on the web.
 


### PR DESCRIPTION
> This commit implements a fully-automated development setup using Gitpod.io, an online IDE for GitHub and GitLab that enables Dev-Environments-As-Code. This makes it easy for anyone to get a ready-to-code workspace for any branch, issue or pull request almost instantly with a single click.

Example: https://gitpod.io/#https://github.com/ylemkimon/KaTeX/tree/ylemkimon/gitpod-setup

The dev server hot reload is blocked on #2301, but this doesn't block the PR.