### PR TITLE
chore(screenshotter): modernize calls to NodeJS Buffer interface

### DIFF
--- a/dockers/screenshotter/screenshotter.js
+++ b/dockers/screenshotter/screenshotter.js
@@ -365,7 +365,7 @@ function setSize(reqW, reqH) {
 }
 
 function imageDimensions(img) {
-    const buf = new Buffer(img, "base64");
+    const buf = Buffer.from(img, "base64");
     return {
         buf: buf,
         width: buf.readUInt32BE(16),


### PR DESCRIPTION
Avoid DeprecationWarning during screenshotting