### PR TITLE
fix: Avoid crash when \operatorname has \limits.

### DIFF
--- a/src/Parser.js
+++ b/src/Parser.js
@@ -326,10 +326,10 @@ export default class Parser {
                     const limits = lex.text === "\\limits";
                     base.limits = limits;
                     base.alwaysHandleSupSub = true;
-                } else if (base && base.type === "operatorname"
-                        && base.alwaysHandleSupSub) {
-                    const limits = lex.text === "\\limits";
-                    base.limits = limits;
+                } else if (base && base.type === "operatorname") {
+                    if (base.alwaysHandleSupSub) {
+                        base.limits = lex.text === "\\limits";
+                    }
                 } else {
                     throw new ParseError(
                         "Limit controls must follow a math operator",

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -2852,6 +2852,8 @@ describe("operatorname support", function() {
         expect("\\operatorname*{x*Π∑\\Pi\\sum\\frac a b}").toBuild();
         expect("\\operatorname*{x*Π∑\\Pi\\sum\\frac a b}_y x").toBuild();
         expect("\\operatorname*{x*Π∑\\Pi\\sum\\frac a b}\\limits_y x").toBuild();
+        // The following does not actually render with limits. But it does not crash either.
+        expect("\\operatorname{sn}\\limits_{b>c}(b+c)").toBuild();
     });
 });
 


### PR DESCRIPTION
Fixes part of #2876.