### PR TITLE
ci: run screenshotter in container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,15 +5,11 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-  pull_request_target:
-    branches: [ master ]
-    types: [ labeled ] # 'test screenshots' label on PRs from fork
 
 jobs:
   test:
     runs-on: ubuntu-latest
     if: |
-      github.event_name != 'pull_request_target' &&
       !contains(toJSON(github.event.commits.*.message), '[skip ci]') &&
       !contains(toJSON(github.event.commits.*.message), '[ci skip]')
 
@@ -57,129 +53,4 @@ jobs:
     - uses: codecov/codecov-action@v1
       with:
         directory: ./coverage/
-
-  screenshotter_dispatcher:
-    runs-on: ubuntu-latest
-    if: |
-      (github.event_name != 'pull_request_target' ||
-        (github.event.pull_request.head.repo.full_name != 'KaTeX/KaTeX' &&
-          contains(github.event.pull_request.labels.*.name, 'test screenshots'))) &&
-      !contains(toJSON(github.event.commits.*.message), '[skip ci]') &&
-      !contains(toJSON(github.event.commits.*.message), '[ci skip]')
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.result }}
-
-    steps:
-    - id: set-matrix
-      uses: actions/github-script@v3
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        script: |
-          const SELENIUM_BROWSERS = ["chrome:3.141.59-20201010", "firefox:3.141.59-20201010"];
-          const BROWSERSTACK_BROWSERS = [{
-              browserName: "safari",
-              browser_version: "13.1",
-              os: "OS X",
-              os_version: "Catalina",
-          }];
-
-          const include = [];
-
-          // running selenium doesn't require access to secrets
-          if (context.eventName !== "pull_request_target") {
-              include.push(...SELENIUM_BROWSERS.map(browserTag => ({
-                  browser: browserTag.split(':')[0],
-                  services: {selenium: {
-                      image: `selenium/standalone-${browserTag}`,
-                      ports: ["4444:4444"],
-                  }},
-              })));
-          }
-
-          // check access to Browserstack crendential secrets
-          if (context.eventName !== "pull_request" ||
-                  context.payload.pull_request.head.repo.full_name === "KaTeX/KaTeX") {
-              if (context.eventName === "pull_request_target") {
-                  github.issues.removeLabel({
-                      issue_number: context.issue.number,
-                      owner: context.repo.owner,
-                      repo: context.repo.repo,
-                      name: "test screenshots",
-                  });
-              }
-              include.push(...BROWSERSTACK_BROWSERS.map(capabilities => ({
-                  browser: capabilities.browserName,
-                  services: {},
-                  browserstack: capabilities,
-              })));
-          }
-
-          return {browser: include.map(b => b.browser), include};
-
-  screenshotter:
-    runs-on: ubuntu-latest
-    needs: screenshotter_dispatcher
-    strategy:
-      matrix: ${{ fromJson(needs.screenshotter_dispatcher.outputs.matrix) }}
-      fail-fast: false
-    services: ${{ matrix.services }}
-
-    steps:
-    - uses: actions/checkout@v2
-      if: github.event_name != 'pull_request_target'
-      with:
-        submodules: recursive
-        persist-credentials: false # minimize exposure and prevent accidental pushes
-    - uses: actions/checkout@v2
-      if: github.event_name == 'pull_request_target'
-      with:
-        # pull_request_target is run in the context of the base repository
-        # of the pull request, so the default ref is master branch and
-        # ref should be manually set to the head of the PR
-        ref: refs/pull/${{ github.event.pull_request.number }}/head
-        submodules: recursive
-
-    - name: Use Node.js 12.x
-      uses: actions/setup-node@v1
-      with:
-        node-version: '12'
-
-    - name: Cache dependencies
-      uses: actions/cache@v2
-      with:
-        path: |
-          .yarn/cache
-          .pnp.js
-        key: yarn-deps-v1-${{ hashFiles('yarn.lock') }}
-        restore-keys: |
-          yarn-deps-v1-
-
-    - name: Install dependencies
-      run: yarn --immutable
-      env:
-        YARN_ENABLE_SCRIPTS: 0 # disable postinstall scripts
-
-    - name: Verify screenshots and generate diffs and new screenshots
-      run: yarn node dockers/screenshotter/screenshotter.js -b ${{ matrix.browser }} --verify --diff --new -c ${{ job.services.selenium.id }}
-      if: matrix.services.selenium
-    - name: Verify screenshots and generate diffs and new screenshots
-      run: yarn node dockers/screenshotter/screenshotter.js -b ${{ matrix.browser }} --verify --diff --new --browserstack --selenium-capabilities '${{ toJson(matrix.browserstack) }}'
-      if: matrix.browserstack
-      env:
-        BROWSERSTACK_USER: ${{ secrets.BROWSERSTACK_USER }}
-        BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
-
-    - name: Print Docker logs
-      run: docker logs ${{ job.services.selenium.id }}
-      if: always() && matrix.services.selenium
-
-    - uses: actions/upload-artifact@v2
-      if: failure()
-      with:
-        name: new-${{ matrix.browser }}
-        path: test/screenshotter/new
-    - uses: actions/upload-artifact@v2
-      if: failure()
-      with:
-        name: diff-${{ matrix.browser }}
-        path: test/screenshotter/diff
+      timeout-minutes: 3

