### PR TITLE
ci: set necessary token permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: '0 0 * * 1'
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,6 +9,7 @@ on:
     - cron: '0 0 * * 1'
 
 permissions:
+  actions: read
   contents: read
   security-events: write
 

--- a/.github/workflows/fonts.yml
+++ b/.github/workflows/fonts.yml
@@ -11,6 +11,9 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'build fonts')
     outputs:
       image: ${{ steps.check-image.outputs.result }}
+    permissions:
+      contents: read
+      pull-requests: write # to remove label
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
I've changed [the default permission of the token to read-only](https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/) and these are the only places we need write access.