### PR TITLE
fix: Replace topEnv with  check of input string.

### DIFF
--- a/src/Settings.js
+++ b/src/Settings.js
@@ -67,7 +67,6 @@ export type SettingsOptions = {
     maxSize?: number;
     maxExpand?: number;
     globalGroup?: boolean;
-    topEnv?: boolean;
 };
 
 /**
@@ -95,7 +94,6 @@ export default class Settings {
     maxSize: number;
     maxExpand: number;
     globalGroup: boolean;
-    topEnv: boolean;
 
     constructor(options: SettingsOptions) {
         // allow null options
@@ -117,7 +115,6 @@ export default class Settings {
         this.maxSize = Math.max(0, utils.deflt(options.maxSize, Infinity));
         this.maxExpand = Math.max(0, utils.deflt(options.maxExpand, 1000));
         this.globalGroup = utils.deflt(options.globalGroup, false);
-        this.topEnv = utils.deflt(options.topEnv, false);
     }
 
     /**

--- a/src/environments/array.js
+++ b/src/environments/array.js
@@ -48,11 +48,14 @@ function getHLines(parser: Parser): boolean[] {
 
 const validateAmsEnvironmentContext = context => {
     const settings = context.parser.settings;
+    const input = context.parser.gullet.lexer.input.trim();
     if (!settings.displayMode) {
-        throw new ParseError(`{${context.envName}} cannot be used inline.`);
-    } else if (settings.strict && !settings.topEnv) {
-        settings.reportNonstrict("textEnv",
-            `{${context.envName}} called from math mode.`);
+        throw new ParseError(`{${context.envName}} can be used only in` +
+            ` display mode.`);
+    } else if (!/^\\begin{/.test(input)) {
+        // Some other math exists in this KaTeX element before this environment.
+        throw new ParseError(`An AMS environment may not be mixed with other math` +
+            ` in the same KaTeX element.`);
     }
 };
 

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -2781,41 +2781,41 @@ describe("AMS environments", function() {
         expect`\begin{CD}A @>a>> B \\@VbVV @AAcA\\C @= D\end{CD}`.not.toParse(nonstrictSettings);
     });
 
-    const nonStrictDisplay = new Settings({displayMode: true, strict: false});
-    it("should build if in non-strict display mode", () => {
-        expect`\begin{gather}a+b\\c+d\end{gather}`.toBuild(nonStrictDisplay);
-        expect`\begin{gather*}a+b\\c+d\end{gather*}`.toBuild(nonStrictDisplay);
-        expect`\begin{align}a&=b+c\\d+e&=f\end{align}`.toBuild(nonStrictDisplay);
-        expect`\begin{align*}a&=b+c\\d+e&=f\end{align*}`.toBuild(nonStrictDisplay);
-        expect`\begin{alignat}{2}10&x+ &3&y = 2\\3&x+&13&y = 4\end{alignat}`.toBuild(nonStrictDisplay);
-        expect`\begin{alignat*}{2}10&x+ &3&y = 2\\3&x+&13&y = 4\end{alignat*}`.toBuild(nonStrictDisplay);
-        expect`\begin{equation}a=b+c\end{equation}`.toBuild(nonStrictDisplay);
-        expect`\begin{equation}\begin{split}a &=b+c\\&=e+f\end{split}\end{equation}`.toBuild(nonStrictDisplay);
-        expect`\begin{split}a &=b+c\\&=e+f\end{split}`.toBuild(nonStrictDisplay);
-        expect`\begin{CD}A @<a<< B @>>b> C @>>> D\\@. @| @AcAA @VVdV \\@. E @= F @>>> G\end{CD}`.toBuild(nonStrictDisplay);
+    const displayMode = new Settings({displayMode: true});
+    it("should build if in display mode", () => {
+        expect`\begin{gather}a+b\\c+d\end{gather}`.toBuild(displayMode);
+        expect`\begin{gather*}a+b\\c+d\end{gather*}`.toBuild(displayMode);
+        expect`\begin{align}a&=b+c\\d+e&=f\end{align}`.toBuild(displayMode);
+        expect`\begin{align*}a&=b+c\\d+e&=f\end{align*}`.toBuild(displayMode);
+        expect`\begin{alignat}{2}10&x+ &3&y = 2\\3&x+&13&y = 4\end{alignat}`.toBuild(displayMode);
+        expect`\begin{alignat*}{2}10&x+ &3&y = 2\\3&x+&13&y = 4\end{alignat*}`.toBuild(displayMode);
+        expect`\begin{equation}a=b+c\end{equation}`.toBuild(displayMode);
+        expect`\begin{equation}\begin{split}a &=b+c\\&=e+f\end{split}\end{equation}`.toBuild(displayMode);
+        expect`\begin{split}a &=b+c\\&=e+f\end{split}`.toBuild(displayMode);
+        expect`\begin{CD}A @<a<< B @>>b> C @>>> D\\@. @| @AcAA @VVdV \\@. E @= F @>>> G\end{CD}`.toBuild(displayMode);
     });
 
     it("{equation} should fail if argument contains two rows.", () => {
-        expect`\begin{equation}a=\cr b+c\end{equation}`.not.toParse(nonStrictDisplay);
+        expect`\begin{equation}a=\cr b+c\end{equation}`.not.toParse(displayMode);
     });
     it("{equation} should fail if argument contains two columns.", () => {
-        expect`\begin{equation}a &=b+c\end{equation}`.not.toBuild(nonStrictDisplay);
+        expect`\begin{equation}a &=b+c\end{equation}`.not.toBuild(displayMode);
     });
     it("{split} should fail if argument contains three columns.", () => {
-        expect`\begin{equation}\begin{split}a &=b &+c\\&=e &+f\end{split}\end{equation}`.not.toBuild(nonStrictDisplay);
+        expect`\begin{equation}\begin{split}a &=b &+c\\&=e &+f\end{split}\end{equation}`.not.toBuild(displayMode);
     });
     it("{array} should fail if body contains more columns than specification.", () => {
-        expect`\begin{array}{2}a & b & c\\d & e  f\end{array}`.not.toBuild(nonStrictDisplay);
+        expect`\begin{array}{2}a & b & c\\d & e  f\end{array}`.not.toBuild(displayMode);
     });
 });
 
 describe("The CD environment", function() {
     it("should fail if not is display mode", function() {
         expect(`\\begin{CD}A @<a<< B @>>b> C @>>> D\\\\@. @| @AcAA @VVdV \\\\@. E @= F @>>> G\\end{CD}`).not.toParse(
-            new Settings({displayMode: false, strict: false})
+            new Settings({displayMode: false})
         );
     });
-    const displaySettings = new Settings({displayMode: true, strict: false});
+    const displaySettings = new Settings({displayMode: true});
     it("should fail if the character after '@' is not in <>AV=|.", function() {
         expect(`\\begin{CD}A @X<a<< B @>>b> C @>>> D\\\\@. @| @AcAA @VVdV \\\\@. E @= F @>>> G\\end{CD}`).not.toParse(displaySettings);
     });


### PR DESCRIPTION
When I wrote the PR for `{equation}`, `{align}`, etc., I included a parameter named `topEnv`. I was trying to follow up on suggestions in issue #2042, but I did not have a firm grasp on what `topEnv` was supposed to accomplish. I ended up using `topEnv` to try to ensure that AMS environments were written at the top level.

I believe I botched that part. Currently `master` will return a ParseError for any AMS environment if the rendering options do not include either (1) strict = false, or (2) topEnv = true.

That's a weird condition to impose on users. So this PR removes `topEnv` and instead checks the input string to see if the environment was defined at the very start. It's a better check. I was even able to strengthen some of the unit test by changing strict from false to "warn".

There is another issue, #2381, which suggests allowing KaTeX input strings to include the `$` delimiters that many editors use to delineate math. I think that is a pretty good idea, but it is a different thing and belongs in a different PR. Right now, `topEnv` is just an awkward, unnecessary check parameter and it should go. We can address #2381 later.