### PR TITLE
ci(fonts): remove fetch-depth: 0

### DIFF
--- a/.github/workflows/fonts.yml
+++ b/.github/workflows/fonts.yml
@@ -92,7 +92,6 @@ jobs:
     - uses: actions/checkout@v2
       with:
         ref: ${{ format('refs/pull/{0}/merge', github.event.pull_request.number) }}
-        fetch-depth: 0
         persist-credentials: false
 
     - name: Build fonts


### PR DESCRIPTION
There is no need to fetch entire Git history (`fetch-depth: 0`) as we're no longer using the last commit date in font building (#3370).