--- a/.github/workflows/screenshotter.yml
+++ b/.github/workflows/screenshotter.yml
@@ -1,0 +1,98 @@
+name: Screenshotter
+
+on:
+  push:
+    branches: [ master ]
+  pull_request_target:
+    branches: [ master ]
+
+jobs:
+  screenshotter:
+    runs-on: ubuntu-latest
+    if: |
+      !contains(toJSON(github.event.commits.*.message), '[skip ci]') &&
+      !contains(toJSON(github.event.commits.*.message), '[ci skip]')
+    strategy:
+      matrix:
+        browser: [chrome, firefox, safari]
+        include:
+        - browser: chrome
+          image: selenium/standalone-chrome:3.141.59-20201010
+        - browser: firefox
+          image: selenium/standalone-firefox:3.141.59-20201010
+        - browser: safari
+          image: ylemkimon/selenium-proxy:latest
+          browserstack:
+            browserName: safari
+            browser_version: 13.1
+            os: OS X
+            os_version: Catalina
+      fail-fast: false
+    services:
+      selenium:
+        image: ${{ matrix.image }}
+        env:
+          # secrets are not supported in matrix, so put it here and limit to browserstack job
+          BROWSERSTACK_USER: ${{ matrix.browserstack && secrets.BROWSERSTACK_USER }}
+          BROWSERSTACK_ACCESS_KEY: ${{ matrix.browserstack && secrets.BROWSERSTACK_ACCESS_KEY }}
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
+        submodules: recursive
+        persist-credentials: false # do not persist credentials
+
+    - name: Use Node.js 14
+      uses: actions/setup-node@v1
+      with:
+        node-version: '14'
+
+    - name: Restore cached dependencies # restore only to prevent cache poisoning
+      uses: ylemkimon/cache-restore@v2
+      with:
+        path: |
+          .yarn/cache
+          .pnp.js
+        key: yarn-deps-v1-${{ hashFiles('yarn.lock') }}
+        restore-keys: |
+          yarn-deps-v1-
+
+    - name: Run screenshotter
+      run: |
+        TOKEN="$(cat /proc/sys/kernel/random/uuid | sha256sum | head -c 64)"
+        echo "::add-mask::$TOKEN"
+        echo "TOKEN=$TOKEN" >> $GITHUB_ENV
+        echo "::stop-commands::$TOKEN" # stop processing workflow commands
+
+        # run in Docker container
+        # mount .git readonly to prevent modification
+        docker run --rm \
+          --network ${{ job.services.selenium.network }} \
+          -v "$PWD:/code" \
+          -v "$PWD/.git:/code/.git:ro" \
+          -w /code \
+          -e YARN_ENABLE_SCRIPTS=0 \
+          -e CI=true \
+          node:14 \
+          /bin/bash -c 'yarn --immutable && yarn node dockers/screenshotter/screenshotter.js -b ${{ matrix.browser }} --verify --diff --new --katex-ip $HOSTNAME ${{ matrix.browserstack && format('--selenium-proxy http://selenium:4445/build --browserstack --selenium-capabilities ''\''''{0}''\', toJson(matrix.browserstack)) || '--selenium-ip selenium' }}'
+        echo "::$TOKEN::"
+      timeout-minutes: 10
+
+    - name: Print Selenium Docker logs
+      if: always()
+      run: |
+        echo "::stop-commands::$TOKEN" # stop processing workflow commands
+        docker logs ${{ job.services.selenium.id }}
+        echo "::$TOKEN::"
+
+    - uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: new-${{ matrix.browser }}
+        path: test/screenshotter/new
+    - uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: diff-${{ matrix.browser }}
+        path: test/screenshotter/diff

