### PR TITLE
fix: matrix environment with zero or inconsistent columns

### DIFF
--- a/src/environments/array.js
+++ b/src/environments/array.js
@@ -820,7 +820,8 @@ defineEnvironment({
         const res: ParseNode<"array"> =
             parseArray(context.parser, payload, dCellStyle(context.envName));
         // Populate cols with the correct number of column alignment specs.
-        res.cols = new Array(res.body[0].length).fill(
+        const numCols = Math.max(0, ...res.body.map((row) => row.length));
+        res.cols = new Array(numCols).fill(
             {type: "align", align: colAlign}
         );
         return delimiters ? {

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -1244,6 +1244,7 @@ describe("A begin/end parser", function() {
 
     it("should parse and build an empty environment", function() {
         expect`\begin{aligned}\end{aligned}`.toBuild();
+        expect`\begin{matrix}\end{matrix}`.toBuild();
     });
 
     it("should parse an environment with hlines", function() {
@@ -1309,6 +1310,13 @@ describe("A begin/end parser", function() {
         expect("\\begin{Vmatrix*}[r] a & -1 \\\\ -1 & d \\end{Vmatrix*}").toBuild();
         expect("\\begin{matrix*} a & -1 \\\\ -1 & d \\end{matrix*}").toBuild();
         expect("\\begin{matrix*}[] a & -1 \\\\ -1 & d \\end{matrix*}").not.toParse();
+    });
+
+    it("should allow blank columns", () => {
+        const parsed = getParsed`\begin{matrix*}[r] a \\ -1 & d \end{matrix*}`;
+        expect(parsed[0].cols).toEqual(
+            [{type: 'align', align: 'r'},
+             {type: 'align', align: 'r'}]);
     });
 });
 


### PR DESCRIPTION
Previously, the matrix family of environments assumed that the number of columns was given by the number of columns in the first row.
* This didn't work when there were zero rows (#3017)
* This didn't handle the case where future rows have more columns than the first (which is visible
when using an alignment other than `c`, such as `\begin{matrix*}[r]`).

This PR fixes both issues, and thereby fixes #3017.