### PR TITLE
fix: \mathinner when invoked as a denominator.

### DIFF
--- a/src/functions/mclass.js
+++ b/src/functions/mclass.js
@@ -22,7 +22,7 @@ function mathmlBuilder(group: ParseNode<"mclass">, options) {
     const inner = mml.buildExpression(group.body, options);
 
     if (group.mclass === "minner") {
-        return mathMLTree.newDocumentFragment(inner);
+        node = new mathMLTree.MathNode("mpadded", inner);
     } else if (group.mclass === "mord") {
         if (group.isCharacterBox) {
             node = inner[0];
@@ -49,6 +49,9 @@ function mathmlBuilder(group: ParseNode<"mclass">, options) {
         } else if (group.mclass === "mopen" || group.mclass === "mclose") {
             node.attributes.lspace = "0em";
             node.attributes.rspace = "0em";
+        } else if (group.mclass === "minner") {
+            node.attributes.lspace = "0.0556em"; // 1 mu is the most likely option
+            node.attributes.width = "+0.1111em";
         }
         // MathML <mo> default space is 5/18 em, so <mrel> needs no action.
         // Ref: https://developer.mozilla.org/en-US/docs/Web/MathML/Element/mo

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -101,6 +101,15 @@ describe("A rel parser", function() {
     });
 });
 
+describe("A mathinner parser", function() {
+    it("should not fail", function() {
+        expect("\\mathinner{\\langle{\\psi}\\rangle}").toParse();
+    });
+    it("should not fail when it is a denominator", function() {
+        expect("\\frac 1 {\\mathinner{\\langle{\\psi}\\rangle}}").toParse();
+    });
+});
+
 describe("A punct parser", function() {
     const expression = ",;";
 


### PR DESCRIPTION
Currently, the MathML version of `\mathinner` returns a fragment, not a group. That results in invalid MathML when `\mathinner` becomes the denominator of a fraction, because in MathML a denominator can be only a single element, not several of them.

This PR revises `\mathinner` so that it returns a single `<mpadded>` element instead of a fragment. It thereby fixes issue #3500, which invokes `\mathinner` via the macro for `\braket`.