--- a/.github/workflows/screenshotter.yml
+++ b/.github/workflows/screenshotter.yml
@@ -1,3 +1,4 @@
+# trivial change to trigger the actions again
 name: Screenshotter
 
 on:

--- a/.github/workflows/screenshotter.yml
+++ b/.github/workflows/screenshotter.yml
@@ -1,4 +1,3 @@
-# trivial change to trigger the actions again
 name: Screenshotter
 
 on:

--- a/dockers/screenshotter/screenshotter.js
+++ b/dockers/screenshotter/screenshotter.js
@@ -8,9 +8,12 @@ const net = require("net");
 const os = require("os");
 const pako = require("pako");
 const path = require("path");
+const got = require("got");
+
 const selenium = require("selenium-webdriver");
 const firefox = require("selenium-webdriver/firefox");
 const chrome = require("selenium-webdriver/chrome");
+const seleniumHttp = require("selenium-webdriver/http");
 
 const istanbulLibCoverage = require('istanbul-lib-coverage');
 const istanbulLibReport = require('istanbul-lib-report');
@@ -44,6 +47,7 @@ const opts = require("commander")
         "Port number of the Selenium web driver", 4444, parseInt)
     .option("--selenium-capabilities <JSON>",
         "Desired capabilities of the Selenium web driver", JSON.parse)
