### PR TITLE
Support \arrowvert and \Arrowvert

### DIFF
--- a/src/macros.js
+++ b/src/macros.js
@@ -364,6 +364,11 @@ defineMacro("\\clap", "\\mathclap{\\textrm{#1}}");
 // \mathstrut from the TeXbook, p 360
 defineMacro("\\mathstrut", "\\vphantom{(}");
 
+// \arrowvert and \Arrowvert from the TeXbook, p 359.
+// TODO: Create the correct font glyphs and use them instead of these macros.
+defineMacro("\\arrowvert", "\\vert");
+defineMacro("\\Arrowvert", "\\Vert");
+
 // \not is defined by base/fontmath.ltx via
 // \DeclareMathSymbol{\not}{\mathrel}{symbols}{"36}
 // It's thus treated like a \mathrel, but defined by a symbol that has zero

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -3119,6 +3119,10 @@ describe("A macro expander", function() {
         expect("\\underset{f}{\\rightarrow} Y").toBuild();
     });
 
+    it("should build \\arrowvert and \\Arrowvert", function() {
+        expect`\arrowvert a \Arrowvert \; \left\arrowvert \frac a b \right\Arrowvert`.toBuild();
+    });
+
     it("should build \\iff, \\implies, \\impliedby", function() {
         expect`X \iff Y`.toBuild();
         expect`X \implies Y`.toBuild();


### PR DESCRIPTION
`\arrowvert` and `\Arrowvert` are extendable delimiters from the TeXbook, page 359. They differ from `\vert` and `\Vert` only in the shape of their tips. Below is a image from quicklatex.com that renders `\left\Arrowvert \frac a b \right\Vert`. You can see that `\vert` has rounded tips and `\arrowvert` has flat tips.

![](https://quicklatex.com/cache3/61/ql_40319cf95970ada996f626aea8663f61_l3.png)

This PR provides versions of `\arrowvert` and `\Arrowvert` that do not render the tips correctly. Instead, it just provides macros that expand to `\vert` or `\Vert`. To get the correct, flat, tips for `\Arrowvert` would involve adding font glyphs. `\arrowvert` could possibly be done with an existing glyph from KaTeX_Main-Regular font, but that would involve new branching code because the extendable delimiters are currently all set up to use glyphs from KaTeX_Size1-Regular font. 

I did not add `\arrowvert` or `\Arrowvert` to the documentation. This PR is here only to support someone who has copied `\arrowvert` from a LaTeX or MathJax document. They will get a nearly correct glyph, which is better than a parse error.