### PR TITLE
chore(screenshotter): Improve screenshotter for Safari

### DIFF
--- a/dockers/screenshotter/screenshotter.js
+++ b/dockers/screenshotter/screenshotter.js
@@ -172,7 +172,8 @@ if (!seleniumURL && opts.container) {
         guessDockerIPs();
     }
     seleniumPort = cmd("docker", "port", opts.container, seleniumPort);
-    seleniumPort = seleniumPort.replace(/^.*:/, "");
+    // Docker can output two lines, such as "0.0.0.0:49156\n:::49156"
+    seleniumPort = seleniumPort.replace(/[^]*:([0-9]+)[^]*/, "$1");
 }
 if (!seleniumURL && seleniumIP) {
     seleniumURL = "http://" + seleniumIP + ":" + seleniumPort + "/wd/hub";

--- a/dockers/screenshotter/screenshotter.js
+++ b/dockers/screenshotter/screenshotter.js
@@ -494,7 +494,7 @@ function takeScreenshot(key) {
     function loadFonts() {
         driver.executeAsyncScript(
                 "var callback = arguments[arguments.length - 1]; " +
-                "load_fonts(callback);")
+                "load_fonts_and_images(callback);")
             .then(waitThenScreenshot);
     }
 

--- a/test/screenshotter/test.html
+++ b/test/screenshotter/test.html
@@ -31,8 +31,8 @@
     <span id="math"></span>
     <span id="post"></span>
     <script type="text/javascript">
-      function load_fonts(callback) {
-        if (!document.fonts || !document.fonts.load) {
+      function load_fonts_and_images(callback) {
+        if (!document.fonts || !document.fonts.load || !document.images || !document.images.load) {
           callback();
           return;
         }
@@ -55,6 +55,17 @@
         }
         load_font("Mincho");
         load_font("Batang");
+
+        document.images.forEach(function (img) {
+          results.push(new Promise(function (done, error) {
+            if (img.complete) {
+              done();
+            } else {
+              img.addEventListener('load', done);
+              img.addEventListener('error', error);
+            }
+          }));
+        });
 
         Promise.all(results).then(callback)
       }

--- a/test/screenshotter/test.html
+++ b/test/screenshotter/test.html
@@ -32,6 +32,11 @@
     <span id="post"></span>
     <script type="text/javascript">
       function load_fonts_and_images(callback) {
+        if (typeof Promise === "undefined") {
+          callback();
+          return;
+        }
+
         var results = [];
 
         function load_font(name, style) {

--- a/test/screenshotter/test.html
+++ b/test/screenshotter/test.html
@@ -32,13 +32,10 @@
     <span id="post"></span>
     <script type="text/javascript">
       function load_fonts_and_images(callback) {
-        if (!document.fonts || !document.fonts.load || !document.images || !document.images.load) {
-          callback();
-          return;
-        }
-
         var results = [];
+
         function load_font(name, style) {
+          if (!document.fonts || !document.fonts.load) return;
           // 10px is arbitrarily selected value
           results.push(document.fonts.load((style || "") + " 10px " + name));
         }
@@ -56,7 +53,8 @@
         load_font("Mincho");
         load_font("Batang");
 
-        document.images.forEach(function (img) {
+        for (var i = 0; i < document.images.length; i++) {
+          var img = document.images[i];
           results.push(new Promise(function (done, error) {
             if (img.complete) {
               done();
@@ -65,7 +63,7 @@
               img.addEventListener('error', error);
             }
           }));
-        });
+        };
 
         Promise.all(results).then(callback)
       }


### PR DESCRIPTION
This PR does two things, and fixes or improves #3012:

1. ~~Upgrade to Safari 14.0; seems good to track modern Safari~~ I accidentally did this only locally, not in CI. I reverted this change because I didn't want to deal with changed screenshots in this PR.
2. Fix running Docker on IPv6 system. This is an aside I guess, but was necessary in my Windows environment; unfortunately, I still couldn't get the screenshotter working on Windows; it seems to just hang while trying to connect to the Selenium docker.
3. Ensure images load before screenshotting, the same way we do with fonts. This is presumably what was causing the `Includegraphics` test to fail on Safari (dunno why it works on other browsers; maybe they load local files fast).

CI doesn't crash on `Includegraphics` tests anymore.  I've seen Safari crash with a "failure to find function `load_fonts_and_images`" error and a timeout error.  I still haven't seen Chrome or Firefox crash, so this PR doesn't seem to have broken anything. I think Safari tests succeed more often now but there might be work left to do.