### PR TITLE
chore: Verify semantic messages via Pull Request title, not commits

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,2 @@
+# Always validate the PR title, and ignore the commits
+titleOnly: true


### PR DESCRIPTION
KaTeX always squash-merges PRs, so this seems like the preferred way to ensure that final commits support semantic-release.  I'm hoping it will make fixing nonsemantic PRs easier as well (like #2680); see https://github.com/zeke/semantic-pull-requests/issues/112
