### PR TITLE
chore(tests): fix use of jest-diff

### DIFF
--- a/test/helpers.js
+++ b/test/helpers.js
@@ -3,7 +3,7 @@ import ParseError from "../src/ParseError";
 import parseTree from "../src/parseTree";
 import Settings from "../src/Settings";
 
-import diff from 'jest-diff';
+import {diff} from 'jest-diff';
 import {RECEIVED_COLOR, printReceived, printExpected} from 'jest-matcher-utils';
 import {formatStackTrace, separateMessageFromStack} from 'jest-message-util';
 


### PR DESCRIPTION
[Jest 27 changed](https://github.com/facebook/jest/blob/master/CHANGELOG.md#2700) the signature for jest-diff to named exports only.

This bug only arises from failing tests, so it wasn't caught by CI.  But I noticed it when debugging #3214.