### PR TITLE
feat: Add support for \dimexpr expressions where sizes are expected

### DIFF
--- a/docs/support_table.md
+++ b/docs/support_table.md
@@ -333,6 +333,7 @@ use `\ce` instead|
 |\diamonds|$\diamonds$||
 |\diamondsuit|$\diamondsuit$||
 |\dim|$\dim$||
+|\dimexpr|$\rule{\dimexpr 2em + 5pt}{1em}$|`\rule{\dimexpr 2em + 5pt}{1em}`|
 |\displaylines|<span style="color:firebrick;">Not supported</span>||
 |\displaystyle|$\displaystyle\sum_0^n$|`\displaystyle\sum_0^n`|
 |\div|$\div$||
@@ -443,6 +444,7 @@ use `\ce` instead|
 |\gggtr|$\gggtr$||
 |\gimel|$\gimel$||
 |\global|$\global\def\add#1#2{#1+#2} \add 2 3$|`\global\def\add#1#2{#1+#2} \add 2 3`|
+|\glueexpr|<span style="color:firebrick;">Not supported</span>||
 |\gnapprox|$\gnapprox$||
 |\gneq|$\gneq$||
 |\gneqq|$\gneqq$||
@@ -705,6 +707,7 @@ use `\ce` instead|
 |\mspace|<span style="color:firebrick;">Not supported</span>||
 |\Mu|$\Mu$||
 |\mu|$\mu$||