+    .option("--selenium-proxy <url>", "Use Selenium proxy if specified")
     .option("--katex-url <url>", "Full URL of the KaTeX development server")
     .option("--katex-ip <ip>", "IP address of the KaTeX development server")
     .option("--katex-port <n>",
@@ -216,7 +220,8 @@ function startServer() {
         devServer = wds;
         katexPort = port;
         attempts = 0;
-        process.nextTick(opts.browserstack ? startBrowserstackLocal : tryConnect);
+        process.nextTick(opts.seleniumProxy ? getDriver
+            : opts.browserstack ? startBrowserstackLocal : tryConnect);
     });
     server.on("error", function(err) {
         if (devServer !== null) { // error after we started listening
@@ -294,6 +299,28 @@ function buildDriver() {
         builder.withCapabilities(opts.seleniumCapabilities);
     }
     driver = builder.build();
+    setupDriver();
+}
+
+function getDriver() {
+    got.post(opts.seleniumProxy, {
+        json: {
+            browserstack: opts.browserstack,
+            capabilities: opts.seleniumCapabilities,
+            seleniumURL,
+        },
+        responseType: 'json',
+    }).then(({body}) => {
+        const session = new selenium.Session(body.id, body.capabilities);
+        const client = Promise.resolve(seleniumURL)
+            .then(url => new seleniumHttp.HttpClient(url));
+        const executor = new seleniumHttp.Executor(client);
+        driver = new selenium.WebDriver(session, executor);
+        setupDriver();
+    });
+}
+
+function setupDriver() {
     driver.manage().timeouts().setScriptTimeout(3000).then(function() {
         let html = '<!DOCTYPE html>' +
             '<html><head><style type="text/css">html,body{' +

--- a/dockers/screenshotter/screenshotter.js
+++ b/dockers/screenshotter/screenshotter.js
@@ -220,7 +220,7 @@ function startServer() {
         devServer = wds;
         katexPort = port;
         attempts = 0;
-        process.nextTick(opts.seleniumProxy ? getDriver
+        process.nextTick(opts.seleniumProxy ? getProxyDriver
             : opts.browserstack ? startBrowserstackLocal : tryConnect);
     });
     server.on("error", function(err) {
@@ -302,7 +302,7 @@ function buildDriver() {
     setupDriver();
 }
 
-function getDriver() {
+function getProxyDriver() {
     got.post(opts.seleniumProxy, {
         json: {
             browserstack: opts.browserstack,

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "file-loader": "^6.0.0",
     "flow-bin": "^0.135.0",
     "fs-extra": "^9.0.1",
+    "got": "^11.8.0",
     "husky": "^4.2.5",
     "istanbul-lib-coverage": "^3.0.0",
     "istanbul-lib-report": "^3.0.0",

--- a/renovate.json
+++ b/renovate.json
@@ -25,10 +25,10 @@
     },
     {
       "fileMatch": [
-        "^\\.github/workflows/ci\\.yml$",
+        "^\\.github/workflows/screenshotter\\.yml$",
         "^dockers/screenshotter/screenshotter\\.sh$"
       ],
-      "matchStrings": ["\"(?<browserTag>[a-z]*):(?<currentValue>[\\d.\\-]*)\""],
+      "matchStrings": ["[-\"](?<browserTag>[a-z]+):(?<currentValue>[\\d.\\-]+)[\"\\s]"],
       "datasourceTemplate": "docker",
       "depNameTemplate": "selenium/standalone-{{browserTag}}",
       "versioningTemplate": "regex:^3\\.141\\.59-(?<patch>\\d+)$"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1563,6 +1563,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sindresorhus/is@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@sindresorhus/is@npm:4.0.0"
+  checksum: 7022d5037ff778c5c369c353e16a173c3797de5f4196b631ec00b0f710a3ccb016937ce454d4fac6ca32d695ed30a59444e941f8f78ff7692dc3c50959b3fe61
+  languageName: node
+  linkType: hard
+
 "@sinonjs/commons@npm:^1.7.0":
   version: 1.8.1
   resolution: "@sinonjs/commons@npm:1.8.1"
@@ -1603,6 +1610,15 @@ __metadata:
     postcss: ">=7.0.0"
     postcss-syntax: ">=0.36.2"
   checksum: 4b1563a1d74cd16d5e2d56c894c7615449813283700402ca4d9c982066929f263446851f9f1296c077002a13b7bd17a8e21a95136e8dde33908571f268312f85
+  languageName: node
+  linkType: hard
+
+"@szmarczak/http-timer@npm:^4.0.5":
+  version: 4.0.5
+  resolution: "@szmarczak/http-timer@npm:4.0.5"
+  dependencies:
+    defer-to-connect: ^2.0.0
+  checksum: 13d8f71dbd792b620b2cd13d72d086ef031ebefd5263a9db2f34693a32e4d90920fa1d7075cd59bf0c9810b2b1b93ad36d89fc88aba4cd3b8022df7ecc5ffdec
   languageName: node
   linkType: hard
 
@@ -1647,6 +1663,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/cacheable-request@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "@types/cacheable-request@npm:6.0.1"
+  dependencies:
+    "@types/http-cache-semantics": "*"
+    "@types/keyv": "*"
+    "@types/node": "*"
+    "@types/responselike": "*"
+  checksum: 3dae802a0808573986c56b92bf16cd031a5b648b6c893d20c7ef6bfda3fc72a2107c7978697d2b27b14febc597162d6959985eeb5befc307a9f9f3c5081d4905
+  languageName: node
+  linkType: hard
+
 "@types/color-name@npm:^1.1.1":
   version: 1.1.1
   resolution: "@types/color-name@npm:1.1.1"
@@ -1680,6 +1708,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/http-cache-semantics@npm:*":
+  version: 4.0.0
+  resolution: "@types/http-cache-semantics@npm:4.0.0"
+  checksum: e16fae56d4daea4ed678b4d5918b693b44ca12fb5e479b87d242d3a35bf3a014974dcf9ed7aba7e29149fdb6c3719f9987fca51b20ef10aa84b58f86553c2f74
+  languageName: node
+  linkType: hard
+
 "@types/istanbul-lib-coverage@npm:*, @types/istanbul-lib-coverage@npm:^2.0.0, @types/istanbul-lib-coverage@npm:^2.0.1":
   version: 2.0.3
   resolution: "@types/istanbul-lib-coverage@npm:2.0.3"
@@ -1709,6 +1744,15 @@ __metadata:
   version: 7.0.6
   resolution: "@types/json-schema@npm:7.0.6"
   checksum: 820cabe35ac915b93e38b0c01957e5c49d7d9f69251dddfbf39af0ff4fe24f6e08b39e55603e0d212dea7bcaa383b1218b58a738d1c02013dc22df06547ff238
+  languageName: node
+  linkType: hard
+
+"@types/keyv@npm:*":
+  version: 3.1.1
+  resolution: "@types/keyv@npm:3.1.1"
+  dependencies:
+    "@types/node": "*"
+  checksum: 3aaf557d5b82e733d5a17b7f55af5d6be953363c3a594f006d64265790fe87c301c6e1400c0b6b1cf72add50a0ceddc25afb8231ab8302a2e5b6ebfbfac30e5d
   languageName: node
   linkType: hard
 
@@ -1758,6 +1802,15 @@ __metadata:
   version: 1.5.4
   resolution: "@types/q@npm:1.5.4"
   checksum: 1a19cf2c41648b862bd25a4c26ba33dc7206f14fcf50c5b78031b59090d21176e703cd10aff8af409eafbefcebb288607d30af765ee3859637cf3fae6e875648
+  languageName: node
+  linkType: hard
+
+"@types/responselike@npm:*, @types/responselike@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@types/responselike@npm:1.0.0"
+  dependencies:
+    "@types/node": "*"
+  checksum: e6e6613c800aeda63e2331e753e8d21df1a2c9aa7a4bc71ed792a848e4811fc96e609759089355314a2318c76eff1f161499cd242044838ab1e6f56e463ebb9c
   languageName: node
   linkType: hard
 
@@ -3063,6 +3116,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cacheable-lookup@npm:^5.0.3":
+  version: 5.0.3
+  resolution: "cacheable-lookup@npm:5.0.3"
+  checksum: a51e3ddb824865b87895a915fc41be6e2097b62932e5441c357711bb87ec23b0a738a7b7a5cefd9043dacd4ed31ca56b62528ec60ba020e360f07175b6ca5bfe
+  languageName: node
+  linkType: hard
+
+"cacheable-request@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "cacheable-request@npm:7.0.1"
+  dependencies:
+    clone-response: ^1.0.2
+    get-stream: ^5.1.0
+    http-cache-semantics: ^4.0.0
+    keyv: ^4.0.0
+    lowercase-keys: ^2.0.0
+    normalize-url: ^4.1.0
+    responselike: ^2.0.0
+  checksum: fe0b6f3b8a145c98fecc00f0f1b13a9886cad9bf4537533c5568cba19db81c8ee09ace9c61967d5a4e72615e174d771b6b8080c3816f0b74fc6f9c69060c3ff0
+  languageName: node
+  linkType: hard
+
 "caller-callsite@npm:^2.0.0":
   version: 2.0.0
   resolution: "caller-callsite@npm:2.0.0"
@@ -3354,6 +3429,15 @@ __metadata:
   dependencies:
     is-regexp: ^2.0.0
   checksum: 9a613954e000b1f95dc9d1e98f93124b830746d35844ac663c1f02e59d11d0d3c49e2156f25d3115cb744f462d9645ca9642693af7930549d5b557a06d7ec7b8
+  languageName: node
+  linkType: hard
+
+"clone-response@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "clone-response@npm:1.0.2"
+  dependencies:
+    mimic-response: ^1.0.0
+  checksum: 71832f9219f2682b0915bdbc0dd187ba8e63d16b0af5342b44f97b34afe9400a1f528a253dd2f70a8dd8b23bfa4c4e106928fcc520fa5899d769af95e4cce53c
   languageName: node
   linkType: hard
 
@@ -4119,6 +4203,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"decompress-response@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "decompress-response@npm:6.0.0"
+  dependencies:
+    mimic-response: ^3.1.0
+  checksum: bb8b8c42be7767994764d27f91a3949e3dc9008da82f1aaeab1de40f1ebb50d7abf17b31b2e4000f8d267a1e75f76052efd58d4419124c04bf430e184c164fad
+  languageName: node
+  linkType: hard
+
 "deep-equal@npm:^1.0.1":
   version: 1.1.1
   resolution: "deep-equal@npm:1.1.1"
@@ -4154,6 +4247,13 @@ __metadata:
     execa: ^1.0.0
     ip-regex: ^2.1.0
   checksum: 5d92439d573a261d850f6205fcc6541ec57378dec2032f3c7d0a18c7f9222f88f7ff4997bfff17607850b8fce6cdf3fb1c231bc43bf5e2bd6bbce3b733082add
+  languageName: node
+  linkType: hard
+
+"defer-to-connect@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "defer-to-connect@npm:2.0.0"
+  checksum: 0453938bfce1c866263d0a4732ade8d69b1a39e27e073d3fbae9e0cc1c6a15a422c2fe5f90320465312ace6a01dbed4a2836755ac2a9519555e82d65141eabdc
   languageName: node
   linkType: hard
 
@@ -5612,7 +5712,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"get-stream@npm:^5.0.0":
+"get-stream@npm:^5.0.0, get-stream@npm:^5.1.0":
   version: 5.2.0
   resolution: "get-stream@npm:5.2.0"
   dependencies:
@@ -5772,6 +5872,25 @@ fsevents@^1.2.7:
   bin:
     gonzales: bin/gonzales.js
   checksum: 9dae79303ae4e81a8d0b047b2ea837358aa7dac0f5abc8a46bf703b7c46684b3ee62ae3404715321942f15389ae38bd87759fba247263510e244ab71eda3f2d0
+  languageName: node
+  linkType: hard
+
+"got@npm:^11.8.0":
+  version: 11.8.0
+  resolution: "got@npm:11.8.0"
+  dependencies:
+    "@sindresorhus/is": ^4.0.0
+    "@szmarczak/http-timer": ^4.0.5
+    "@types/cacheable-request": ^6.0.1
+    "@types/responselike": ^1.0.0
+    cacheable-lookup: ^5.0.3
+    cacheable-request: ^7.0.1
+    decompress-response: ^6.0.0
+    http2-wrapper: ^1.0.0-beta.5.2
+    lowercase-keys: ^2.0.0
+    p-cancelable: ^2.0.0
+    responselike: ^2.0.0
+  checksum: 9ad3dddd7292e34484b314eabfcb140074e70b14e0d501fce6afd341715c2300838d5382392562ce7764c1ac46506d1b835db4f5988053211d5506d5b9a4b849
   languageName: node
   linkType: hard
 
@@ -6038,6 +6157,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"http-cache-semantics@npm:^4.0.0":
+  version: 4.1.0
+  resolution: "http-cache-semantics@npm:4.1.0"
+  checksum: 451df9784af2acbe0cc1fd70291285c08ca4a8966ab5ee4d3975e003d1ad4d74c81473086d628f31296b31221966fda8bc5ea1e29dd8f1f33f9fc2b0fdca65ca
+  languageName: node
+  linkType: hard
+
 "http-deceiver@npm:^1.2.7":
   version: 1.2.7
   resolution: "http-deceiver@npm:1.2.7"
@@ -6114,6 +6240,16 @@ fsevents@^1.2.7:
     jsprim: ^1.2.2
     sshpk: ^1.7.0
   checksum: d28227eed37cb0dae0e76c46b2a5e611c678808433e5642238f17dba7f2c9c8f8d1646122d57ec1a110ecc7e8b9f5b7aa0462f1e2a5fa3b41f2fca5a69af7edf
+  languageName: node
+  linkType: hard
+
+"http2-wrapper@npm:^1.0.0-beta.5.2":
+  version: 1.0.0-beta.5.2
+  resolution: "http2-wrapper@npm:1.0.0-beta.5.2"
+  dependencies:
+    quick-lru: ^5.1.1
+    resolve-alpn: ^1.0.0
+  checksum: 74db457c83d2cef5ea36e6a0a013a0a12b3fff575c4cabfc91c012b7335463d09ed3dba2d7e87babab4396a170df466730b1c13d92f99bbdd82b7aec99387683
   languageName: node
   linkType: hard
 
@@ -7527,6 +7663,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"json-buffer@npm:3.0.1":
+  version: 3.0.1
+  resolution: "json-buffer@npm:3.0.1"
+  checksum: 78011309cb53c19195702ece9e282c8c58d7facd8d6e286857fd4daf511f0bd93424498898d0b9ecfde6ab8e87a2ab0c0a654fba4b1a4ec81fa51f2c48a5ddba
+  languageName: node
+  linkType: hard
+
 "json-parse-better-errors@npm:^1.0.1, json-parse-better-errors@npm:^1.0.2":
   version: 1.0.2
   resolution: "json-parse-better-errors@npm:1.0.2"
@@ -7705,6 +7848,7 @@ fsevents@^1.2.7:
     file-loader: ^6.0.0
     flow-bin: ^0.135.0
     fs-extra: ^9.0.1
+    got: ^11.8.0
     husky: ^4.2.5
     istanbul-lib-coverage: ^3.0.0
     istanbul-lib-report: ^3.0.0
@@ -7744,6 +7888,15 @@ fsevents@^1.2.7:
     katex: cli.js
   languageName: unknown
   linkType: soft
+
+"keyv@npm:^4.0.0":
+  version: 4.0.3
+  resolution: "keyv@npm:4.0.3"
+  dependencies:
+    json-buffer: 3.0.1
+  checksum: 63527e3d010dd9b8f8e62435130cdb1518de7b7d0ebafcff1359611caa0e79c7f80f1863ff73e712d99ce69fa06be62b66a78fb5cfee6483f2f95eeac340f12b
+  languageName: node
+  linkType: hard
 
 "killable@npm:^1.0.1":
   version: 1.0.1
@@ -8028,6 +8181,13 @@ fsevents@^1.2.7:
   bin:
     loose-envify: cli.js
   checksum: 5c3b47bbe5f597a3889fb001a3a98aaea2a3fafa48089c19034de1e0121bf57dbee609d184478514d74d5c5a7e9cfa3d846343455e5123b060040d46c39e91dc
+  languageName: node
+  linkType: hard
+
+"lowercase-keys@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "lowercase-keys@npm:2.0.0"
+  checksum: 4da67f41865a25360bb05749a66a83c60987c7efa0b8ec443941a19978c21ba916ae9fedca25b96fc652026c4264a437d3fec099d1949716b5483eec42395ec9
   languageName: node
   linkType: hard
 
@@ -8326,6 +8486,20 @@ fsevents@^1.2.7:
   version: 2.1.0
   resolution: "mimic-fn@npm:2.1.0"
   checksum: f7d2d7febe3d7dd71da0700b1d455ec6c951a96b463ffcc303c93771b9fe4e45318152ea677c241505b19b39e41d906e5052cfb382d59a44bdb6d3d57f8b467b
+  languageName: node
+  linkType: hard
+
+"mimic-response@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "mimic-response@npm:1.0.1"
+  checksum: 64b43c717ed8710bc920576e96d38d0e504e9eec3114af8e00c9e3d7ae53cd459ee38febb0badc83e3a4e6d21cd571db43e9011f8cf014809989c87a1a9f0ea4
+  languageName: node
+  linkType: hard
+
+"mimic-response@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "mimic-response@npm:3.1.0"
+  checksum: cfbf19f66de6ad46df7481d9e8c1a7f30b6fa77dd771ad4a72a0443265041a39768182bde6d1de39001c2774168635bc74f42902e401c8ba33db55d69b773004
   languageName: node
   linkType: hard
 
@@ -8755,6 +8929,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"normalize-url@npm:^4.1.0":
+  version: 4.5.0
+  resolution: "normalize-url@npm:4.5.0"
+  checksum: 09794941dbe5c7b91caf6f3cd1ae167c27f6d09793e4a03601a68b62de7e8ee9e5de21a246130cdbab98b01481de292f9556d492444a527648f9cf1220e4b0df
+  languageName: node
+  linkType: hard
+
 "npm-run-path@npm:^2.0.0":
   version: 2.0.2
   resolution: "npm-run-path@npm:2.0.2"
@@ -9072,6 +9253,13 @@ fsevents@^1.2.7:
     os-homedir: ^1.0.0
     os-tmpdir: ^1.0.0
   checksum: 1c7462808c5ff0c2816b11f2f46265a98c395586058f98d73a6deac82955744484b277baedceeb962c419f3b75d0831a77ce7cf38b9e4f20729943ba79d72b08
+  languageName: node
+  linkType: hard
+
+"p-cancelable@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "p-cancelable@npm:2.0.0"
+  checksum: 966065f056a116a1ca3b6c7064d4d27a65bc1740c25cc60729faa5deea385bbd0f2317aedabb8e64c0cfc3c6b2dafe7f3ea65c267373d6d9be1602af443b4f12
   languageName: node
   linkType: hard
 
@@ -10545,6 +10733,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"quick-lru@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "quick-lru@npm:5.1.1"
+  checksum: fafb2b2fa1a948d6f2e88d4a60571be70b316d9b0be857d24fba0ac28fc31acebf535b643fe968473d689f8c655bcb2a0e4da67912f571059a4e4eb15740b021
+  languageName: node
+  linkType: hard
+
 "randombytes@npm:^2.0.0, randombytes@npm:^2.0.1, randombytes@npm:^2.0.5, randombytes@npm:^2.1.0":
   version: 2.1.0
   resolution: "randombytes@npm:2.1.0"
@@ -10932,6 +11127,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"resolve-alpn@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "resolve-alpn@npm:1.0.0"
+  checksum: 17baee01c03a57cebd163aa5c9bd94f33646378bce8aa94c7a8d29fc0e1bf0807532bda3c36bb929511606633921d0f4a69e7fcc894cf02ad1c742e649b71673
+  languageName: node
+  linkType: hard
+
 "resolve-cwd@npm:^2.0.0":
   version: 2.0.0
   resolution: "resolve-cwd@npm:2.0.0"
@@ -11005,6 +11207,15 @@ fsevents@^1.2.7:
     is-core-module: ^2.0.0
     path-parse: ^1.0.6
   checksum: 9e62d2803ad1ec21b13780cc6a45b72bb7b6525eb5b44f0ede7cde37c00a8eb310c06ebfcc7de7dc10c2234d7d271bc4f1eed9783fb87acac141597cd4efaeec
+  languageName: node
+  linkType: hard
+
+"responselike@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "responselike@npm:2.0.0"
+  dependencies:
+    lowercase-keys: ^2.0.0
+  checksum: 11d8225dd8bbbd2ab7482c2e54ff2618e346c7d785e66d2ff5da03d6eafa8b33c3a4c6d685324dccf06f36ee2695db9bd2579382548c2a7253d770204694a63d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* Run screenshotters in a separate container: this would enable to run screenshotters (relatively) safely on PRs from forks, eliminating the need for the dispatcher and manual approval (`test screenshots` label)
  * Use `selenium-proxy` to hide Browserstack credentials
  * Only restore cache to prevent cache poisoning
  * Stop processing workflow commands when printing logs