### PR TITLE
feat: add basic \odv and \pdv

### DIFF
--- a/docs/support_table.md
+++ b/docs/support_table.md
@@ -787,6 +787,7 @@ use `\ce` instead|
 |\O|$\text{\O}$|`\text{\O}`|
 |\o|$\text{\o}$|`\text{\o}`|
 |\odot|$\odot$||
+|\odv|$\odv{y}{x}$|`\odv{y}{x}`|
 |\OE|$\text{\OE}$|`\text{\OE}`|
 |\oe|$\text{\oe}$|`\text{\oe}`|
 |\officialeuro|<span style="color:firebrick;">Not supported</span>||
@@ -833,6 +834,7 @@ use `\ce` instead|
 |\parallel|$\parallel$||
 |\part|<span style="color:firebrick;">Not supported</span>|[Deprecated](https://en.wikipedia.org/wiki/Help:Displaying_a_formula#Deprecated_syntax)|
 |\partial|$\partial$||
+|\pdv|$\pdv{y}{x}$|`\pdv{y}{x}`|
 |\perp|$\perp$||
 |\phantom|$\Gamma^{\phantom{i}j}_{i\phantom{j}k}$|`\Gamma^{\phantom{i}j}_{i\phantom{j}k}`|
 |\phase|$\phase{-78^\circ}$|`\phase{-78^\circ}`|

--- a/docs/supported.md
+++ b/docs/supported.md
@@ -396,6 +396,7 @@ Direct Input: $+ - / * ⋅ ± × ÷ ∓ ∔ ∧ ∨ ∩ ∪ ≀ ⊎ ⊓ ⊔ ⊕ 
 ||||
 |:--------------------------|:----------------------------|:-----
 |$\frac{a}{b}$ `\frac{a}{b}`|$\tfrac{a}{b}$ `\tfrac{a}{b}`|$\genfrac ( ] {2pt}{1}a{a+1}$ `\genfrac ( ] {2pt}{1}a{a+1}`
+|$\odv{y}{x}$ `\odv{y}{x}`|$\pdv{y}{x}$ `\pdv{y}{x}`|
 |${a \over b}$ `{a \over b}`|$\dfrac{a}{b}$ `\dfrac{a}{b}`|${a \above{2pt} b+1}$ `{a \above{2pt} b+1}`
 |$a/b$ `a/b`                |  |$\cfrac{a}{1 + \cfrac{1}{b}}$ `\cfrac{a}{1 + \cfrac{1}{b}}`
 

--- a/src/macros.js
+++ b/src/macros.js
@@ -973,3 +973,9 @@ defineMacro("\\grayH", "\\textcolor{##3b3e40}{#1}");
 defineMacro("\\grayI", "\\textcolor{##21242c}{#1}");
 defineMacro("\\kaBlue", "\\textcolor{##314453}{#1}");
 defineMacro("\\kaGreen", "\\textcolor{##71B307}{#1}");
+
+//////////////////////////////////////////////////////////////////////
+// derivative
+// https://ctan.org/pkg/derivative
+defineMacro("\\odv", "\\frac{\\mathrm{d}#1}{\\mathrm{d}#2}");
+defineMacro("\\pdv", "\\frac{\\partial #1}{\\partial #2}");


### PR DESCRIPTION
**What is the new behavior after this PR?**
Two new commands are available: \odv{y}{x} and \pdv{y}{x}, respectively for ordinary derivatives and partial derivatives.
These are macros based on \frac and only support first order derivatives.

See #3038 for discussion.