### PR TITLE
Minor documentation fixes

### DIFF
--- a/docs/autorender.md
+++ b/docs/autorender.md
@@ -37,7 +37,16 @@ For example:
 <script>
     document.addEventListener("DOMContentLoaded", function() {
         renderMathInElement(document.body, {
-            // ...options...
+          // customised options
+          // • auto-render specific keys, e.g.:
+          delimiters: [
+              {left: '$$', right: '$$', display: true},
+              {left: '$', right: '$', display: false},
+              {left: '\\(', right: '\\)', display: false},
+              {left: '\\[', right: '\\]', display: true}
+          ],
+          // • rendering keys, e.g.:
+          throwOnError : false
         });
     });
 </script>
@@ -67,8 +76,8 @@ function renderMathInElement(elem, options)
 nodes inside this element and render the math in them.
 
 `options` is an optional object argument that can have the same keys as [the
-object passed to `katex.render`](https://github.com/KaTeX/KaTeX/#rendering-options),
-in addition to two auto-render-specific keys:
+object passed to `katex.render`](options.html),
+in addition to five auto-render-specific keys:
 
 - `delimiters`: This is a list of delimiters to look for math, processed in
   the same order as the list. Each delimiter has three properties:

--- a/docs/options.md
+++ b/docs/options.md
@@ -29,7 +29,7 @@ You can provide an object of options as the last argument to [`katex.render` and
     LaTeX would thereby comment out the end of math mode (e.g. `$`),
     causing an error.
   - `"htmlExtension"`: Use of HTML extension (`\html`-prefixed) commands,
-    which are provieded for HTML manipulation.
+    which are provided for HTML manipulation.
 
   A second category of `errorCode`s never throw errors, but their strictness
   affects the behavior of KaTeX:

--- a/docs/supported.md
+++ b/docs/supported.md
@@ -339,7 +339,9 @@ Macros can also be defined in the KaTeX [rendering options](options.md).
 
 Macros accept up to nine arguments: #1, #2, etc.
 
-<div id="gdef"></div>
+</div>
+
+<div id="gdef">
 
 Macros defined by `\gdef`, `\xdef`, `\global\def`, `\global\edef`, `\global\let`, and `\global\futurelet` will persist between math expressions. (Exception: macro persistence may be disabled. There are legitimate security reasons for that.)
 


### PR DESCRIPTION
This PR fixes a few minor documentation issues:
* fix of broken link
* fix of typo
* fixing of unclosed `<div>` element
* small addition in code sample (`autorender.md`)
* correcting number of auto-render-specific keys.