### PR TITLE
docs: fix braket rows in support table

### DIFF
--- a/docs/support_table.md
+++ b/docs/support_table.md
@@ -190,9 +190,9 @@ table td {
 |\boxminus|$\boxminus$||
 |\boxplus|$\boxplus$||
 |\boxtimes|$\boxtimes$||
-|\Bra|$\left\langle\psi\right\|$|`\Bra{\psi}`|
-|\bra|$\mathinner{\langle{\psi}\|}$|`\bra{\psi}`|
-|\braket|$\mathinner{\langle{\phi\|\psi}\rangle}$|`\braket{\phi|\psi}`|
+|\Bra|$\Bra{\psi}$|`\Bra{\psi}`|
+|\bra|$\bra{\psi}$|`\bra{\psi}`|
+|\braket|$\braket{\phi\vert\psi}$|`\braket{\phi\vert\psi}`|
 |\brace|${n\brace k}$|`{n\brace k}`|
 |\bracevert|<span style="color:firebrick;">Not supported</span>||
 |\brack|${n\brack k}$|`{n\brack k}`|
@@ -537,8 +537,8 @@ use `\ce` instead|
 |\KaTeX|$\KaTeX$||
 |\ker|$\ker$||
 |\kern|$I\kern-2.5pt R$|`I\kern-2.5pt R`|
-|\Ket|$\left\|\psi\right\rangle$|`\Ket{\psi}`|
-|\ket|$\mathinner{\|{\psi}\rangle}$|`\ket{\psi}`|
+|\Ket|$\Ket{\psi}$|`\Ket{\psi}`|
+|\ket|$\ket{\psi}$|`\ket{\psi}`|
 |\Koppa|<span style="color:firebrick;">Not supported</span>||
 |\koppa|<span style="color:firebrick;">Not supported</span>||
 


### PR DESCRIPTION
The rows displaying the braket macros in the support table are not rendering properly due to problems with escaping pipes (see ket/Ket under https://katex.org/docs/support_table.html#jk for example). I replaced the "Rendered" columns for braket with the actual macros (which I think is suppose to be used) so the pipes are no longer needed.