### PR TITLE
feat: Add a targetable HTML id to \tag

### DIFF
--- a/docs/supported.md
+++ b/docs/supported.md
@@ -220,6 +220,8 @@ $$\tag{hi} x+y^{2x}$$
 `\tag*{hi} x+y^{2x}`
 $$\tag*{hi} x+y^{2x}$$
 
+If the argument to `\tag` or `\tag*` contains all text (no math), KaTeX will insert a targetable HTML id. Example: `tag{hi}` will result in `id="eqn-hi"`.
+
 ### Line Breaks
 
 KaTeX 0.10.0+ will insert automatic line breaks in inline math after relations or binary operators such as “=” or “+”. These can be suppressed by `\nobreak` or by placing math inside a pair of braces, as in `{F=ma}`. `\allowbreak` will allow automatic line breaks at locations other than relations or operators.

--- a/src/buildHTML.js
+++ b/src/buildHTML.js
@@ -14,6 +14,8 @@ import utils from "./utils";
 import {spacings, tightSpacings} from "./spacingData";
 import {_htmlGroupBuilders as groupBuilders} from "./defineFunction";
 import {DocumentFragment} from "./tree";
+import {assertNodeType, checkSymbolNodeType,
+    assertSymbolNodeType} from "./parseNode";
 
 import type Options from "./Options";
 import type {AnyParseNode} from "./parseNode";
