### PR TITLE
docs: add GitHub Sponsors to FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
+github: KaTeX
 open_collective: katex


### PR DESCRIPTION
**What is the previous behavior before this PR?**

N/A

**What is the new behavior after this PR?**

@KaTeX has been approved for GitHub Sponsors and is live on https://github.com/sponsors/KaTeX.