### PR TITLE
feat(array): add support for repetition in format description

### DIFF
--- a/src/environments/array.js
+++ b/src/environments/array.js
@@ -788,12 +788,23 @@ defineEnvironment({
             symNode ? [args[0]] : assertNodeType(args[0], "ordgroup").body;
         let myColAlign = [];
         if (colalign[0].text === "*") {
-            const numStart = colalign[1].loc.start + 1;
-            const numEnd = colalign[1].loc.end - 1;
-            const iRepeat = colalign[0].loc.lexer.input.slice(numStart, numEnd);
-            for (let i = 0; i < iRepeat; i++) {
-                for (let j = 0; j < colalign[2].body.length ; j++) {
-                    myColAlign.push(colalign[2].body[j]);
+            const repeatCol = assertNodeType(colalign[1], "ordgroup");
+            let repeatString = "";
+            for (let i = 0; i < repeatCol.body.length ; i++) {
+                const iRepeat = assertNodeType(repeatCol.body[i], "textord");
+                repeatString += iRepeat.text ;
+            }
+            const nRepeat = parseInt(repeatString);
+            if (isNaN(nRepeat)) {
+                throw new ParseError("Repeat specification not a number: "
+                + repeatString, repeatCol);
+            }
+            const ca = assertNodeType(colalign[2], "ordgroup");
+            const caLength = ca.body.length;
+            for (let i = 0; i < nRepeat; i++) {
+                for (let j = 0; j < caLength ; j++) {
+                    const jca = assertNodeType(ca.body[j], "mathord");
+                    myColAlign.push(jca);
                 }
             }
         } else {

--- a/src/environments/array.js
+++ b/src/environments/array.js
@@ -786,7 +786,20 @@ defineEnvironment({
         const symNode = checkSymbolNodeType(args[0]);
         const colalign: AnyParseNode[] =
             symNode ? [args[0]] : assertNodeType(args[0], "ordgroup").body;
-        const cols = colalign.map(function(nde) {
+        let myColAlign = [];
+        if (colalign[0].text === "*") {
+            const numStart = colalign[1].loc.start + 1;
+            const numEnd = colalign[1].loc.end - 1;
+            const iRepeat = colalign[0].loc.lexer.input.slice(numStart, numEnd);
+            for (let i = 0; i < iRepeat; i++) {
+                for (let j = 0; j < colalign[2].body.length ; j++) {
+                    myColAlign.push(colalign[2].body[j]);
+                }
+            }
+        } else {
+            myColAlign = colalign;
+        }
+        const cols = myColAlign.map(function(nde) {
             const node = assertSymbolNodeType(nde);
             const ca = node.text;
             if ("lcr".indexOf(ca) !== -1) {

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -1260,6 +1260,10 @@ describe("A begin/end parser", function() {
         expect`\begin{array}{cc}a&b\\c&d\end{array}`.toParse();
     });
 
+    it("should parse an environment with argument in repetition format", function() {
+        expect`\begin{array}{*{35}{l}} x+y\le 12, \ 2x-y\ge 0, \ x-2y\le 0\end{array}`.toParse();
+    });
+
     it("should parse and build an empty environment", function() {
         expect`\begin{aligned}\end{aligned}`.toBuild();
         expect`\begin{matrix}\end{matrix}`.toBuild();


### PR DESCRIPTION
It is now possible to describe an array environment like
\begin{array}{* {35}{l}}
This completes task number 3 on
[#269](https://github.com/KaTeX/KaTeX/issues/269)

<!-- PR title should follow Angular Commit Message Conventions (https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines) -->

**What is the previous behavior before this PR?**
When encountering an array environment described with the repetition format ( `\begin{array}{* {7}{cl}` ), KaTeX would throw an error and not render the equation.

**What is the new behavior after this PR?**
Equation now renders as expected.

<!-- If this PR contains a breaking change, please uncomment following line -->
<!-- BREAKING CHANGE: describe its impact and migration methods -->

<!-- If this PR fixes or closes issues, please uncomment following line and change the issue number -->
Contribtues to #269 