### PR TITLE
feat: support Unicode ◯, U+25EF

### DIFF
--- a/docs/supported.md
+++ b/docs/supported.md
@@ -363,7 +363,7 @@ Direct Input: $∫ ∬ ∭ ∮ ∏ ∐ ∑ ⋀ ⋁ ⋂ ⋃ ⨀ ⨁ ⨂ ⨄ ⨆$
 | $\Cap$ `\Cap`| $\doublecap$ `\doublecap`| $\oslash$ `\oslash`| $\wedge$ `\wedge`  |
 | $\cap$ `\cap`| $\doublecup$ `\doublecup`| $\pm$ `\pm` or `\plusmn` | $\wr$ `\wr`  |
 
-Direct Input: $+ - / * ⋅ ± × ÷ ∓ ∔ ∧ ∨ ∩ ∪ ≀ ⊎ ⊓ ⊔ ⊕ ⊖ ⊗ ⊘ ⊙ ⊚ ⊛ ⊝$
+Direct Input: $+ - / * ⋅ ± × ÷ ∓ ∔ ∧ ∨ ∩ ∪ ≀ ⊎ ⊓ ⊔ ⊕ ⊖ ⊗ ⊘ ⊙ ⊚ ⊛ ⊝ ◯$
 
 ### Fractions and Binomials
 

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -168,7 +168,7 @@ defineSymbol(math, main, bin, "\u228e", "\\uplus", true);
 defineSymbol(math, main, bin, "\u2293", "\\sqcap", true);
 defineSymbol(math, main, bin, "\u2217", "\\ast");
 defineSymbol(math, main, bin, "\u2294", "\\sqcup", true);
-defineSymbol(math, main, bin, "\u25ef", "\\bigcirc");
+defineSymbol(math, main, bin, "\u25ef", "\\bigcirc", true);
 defineSymbol(math, main, bin, "\u2219", "\\bullet");
 defineSymbol(math, main, bin, "\u2021", "\\ddagger");
 defineSymbol(math, main, bin, "\u2240", "\\wr", true);

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -3653,7 +3653,7 @@ describe("Unicode", function() {
     });
 
     it("should build binary operators", function() {
-        expect("±×÷∓∔∧∨∩∪≀⊎⊓⊔⊕⊖⊗⊘⊙⊚⊛⊝⊞⊟⊠⊡⊺⊻⊼⋇⋉⋊⋋⋌⋎⋏⋒⋓⩞\u22C5").toBuild(strictSettings);
+        expect("±×÷∓∔∧∨∩∪≀⊎⊓⊔⊕⊖⊗⊘⊙⊚⊛⊝◯⊞⊟⊠⊡⊺⊻⊼⋇⋉⋊⋋⋌⋎⋏⋒⋓⩞\u22C5").toBuild(strictSettings);
     });
 
     it("should build delimiters", function() {


### PR DESCRIPTION
In 2017 and 2018 we added a lot Unicode characters. But I avoided a few because there were ambiguities in how they should be used. I did not want a couple of edge cases to hold up review for the whole effort.

One of those characters was ◯, U+25EF. It's the character that KaTeX renders for `\bigcirc`. I avoided it earlier because of a disagreement. The `unicode-math` package classifies ◯ as a mathord, but `\bigcirc` is a binary operator.

I thought `unicode-math` was wrong in this case and I still think that way.  In support of this interpretation, I now cite a case in the wild. A [paper on matrix calculus](https://explained.ai/matrix-calculus/) uses ◯ and it is clearly a binary operator. With this evidence in hand, I offer this PR, which adds ◯ as a binary operator.