### PR TITLE
feat: implement \relax as no-op function

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -3,6 +3,12 @@ id: migration
 title: Migration Guide
 ---
 
+## v0.15.0
+
+`\relax` is now implemented as a function. It'll stop expansions and parsing,
+so the behavior around `\relax` may change. For example, `\kern2\relax em` will
+no longer work.
+
 ## v0.14.0
 
 With module loaders that support conditional exports and ECMAScript modules,

--- a/src/MacroExpander.js
+++ b/src/MacroExpander.js
@@ -20,7 +20,6 @@ import type Settings from "./Settings";
 // List of commands that act like macros but aren't defined as a macro,
 // function, or symbol.  Used in `isDefined`.
 export const implicitCommands = {
-    "\\relax": true,     // MacroExpander.js
     "^": true,           // Parser.js
     "_": true,           // Parser.js
     "\\limits": true,    // Parser.js

--- a/src/MacroExpander.js
+++ b/src/MacroExpander.js
@@ -333,15 +333,12 @@ export default class MacroExpander implements MacroContextInterface {
             const expanded = this.expandOnce();
             // expandOnce returns Token if and only if it's fully expanded.
             if (expanded instanceof Token) {
-                // \relax stops the expansion, but shouldn't get returned (a
-                // null return value couldn't get implemented as a function).
                 // the token after \noexpand is interpreted as if its meaning
                 // were ‘\relax’
-                if (expanded.text === "\\relax" || expanded.treatAsRelax) {
-                    this.stack.pop();
-                } else {
-                    return this.stack.pop();  // === expanded
+                if (expanded.treatAsRelax) {
+                    expanded.text = "\\relax";
                 }
+                return this.stack.pop();  // === expanded
             }
         }
 

--- a/src/functions.js
+++ b/src/functions.js
@@ -37,6 +37,7 @@ import "./functions/ordgroup";
 import "./functions/overline";
 import "./functions/phantom";
 import "./functions/raisebox";
+import "./functions/relax";
 import "./functions/rule";
 import "./functions/sizing";
 import "./functions/smash";

--- a/src/functions/relax.js
+++ b/src/functions/relax.js
@@ -1,0 +1,17 @@
+//@flow
+import defineFunction from "../defineFunction";
+
+defineFunction({
+    type: "internal",
+    names: ["\\relax"],
+    props: {
+        numArgs: 0,
+        allowedInText: true,
+    },
+    handler({parser}) {
+        return {
+            type: "internal",
+            mode: parser.mode,
+        };
+    },
+});

--- a/src/macros.js
+++ b/src/macros.js
@@ -368,7 +368,7 @@ defineMacro("\\substack", "\\begin{subarray}{c}#1\\end{subarray}");
 // \renewcommand{\colon}{\nobreak\mskip2mu\mathpunct{}\nonscript
 // \mkern-\thinmuskip{:}\mskip6muplus1mu\relax}
 defineMacro("\\colon", "\\nobreak\\mskip2mu\\mathpunct{}" +
-    "\\mathchoice{\\mkern-3mu}{\\mkern-3mu}{}{}{:}\\mskip6mu");
+    "\\mathchoice{\\mkern-3mu}{\\mkern-3mu}{}{}{:}\\mskip6mu\\relax");
 
 // \newcommand{\boxed}[1]{\fbox{\m@th$\displaystyle#1$}}
 defineMacro("\\boxed", "\\fbox{$\\displaystyle{#1}$}");

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -4046,3 +4046,9 @@ describe("debugging macros", () => {
         });
     });
 });
+
+describe("\\relax", () => {
+    it("should stop the expansion", () => {
+        expect`\kern2\relax em`.not.toParse();
+    });
+});


### PR DESCRIPTION
**What is the previous behavior before this PR?**

`\relax` was just ignored in the `MacroExpander` level, not being able to be consumed.

**What is the new behavior after this PR?**

Thanks to `internal` parseNode type, we can implement it as a no-op function. It now stops expansions such as `\kern2\relax em`. No existing tests break, but it'll break edge cases like `\relax` being used in the middle of an expansion, though this wouldn't have worked in LaTeX as well. Therefore, I'm not sure this would count as a breaking change.

Related: #2123.