### PR TITLE
chore(ci): Disable Includegraphics test on Safari

### DIFF
--- a/.github/workflows/screenshotter.yml
+++ b/.github/workflows/screenshotter.yml
@@ -24,6 +24,8 @@ jobs:
             browser_version: 13.1
             os: OS X
             os_version: Catalina
+          # Includegraphics test is currently too unreliable on Safari
+          excludeTests: Includegraphics
       fail-fast: false
     services:
       selenium:
@@ -71,7 +73,7 @@ jobs:
           -e YARN_ENABLE_SCRIPTS=0 \
           -e CI=true \
           node:14 \
-          /bin/bash -c 'yarn --immutable && yarn node dockers/screenshotter/screenshotter.js -b ${{ matrix.browser }} --verify --diff --new --katex-ip $HOSTNAME ${{ matrix.browserstack && format('--selenium-proxy http://selenium:4445/build --browserstack --selenium-capabilities ''\''''{0}''\', toJson(matrix.browserstack)) || '--selenium-ip selenium' }}'
+          /bin/bash -c 'yarn --immutable && yarn node dockers/screenshotter/screenshotter.js -b ${{ matrix.browser }} --verify --diff --new --katex-ip $HOSTNAME ${{ matrix.browserstack && format('--selenium-proxy http://selenium:4445/build --browserstack --selenium-capabilities ''\''''{0}''\', toJson(matrix.browserstack)) || '--selenium-ip selenium' }} ${{ matrix.excludeTests && format('--exclude {0}', matrix.excludeTests) }}'
         echo "::$TOKEN::"
       timeout-minutes: 10
 


### PR DESCRIPTION
Exclude Includegraphics test from CI, as it's too unreliable for automated testing, as [suggested by @ylemkimon](https://github.com/KaTeX/KaTeX/issues/3012#issuecomment-841507334).

Should fix #3012