### PR TITLE
fix(browserslist): remove Chrome 49, Samsung 4, and Node

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -6,6 +6,5 @@ not dead
 > 0.1%
 not ie < 11
 not safari < 9
-
-# Currently maintained Node.js versions
-maintained node versions
+not chrome < 60
+not dead


### PR DESCRIPTION
This will remove the following browserslist entries:
* Chrome 49
  * Last release: 2016
  * The last version supported on Windows XP, Windows Vista, Mac OS X 10.6, 10.7, and 10.8.
  * Global usage: 0.27%
* Samsung Internet 4
  * Last release: 2016
  * Global usage: 0.27%
* Node
  * Its supports by other tools were buggy and as they use the same engine as Chrome, tracking Chrome version would suffice

However, they will not have any immediate effect as IE 11 is still supported.