+|\muexpr|<span style="color:firebrick;">Not supported</span>||
 |\multicolumn|<span style="color:firebrick;">Not supported</span>|[Issue #269](https://github.com/KaTeX/KaTeX/issues/269)|
 |{multiline}|<span style="color:firebrick;">Not supported</span>||
 |\multimap|$\multimap$||
@@ -774,6 +777,7 @@ use `\ce` instead|
 |\ntrianglerighteq|$\ntrianglerighteq$||
 |\Nu|$\Nu$||
 |\nu|$\nu$||
+|\numexpr|<span style="color:firebrick;">Not supported</span>||
 |\nVDash|$\nVDash$||
 |\nVdash|$\nVdash$||
 |\nvDash|$\nvDash$||

--- a/docs/supported.md
+++ b/docs/supported.md
@@ -714,3 +714,12 @@ The effect of style and size:
 | others |$\rule{10pt}{10pt}$|$\scriptscriptstyle\rule{10pt}{10pt}$|$\huge\rule{10pt}{10pt}$
 
 </div>
+
+Units can be combined using `\dimexpr`, which is accepted in all places a size is expected:
+
+|||
+|:--------------------------------|:-----
+|`\rule{2em}{1em} \rule{10pt}{1em}`|$\rule{2em}{1em}\rule{10pt}{1em}$
+|`\rule{\dimexpr 2em + 10pt}{1em}` |$\rule{\dimexpr 2em + 10pt}{1em}$
+
+As the above example demonstrates, `\dimexpr` can be used to combine absolute and font-relative units, which is not always otherwise possible.

--- a/src/MacroExpander.js
+++ b/src/MacroExpander.js
@@ -25,6 +25,7 @@ export const implicitCommands = {
     "_": true,           // Parser.js
     "\\limits": true,    // Parser.js
     "\\nolimits": true,  // Parser.js
+    "\\dimexpr": true,   // Parser.js
 };
 
 export default class MacroExpander implements MacroContextInterface {
@@ -320,7 +321,7 @@ export default class MacroExpander implements MacroContextInterface {
     /**
      * Recursively expand first token, then return first non-expandable token.
      */
-    expandNextToken(): Token {
+    expandNextToken(keepRelax?: boolean): Token {
         for (;;) {
             const expanded = this.expandOnce();
             // expandOnce returns Token if and only if it's fully expanded.
@@ -329,7 +330,8 @@ export default class MacroExpander implements MacroContextInterface {
                 // null return value couldn't get implemented as a function).
                 // the token after \noexpand is interpreted as if its meaning
                 // were ‘\relax’
-                if (expanded.text === "\\relax" || expanded.treatAsRelax) {
+                if (!keepRelax &&
+                      (expanded.text === "\\relax" || expanded.treatAsRelax)) {
                     this.stack.pop();
                 } else {
                     return this.stack.pop();  // === expanded

--- a/src/buildCommon.js
+++ b/src/buildCommon.js
@@ -18,7 +18,7 @@ import type {CharacterMetrics} from "./fontMetrics";
 import type {FontVariant, Mode} from "./types";
 import type {documentFragment as HtmlDocumentFragment} from "./domTree";
 import type {HtmlDomNode, DomSpan, SvgSpan, CssStyle} from "./domTree";
-import type {Measurement} from "./units";
+import type {MeasurementExpr} from "./units";
 
 /**
  * Looks up the given symbol in fontMetrics, after applying any symbol
@@ -622,7 +622,7 @@ const makeVList = function(params: VListParam, options: Options): DomSpan {
 // Glue is a concept from TeX which is a flexible space between elements in
 // either a vertical or horizontal list. In KaTeX, at least for now, it's
 // static space between elements in a horizontal layout.
-const makeGlue = (measurement: Measurement, options: Options): DomSpan => {
+const makeGlue = (measurement: MeasurementExpr, options: Options): DomSpan => {
     // Make an empty span for the space
     const rule = makeSpan(["mspace"], [], options);
     const size = calculateSize(measurement, options);

--- a/src/environments/array.js
+++ b/src/environments/array.js
@@ -260,7 +260,7 @@ const htmlBuilder: HtmlBuilder<"array"> = function(group, options) {
 
     // Vertical spacing
     const baselineskip = group.colSeparationType === "CD"
-      ? calculateSize({number: 3, unit: "ex"}, options)
+      ? calculateSize({type: "atom", number: 3, unit: "ex"}, options)
       : 12 * pt; // see size10.clo
     // Default \jot from ltmath.dtx
     // TODO(edemaine): allow overriding \jot via \setlength (#687)

--- a/src/functions/enclose.js
+++ b/src/functions/enclose.js
@@ -39,8 +39,10 @@ const htmlBuilder = (group, options) => {
 
     } else if (label === "phase") {
         // Set a couple of dimensions from the steinmetz package.
-        const lineWeight = calculateSize({number: 0.6, unit: "pt"}, options);
-        const clearance = calculateSize({number: 0.35, unit: "ex"}, options);
+        const lineWeight = calculateSize(
+            {type: "atom", number: 0.6, unit: "pt"}, options);
+        const clearance = calculateSize(
+            {type: "atom", number: 0.35, unit: "ex"}, options);
 
         // Prevent size changes like \Huge from affecting line thickness
         const newOptions = options.havingBaseSizing();

--- a/src/functions/kern.js
+++ b/src/functions/kern.js
@@ -9,6 +9,29 @@ import {assertNodeType} from "../parseNode";
 
 // TODO: \hskip and \mskip should support plus and minus in lengths
 
+const checkUnitConsistency = (expr, funcName, mathFunction, settings) => {
+    if (expr.type === "sum") {
+        checkUnitConsistency(expr.lhs, funcName, mathFunction, settings);
+        checkUnitConsistency(expr.rhs, funcName, mathFunction, settings);
+    } else if (expr.type === "multiply") {
+        checkUnitConsistency(expr.lhs, funcName, mathFunction, settings);
+    } else {
+        const muUnit = (expr.unit === 'mu');
+        if (mathFunction) {
+            if (!muUnit) {
+                settings.reportNonstrict("mathVsTextUnits",
+                    `LaTeX's ${funcName} supports only mu units, ` +
+                    `not ${expr.unit} units`);
+            }
+        } else {
+            if (muUnit) {
+                settings.reportNonstrict("mathVsTextUnits",
+                    `LaTeX's ${funcName} doesn't support mu units`);
+            }
+        }
+    }
+};
+
 defineFunction({
     type: "kern",
     names: ["\\kern", "\\mkern", "\\hskip", "\\mskip"],
@@ -22,22 +45,11 @@ defineFunction({
         const size = assertNodeType(args[0], "size");
         if (parser.settings.strict) {
             const mathFunction = (funcName[1] === 'm');  // \mkern, \mskip
-            const muUnit = (size.value.unit === 'mu');
-            if (mathFunction) {
-                if (!muUnit) {
-                    parser.settings.reportNonstrict("mathVsTextUnits",
-                        `LaTeX's ${funcName} supports only mu units, ` +
-                        `not ${size.value.unit} units`);
-                }
-                if (parser.mode !== "math") {
-                    parser.settings.reportNonstrict("mathVsTextUnits",
-                        `LaTeX's ${funcName} works only in math mode`);
-                }
-            } else {  // !mathFunction
-                if (muUnit) {
-                    parser.settings.reportNonstrict("mathVsTextUnits",
-                        `LaTeX's ${funcName} doesn't support mu units`);
-                }
+            checkUnitConsistency(
+                size.value, funcName, mathFunction, parser.settings);
+            if (mathFunction && parser.mode !== "math") {
+                parser.settings.reportNonstrict("mathVsTextUnits",
+                    `LaTeX's ${funcName} works only in math mode`);
             }
         }
         return {

--- a/src/functions/raisebox.js
+++ b/src/functions/raisebox.js
@@ -39,8 +39,8 @@ defineFunction({
     mathmlBuilder(group, options) {
         const node = new mathMLTree.MathNode(
             "mpadded", [mml.buildGroup(group.body, options)]);
-        const dy = group.dy.number + group.dy.unit;
-        node.setAttribute("voffset", dy);
+        const dy = calculateSize(group.dy, options);
+        node.setAttribute("voffset", dy + "em");
         return node;
     },
 });

--- a/src/parseNode.js
+++ b/src/parseNode.js
@@ -5,7 +5,7 @@ import type {AlignSpec, ColSeparationType} from "./environments/array";
 import type {Atom} from "./symbols";
 import type {Mode, StyleStr} from "./types";
 import type {Token} from "./Token";
-import type {Measurement} from "./units";
+import type {MeasurementExpr} from "./units";
 
 export type NodeType = $Keys<ParseNodeTypes>;
 export type ParseNode<TYPE: NodeType> = $ElementType<ParseNodeTypes, TYPE>;
@@ -37,7 +37,7 @@ type ParseNodeTypes = {
         cols?: AlignSpec[],
         arraystretch: number,
         body: AnyParseNode[][], // List of rows in the (2D) array.
-        rowGaps: (?Measurement)[],
+        rowGaps: (?MeasurementExpr)[],
         hLinesBeforeRow: Array<boolean[]>,
         addEqnNum?: boolean,
         leqno?: boolean,
@@ -113,7 +113,7 @@ type ParseNodeTypes = {
         type: "size",
         mode: Mode,
         loc?: ?SourceLocation,
-        value: Measurement,
+        value: MeasurementExpr,
         isBlank: boolean,
     |},
     "styling": {|
@@ -224,7 +224,7 @@ type ParseNodeTypes = {
         mode: Mode,
         loc?: ?SourceLocation,
         newLine: boolean,
-        size: ?Measurement,
+        size: ?MeasurementExpr,
     |},
     "delimsizing": {|
         type: "delimsizing",
@@ -268,7 +268,7 @@ type ParseNodeTypes = {
         leftDelim: ?string,
         rightDelim: ?string,
         size: StyleStr | "auto",
-        barSize: Measurement | null,
+        barSize: MeasurementExpr | null,
     |},
     "hbox": {|
         type: "hbox",
@@ -310,9 +310,9 @@ type ParseNodeTypes = {
         mode: Mode,
         loc?: ?SourceLocation,
         alt: string,
-        width: Measurement,
-        height: Measurement,
-        totalheight: Measurement,
+        width: MeasurementExpr,
+        height: MeasurementExpr,
+        totalheight: MeasurementExpr,
         src: string,
     |},
     "infix": {|
@@ -320,7 +320,7 @@ type ParseNodeTypes = {
         mode: Mode,
         loc?: ?SourceLocation,
         replaceWith: string,
-        size?: Measurement,
+        size?: MeasurementExpr,
         token: ?Token,
     |},
     "internal": {|
@@ -332,7 +332,7 @@ type ParseNodeTypes = {
         type: "kern",
         mode: Mode,
         loc?: ?SourceLocation,
-        dimension: Measurement,
+        dimension: MeasurementExpr,
     |},
     "lap": {|
         type: "lap",
@@ -417,16 +417,16 @@ type ParseNodeTypes = {
         type: "raisebox",
         mode: Mode,
         loc?: ?SourceLocation,
-        dy: Measurement,
+        dy: MeasurementExpr,
         body: AnyParseNode,
     |},
     "rule": {|
         type: "rule",
         mode: Mode,
         loc?: ?SourceLocation,
-        shift: ?Measurement,
-        width: Measurement,
-        height: Measurement,
+        shift: ?MeasurementExpr,
+        width: MeasurementExpr,
+        height: MeasurementExpr,
     |},
     "sizing": {|
         type: "sizing",

--- a/src/spacingData.js
+++ b/src/spacingData.js
@@ -5,14 +5,17 @@
 import type {Measurement} from "./units";
 
 const thinspace: Measurement = {
+    type: "atom",
     number: 3,
     unit: "mu",
 };
 const mediumspace: Measurement = {
+    type: "atom",
     number: 4,
     unit: "mu",
 };
 const thickspace: Measurement = {
+    type: "atom",
     number: 5,
     unit: "mu",
 };

--- a/src/units.js
+++ b/src/units.js
@@ -37,7 +37,18 @@ const relativeUnit = {
     "mu": true,
 };
 
-export type Measurement = {| number: number, unit: string |};
+export type Measurement = {| type: "atom", number: number, unit: string |};
+export type MeasurementExpr = Measurement | {|
+    type: "sum",
+    operator: "+" | "-",
+    lhs: MeasurementExpr,
+    rhs: MeasurementExpr
+|} | {|
+    type: "multiply",
+    operator: "*" | "/",
+    lhs: MeasurementExpr,
+    rhs: number
+|};
 
 /**
  * Determine whether the specified unit (either a string defining the unit
@@ -56,43 +67,60 @@ export const validUnit = function(unit: string | Measurement): boolean {
  * current style/scale.  `options` gives the current options.
  */
 export const calculateSize = function(
-        sizeValue: Measurement, options: Options): number {
-    let scale;
-    if (sizeValue.unit in ptPerUnit) {
-        // Absolute units
-        scale = ptPerUnit[sizeValue.unit]   // Convert unit to pt
-           / options.fontMetrics().ptPerEm  // Convert pt to CSS em
-           / options.sizeMultiplier;        // Unscale to make absolute units
-    } else if (sizeValue.unit === "mu") {
-        // `mu` units scale with scriptstyle/scriptscriptstyle.
-        scale = options.fontMetrics().cssEmPerMu;
+        sizeValue: MeasurementExpr, options: Options): number {
+    if (sizeValue.type === "sum") {
+        const lhs = calculateSize(sizeValue.lhs, options);
+        const rhs = calculateSize(sizeValue.rhs, options);
+        if (sizeValue.operator === "+") {
+            return lhs + rhs;
+        } else {
+            return lhs - rhs;
+        }
+    } else if (sizeValue.type === "multiply") {
+        const lhs = calculateSize(sizeValue.lhs, options);
+        if (sizeValue.operator === "*") {
+            return lhs * sizeValue.rhs;
+        } else {
+            return lhs / sizeValue.rhs;
+        }
     } else {
-        // Other relative units always refer to the *textstyle* font
-        // in the current size.
-        let unitOptions;
-        if (options.style.isTight()) {
-            // isTight() means current style is script/scriptscript.
-            unitOptions = options.havingStyle(options.style.text());
+        let scale;
+        if (sizeValue.unit in ptPerUnit) {
+            // Absolute units
+            scale = ptPerUnit[sizeValue.unit]   // Convert unit to pt
+               / options.fontMetrics().ptPerEm  // Convert pt to CSS em
+               / options.sizeMultiplier;        // Unscale to make absolute units
+        } else if (sizeValue.unit === "mu") {
+            // `mu` units scale with scriptstyle/scriptscriptstyle.
+            scale = options.fontMetrics().cssEmPerMu;
         } else {
-            unitOptions = options;
+            // Other relative units always refer to the *textstyle* font
+            // in the current size.
+            let unitOptions;
+            if (options.style.isTight()) {
+                // isTight() means current style is script/scriptscript.
+                unitOptions = options.havingStyle(options.style.text());
+            } else {
+                unitOptions = options;
+            }
+            // TODO: In TeX these units are relative to the quad of the current
+            // *text* font, e.g. cmr10. KaTeX instead uses values from the
+            // comparably-sized *Computer Modern symbol* font. At 10pt, these
+            // match. At 7pt and 5pt, they differ: cmr7=1.138894, cmsy7=1.170641;
+            // cmr5=1.361133, cmsy5=1.472241. Consider $\scriptsize a\kern1emb$.
+            // TeX \showlists shows a kern of 1.13889 * fontsize;
+            // KaTeX shows a kern of 1.171 * fontsize.
+            if (sizeValue.unit === "ex") {
+                scale = unitOptions.fontMetrics().xHeight;
+            } else if (sizeValue.unit === "em") {
+                scale = unitOptions.fontMetrics().quad;
+            } else {
+                throw new ParseError("Invalid unit: '" + sizeValue.unit + "'");
+            }
+            if (unitOptions !== options) {
+                scale *= unitOptions.sizeMultiplier / options.sizeMultiplier;
+            }
         }
-        // TODO: In TeX these units are relative to the quad of the current
-        // *text* font, e.g. cmr10. KaTeX instead uses values from the
-        // comparably-sized *Computer Modern symbol* font. At 10pt, these
-        // match. At 7pt and 5pt, they differ: cmr7=1.138894, cmsy7=1.170641;
-        // cmr5=1.361133, cmsy5=1.472241. Consider $\scriptsize a\kern1emb$.
-        // TeX \showlists shows a kern of 1.13889 * fontsize;
-        // KaTeX shows a kern of 1.171 * fontsize.
-        if (sizeValue.unit === "ex") {
-            scale = unitOptions.fontMetrics().xHeight;
-        } else if (sizeValue.unit === "em") {
-            scale = unitOptions.fontMetrics().quad;
-        } else {
-            throw new ParseError("Invalid unit: '" + sizeValue.unit + "'");
-        }
-        if (unitOptions !== options) {
-            scale *= unitOptions.sizeMultiplier / options.sizeMultiplier;
-        }
+        return Math.min(sizeValue.number * scale, options.maxSize);
     }
-    return Math.min(sizeValue.number * scale, options.maxSize);
 };

--- a/test/errors-spec.js
+++ b/test/errors-spec.js
@@ -309,15 +309,15 @@ describe("Lexer:", function() {
     describe("#_innerLexSize", function() {
         it("reject size without unit", function() {
             expect`\rule{0}{2em}`.toFailWithParseError(
-                   "Invalid size: '0' at position 6: \\rule{̲0̲}̲{2em}");
+                   "Invalid size: '0' at position 7: \\rule{0̲}{2em}");
         });
         it("reject size with bogus unit", function() {
             expect`\rule{1au}{2em}`.toFailWithParseError(
-                   "Invalid unit: 'au' at position 6: \\rule{̲1̲a̲u̲}̲{2em}");
+                   "Invalid unit: 'au' at position 7: \\rule{1̲a̲u̲}{2em}");
         });
         it("reject size without number", function() {
             expect`\rule{em}{2em}`.toFailWithParseError(
-                   "Invalid size: 'em' at position 6: \\rule{̲e̲m̲}̲{2em}");
+                   "Invalid size: 'e' at position 7: \\rule{e̲m}{2em}");
         });
     });
 


### PR DESCRIPTION
This PR adds support for the ε-TeX `\dimexpr` command, which provides a simple expression language for combining sizes. In addition to making it easier for macros to programmatically compose sizes, this allows a size to have both an absolute and a font-relative component, something that was previously impossible.

Example:

![screenshot of example from docs](https://user-images.githubusercontent.com/759911/128589348-f309b320-4e60-483b-bff1-97d86ab66dfa.png)

Implementing `\dimexpr` in KaTeX was a bit tricky, because `\dimexpr` is a rather awkward command. Like TeX’s `<dimen> plus <dimen> minus <dimen>` glue syntax, arguments to `\dimexpr` are entirely ungrouped, and they support uses of `+`, `-`, `*`, and `/` as infix operators. This necessitates the use of `\relax` to reliably terminate an argument to `\dimexpr` when the token that immediately follows it is not known, which required some minor modifications to KaTeX’s parser and macro expander to properly handle. See the added test cases for examples of all the subtleties.