### PR TITLE
ci: fix yarn pnp caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,9 @@ jobs:
         path: |
           .yarn/cache
           .pnp.cjs
-        key: yarn-deps-v1-${{ hashFiles('yarn.lock') }}
+        key: yarn-deps-v2-${{ hashFiles('yarn.lock') }}
         restore-keys: |
-          yarn-deps-v1-
+          yarn-deps-v2-
 
     - name: Install dependencies
       run: yarn --immutable
@@ -74,9 +74,9 @@ jobs:
         path: |
           .yarn/cache
           .pnp.cjs
-        key: yarn-deps-v1-${{ hashFiles('yarn.lock') }}
+        key: yarn-deps-v2-${{ hashFiles('yarn.lock') }}
         restore-keys: |
-          yarn-deps-v1-
+          yarn-deps-v2-
     - name: Run semantic-release
       run: yarn run semantic-release --debug
       env:


### PR DESCRIPTION
Fixes #3194 (hopefully)

[Yarn changelog](https://github.com/yarnpkg/berry/blob/master/CHANGELOG.md#300) points out that "Yarn will now generate `.pnp.cjs` files (instead of `.pnp.js`) when using PnP, regardless of what the type field inside the manifest is set to."
