### PR TITLE
ci(renovate): update screenshotter browser, .flowconfig, editor SDKs, and Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/" # Location of .github
-    schedule:
-      interval: "daily"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
-          const SELENIUM_BROWSERS = ["chrome", "firefox"];
+          const SELENIUM_BROWSERS = ["chrome:3.141.59-20200525", "firefox:3.141.59-20200525"];
           const BROWSERSTACK_BROWSERS = [{
               browserName: "safari",
               browser_version: "13.1",
@@ -87,10 +87,10 @@ jobs:
 
           // running selenium doesn't require access to secrets
           if (context.eventName !== "pull_request_target") {
-              include.push(...SELENIUM_BROWSERS.map(name => ({
-                  browser: name,
+              include.push(...SELENIUM_BROWSERS.map(browserTag => ({
+                  browser: browserTag.split(':')[0],
                   services: {selenium: {
-                      image: `selenium/standalone-${name}:3.141.59-20200525`,
+                      image: `selenium/standalone-${browserTag}`,
                       ports: ["4444:4444"],
                   }},
               })));

--- a/dockers/screenshotter/screenshotter.sh
+++ b/dockers/screenshotter/screenshotter.sh
@@ -17,7 +17,7 @@ cleanup() {
 container=
 trap cleanup EXIT
 status=0
-for browserTag in firefox:3.141.59-20200525 chrome:3.141.59-20200525; do
+for browserTag in "firefox:3.141.59-20200525" "chrome:3.141.59-20200525"; do
     browser=${browserTag%:*}
     image=selenium/standalone-${browserTag}
     echo "Starting container for ${image}"

--- a/renovate.json
+++ b/renovate.json
@@ -27,6 +27,15 @@
       "datasourceTemplate": "docker",
       "depNameTemplate": "selenium/standalone-{{browserTag}}",
       "versioningTemplate": "regex:^3\\.141\\.59-(?<patch>\\d+)$"
+    }, {
+      "fileMatch": ["^\\.flowconfig$"],
+      "matchStrings": ["\\[version\\]\\s*(?<currentValue>.*?)\\s"],
+      "datasourceTemplate": "npm",
+      "depNameTemplate": "flow-bin"
+    }, {
+      "fileMatch": ["^\\.yarn/sdks/[^/]+/package\\.json$"],
+      "matchStrings": ["\"name\": \"(?<depName>.*?)\",\\s*\"version\": \"(?<currentValue>.*?)-pnpify\""],
+      "datasourceTemplate": "npm"
     }
   ],
   "stabilityDays": 3,

--- a/renovate.json
+++ b/renovate.json
@@ -7,8 +7,7 @@
     "group:linters"
   ],
   "git-submodules": {
-    "enabled": true,
-    "automerge": false
+    "enabled": true
   },
   "lockFileMaintenance": {
     "enabled": true,

--- a/renovate.json
+++ b/renovate.json
@@ -16,10 +16,18 @@
     "stabilityDays": 0,
     "dependencyDashboardApproval": true
   },
-  "includePaths": [
-    "package.json",
-    "website/package.json",
-    ".gitmodules"
+  "ignorePaths": ["dockers/texcmp/"],
+  "regexManagers": [
+    {
+      "fileMatch": [
+        "^\\.github/workflows/ci\\.yml$",
+        "^dockers/screenshotter/screenshotter\\.sh$"
+      ],
+      "matchStrings": ["\"(?<browserTag>[a-z]*):(?<currentValue>[\\d.\\-]*)\""],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "selenium/standalone-{{browserTag}}",
+      "versioningTemplate": "regex:^3\\.141\\.59-(?<patch>\\d+)$"
+    }
   ],
   "stabilityDays": 3,
   "rangeStrategy": "update-lockfile",

--- a/renovate.json
+++ b/renovate.json
@@ -40,5 +40,9 @@
   "stabilityDays": 3,
   "rangeStrategy": "update-lockfile",
   "commitBody": "[skip netlify]",
-  "postUpdateOptions": ["yarnDedupeHighest"]
+  "postUpdateOptions": ["yarnDedupeHighest"],
+  "packageRules": [{
+    "paths": ["website/**"],
+    "commitBody": ""
+  }]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,12 @@
   "ignorePaths": ["dockers/texcmp/"],
   "regexManagers": [
     {
+      "fileMatch": ["^\\.github/workflows/[^/]+\\.ya?ml$"],
+      "matchStrings": ["uses: (?<depName>.*?)@(?<currentValue>.*?)\\s"],
+      "datasourceTemplate": "github-tags",
+      "versioningTemplate": "regex:^v(?<major>\\d+)$"
+    },
+    {
       "fileMatch": [
         "^\\.github/workflows/ci\\.yml$",
         "^dockers/screenshotter/screenshotter\\.sh$"

--- a/renovate.json
+++ b/renovate.json
@@ -45,10 +45,10 @@
   ],
   "stabilityDays": 3,
   "rangeStrategy": "update-lockfile",
-  "commitBody": "[skip netlify]",
+  "commitMessageSuffix": "[skip netlify]",
   "postUpdateOptions": ["yarnDedupeHighest"],
   "packageRules": [{
     "paths": ["website/**"],
-    "commitBody": ""
+    "commitMessageSuffix": ""
   }]
 }


### PR DESCRIPTION
Enable Renovate to
- update screenshotter browser image
  * #2491 proved it's important to test on latest browsers
  * Example: https://github.com/ylemkimon/KaTeX/pull/48
- update versions in `.flowconfig` and Yarn 2 editor SDKs
  * Example: https://github.com/ylemkimon/renovate-flow/pull/2
- update GitHub Actions in workflows
  * Turns out https://github.com/KaTeX/KaTeX/pull/2493#discussion_r487341345 was wrong and Renovate updates GitHub Actions more reliably

and fixes #2483, netlify skip.