### PR TITLE
revert: update selenium/standalone-firefox docker tag to v3.141.59-20210311 [skip netlify]

### DIFF
--- a/.github/workflows/screenshotter.yml
+++ b/.github/workflows/screenshotter.yml
@@ -19,7 +19,7 @@ jobs:
         - browser: chrome
           image: selenium/standalone-chrome:3.141.59-20210311
         - browser: firefox
-          image: selenium/standalone-firefox:3.141.59-20210311
+          image: selenium/standalone-firefox:3.141.59-20201119
         - browser: safari
           image: ylemkimon/selenium-proxy:latest
           browserstack:

--- a/dockers/screenshotter/screenshotter.sh
+++ b/dockers/screenshotter/screenshotter.sh
@@ -17,7 +17,7 @@ cleanup() {
 container=
 trap cleanup EXIT
 status=0
-for browserTag in "firefox:3.141.59-20210311" "chrome:3.141.59-20210311"; do
+for browserTag in "firefox:3.141.59-20201119" "chrome:3.141.59-20210311"; do
     browser=${browserTag%:*}
     image=selenium/standalone-${browserTag}
     echo "Starting container for ${image}"


### PR DESCRIPTION
Reverts KaTeX/KaTeX#2841