### PR TITLE
Set tags in float (WIP)

### DIFF
--- a/src/katex.less
+++ b/src/katex.less
@@ -622,17 +622,12 @@
     text-align: center;
 
     > .katex {
-        display: block;
-        text-align: center;
-        white-space: nowrap;
 
         > .katex-html {
-            display: block;
-            position: relative;
+            width: 100%;
 
             > .tag {
-                position: absolute;
-                right: 0;
+                float: right;
             }
         }
     }
@@ -640,8 +635,7 @@
 
 // Left-justified tags (default is right-justified)
 .katex-display.leqno > .katex > .katex-html > .tag {
-    left: 0;
-    right: auto;
+    float: left;
 }
 
 // Flush-left display math


### PR DESCRIPTION
I offer this PR, before writing any tests, for discussion. It avoids tag overlap by setting tags as `float: right` or `float: left`. The result for `\tag` is pretty good:

![tag](https://user-images.githubusercontent.com/16403058/88826704-e917f500-d17d-11ea-967b-9c192cc327ef.png)

The problem will be in environments that apply multiple equation numbers. Like this `{gather}` environment:

![gather](https://user-images.githubusercontent.com/16403058/88826855-12388580-d17e-11ea-8980-699b734fb8da.png)

LaTeX would align the top equation with (1). As you can see, this PR gets it wrong.

KaTeX environments construct their HTML column-wise, not row-wise like a HTML table. When @edemaine created KaTeX tags, he inserted clever struts into the tag elements so that a tag would align with content. But KaTeX has no way of knowing when a environment equation will wrap. In that case, the struts are not enough.

I cannot think of any way to ensure alignment except to (1) allow overlaps as is currently done, or (2) rewrite `array.js` from scratch to build the HTML row-wise ~~(probably in tables)~~ instead of column-wise.

I do not volunteer to rewrite `array.js`.  We may just have to live with tag overlaps.
