### PR TITLE
ci: use personal access token in Dependabot autofix

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -12,6 +12,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 2
+        token: ${{ secrets.GH_TOKEN }}
     - name: Use Node.js 12.x
       uses: actions/setup-node@v1
       with:

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -39,6 +39,8 @@ jobs:
 
         # deduplicate lockfile
         yarn deduplicate
+      env:
+        YARN_ENABLE_SCRIPTS: 0 # disable postinstall scripts
     - name: Config Git
       run: |
         # use personal access token to allow triggering new workflow

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -7,12 +7,13 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
 
     steps:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 2
-        token: ${{ secrets.GH_TOKEN }}
+        persist-credentials: false # minimize exposure
     - name: Use Node.js 12.x
       uses: actions/setup-node@v1
       with:
@@ -38,11 +39,17 @@ jobs:
 
         # deduplicate lockfile
         yarn deduplicate
+    - name: Config Git
+      run: |
+        # use personal access token to allow triggering new workflow
+        BASIC_AUTH=$(echo -n "x-access-token:${{ secrets.GH_TOKEN }}" | base64)
+        echo "::add-mask::$BASIC_AUTH"
+        git config --global user.name '${{ github.event.commits[0].author.name }}'
+        git config --global user.email '${{ github.event.commits[0].author.email }}'
+        git config --local http.$GITHUB_SERVER_URL/.extraheader "AUTHORIZATION: basic $BASIC_AUTH"
     - name: Commit changes
       run: |
         cd .`git log -1 --pretty=%s | awk '{ print $9 }'`
         git add yarn.lock
-        git config --global user.name 'dependabot[bot]'
-        git config --global user.email '49699333+dependabot[bot]@users.noreply.github.com'
         git commit -m "Dependabot autofix [skip netlify]"
         git push


### PR DESCRIPTION
A commit pushed using the default `GITHUB_TOKEN` will not create a new workflow run, i.e., run tests.

cf. https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token