@@ -310,9 +312,29 @@ function buildHTMLUnbreakable(children, options) {
 export default function buildHTML(tree: AnyParseNode[], options: Options): DomSpan {
     // Strip off outer tag wrapper for processing below.
     let tag = null;
+    let tagText = "";
     if (tree.length === 1 && tree[0].type === "tag") {
         tag = tree[0].tag;
         tree = tree[0].body;
+        // Retrieve the tag's input text, for use in an HTML id.
+        let textNode = assertNodeType(tag[0], "text");
+        const L = textNode.body.length;
+        if (assertSymbolNodeType(textNode.body[0]).text === "(" && L === 3 &&
+            assertSymbolNodeType(textNode.body[2]).text === ")") {
+            // omit parens inserted by \tag
+            textNode = assertNodeType(textNode.body[1], "ordgroup");
+        }
+        for (let i = 0; i < textNode.body.length; i++) {
+            if (!checkSymbolNodeType(textNode.body[i])) {
+                // A non-symbol input. Abort the HTML id.
+                tagText = "";
+                break;
+            }
+            const letter = assertNodeType(textNode.body[i], "textord").text;
+            if ("<>&'\"/".indexOf(letter) === -1) {
+                tagText += letter;
+            }
+        }
     }
 
     // Build the expression contained in the tree
@@ -378,6 +400,9 @@ export default function buildHTML(tree: AnyParseNode[], options: Options): DomSp
             buildExpression(tag, options, true)
         );
         tagChild.classes = ["tag"];
+        if (tagText.length > 0) {
+            tagChild.setAttribute("id", `eqn-${tagText}`);
+        }
         children.push(tagChild);
     } else if (eqnNum) {
         children.push(eqnNum);

--- a/test/__snapshots__/katex-spec.js.snap
+++ b/test/__snapshots__/katex-spec.js.snap
@@ -1,5 +1,193 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`\\tag support should include a targetable HTML id that omits unsafe characters 1`] = `
+[
+  {
+    "classes": [
+      "mord",
+      "mathnormal"
+    ],
+    "depth": 0,
+    "height": 0.43056,
+    "italic": 0,
+    "maxFontSize": 1,
+    "skew": 0.02778,
+    "style": {
+    },
+    "text": "x",
+    "width": 0.57153
+  },
+  {
+    "attributes": {
+    },
+    "children": [
+    ],
+    "classes": [
+      "mspace"
+    ],
+    "depth": 0,
+    "height": 0,
+    "maxFontSize": 0,
+    "style": {
+      "marginRight": "0.2222222222222222em"
+    }
+  },
+  {
+    "classes": [
+      "mbin"
+    ],
+    "depth": 0.08333,
+    "height": 0.58333,
+    "italic": 0,
+    "maxFontSize": 1,
+    "skew": 0,
+    "style": {
+    },
+    "text": "+",
+    "width": 0.77778
+  },
+  {
+    "attributes": {
+    },
+    "children": [
+    ],
+    "classes": [
+      "mspace"
+    ],
+    "depth": 0,
+    "height": 0,
+    "maxFontSize": 0,
+    "style": {
+      "marginRight": "0.2222222222222222em"
+    }
+  },
+  {
+    "classes": [
+      "mord",
+      "mathnormal"
+    ],
+    "depth": 0.19444,
+    "height": 0.43056,
+    "italic": 0.03588,
+    "maxFontSize": 1,
+    "skew": 0.05556,
+    "style": {
+    },
+    "text": "y",
+    "width": 0.49028
+  },
+  {
+    "attributes": {
+    },
+    "children": [
+      {
+        "classes": [
+          "mord",
+          "",
+          ""
+        ],
+        "depth": 0.25,
+        "height": 0.75,
+        "italic": 0,
+        "maxFontSize": 1,
+        "skew": 0,
+        "style": {
+        },
+        "text": "(",
+        "width": 0.38889
+      },
+      {
+        "attributes": {
+        },
+        "children": [
+          {
+            "classes": [
+              "mord",
+              "",
+              ""
+            ],
+            "depth": 0.0391,
+            "height": 0.5391,
+            "italic": 0,
+            "maxFontSize": 1,
+            "skew": 0,
+            "style": {
+            },
+            "text": "<",
+            "width": 0.77778
+          },
+          {
+            "classes": [
+              "mord",
+              "",
+              ""
+            ],
+            "depth": 0,
+            "height": 0.69444,
+            "italic": 0,
+            "maxFontSize": 1,
+            "skew": 0,
+            "style": {
+            },
+            "text": "h",
+            "width": 0.55556
+          },
+          {
+            "classes": [
+              "mord",
+              "",
+              ""
+            ],
+            "depth": 0,
+            "height": 0.66786,
+            "italic": 0,
+            "maxFontSize": 1,
+            "skew": 0,
+            "style": {
+            },
+            "text": "i",
+            "width": 0.27778
+          }
+        ],
+        "classes": [
+          "mord"
+        ],
+        "depth": 0.0391,
+        "height": 0.69444,
+        "maxFontSize": 1,
+        "style": {
+        }
+      },
+      {
+        "classes": [
+          "mord",
+          "",
+          ""
+        ],
+        "depth": 0.25,
+        "height": 0.75,
+        "italic": 0,
+        "maxFontSize": 1,
+        "skew": 0,
+        "style": {
+        },
+        "text": ")",
+        "width": 0.38889
+      }
+    ],
+    "classes": [
+      "mord",
+      "text"
+    ],
+    "depth": 0.25,
+    "height": 0.75,
+    "maxFontSize": 1,
+    "style": {
+    }
+  }
+]
+`;
+
 exports[`A begin/end parser should grab \\arraystretch 1`] = `
 [
   {

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -3504,6 +3504,11 @@ describe("\\tag support", function() {
     it("should handle \\tag* like \\tag", () => {
         expect`\tag{hi}x+y`.toParseLike(r`\tag*{({hi})}x+y`, displayMode);
     });
+
+    it("should include a targetable HTML id that omits unsafe characters", () => {
+        const built = getBuilt(r`\tag{<hi} x+y`, displayMode);
+        expect(built).toMatchSnapshot();
+    });
 });
 
 describe("leqno and fleqn rendering options", () => {


### PR DESCRIPTION
This PR adds an HTML id to the same element to which KaTeX assigns `class="tag"`. This enables an author to write a link elsewhere in the document. It may someday be useful in the implementation of `\ref`.

The id takes the form `eqn-<tagText>`.

There are a couple of exceptions. Any `\tag` that contains math will not get an id. The characters `<>&'"/` will be omitted from the id.