### PR TITLE
fix: Protect fraction bars from CSS border-color

### DIFF
--- a/src/katex.less
+++ b/src/katex.less
@@ -17,12 +17,14 @@
     // Prevent a rendering bug that misplaces \vec in Chrome.
     text-rendering: auto;
 
-    // Insulate fraction bars and rules from CSS that sets border-color.
-    border-color: currentColor;
-
-    // Prevent background resetting on elements in Windows's high-contrast
-    // mode, while still allowing background/foreground setting on root .katex
-    * { -ms-high-contrast-adjust: none !important; }
+    * {
+        // Prevent background resetting on elements in Windows's high-contrast
+        // mode, while still allowing background/foreground setting on root .katex
+        -ms-high-contrast-adjust: none !important;
+        
+        // Insulate fraction bars and rules from CSS that sets border-color.
+        border-color: currentColor;
+    }
 
     .katex-version::after {
         content: @version;

--- a/src/katex.less
+++ b/src/katex.less
@@ -21,7 +21,7 @@
         // Prevent background resetting on elements in Windows's high-contrast
         // mode, while still allowing background/foreground setting on root .katex
         -ms-high-contrast-adjust: none !important;
-        
+
         // Insulate fraction bars and rules from CSS that sets border-color.
         border-color: currentColor;
     }


### PR DESCRIPTION
`border-color` is not inheritable (https://drafts.csswg.org/css-backgrounds-3/#propdef-border-color), so the previous fix (#2292), which applied `border-color` to `.katex`, did not work. This PR applies `border-color: currentColor` to `.katex *`.

closes #2731 