### PR TITLE
feat: Add `\strictif` and `\strictfi` symbols

### DIFF
--- a/docs/support_table.md
+++ b/docs/support_table.md
@@ -1005,6 +1005,8 @@ use `\ce` instead|
 |\Stigma|<span style="color:firebrick;">Not supported</span>||
 |\stigma|<span style="color:firebrick;">Not supported</span>||
 |\strut|<span style="color:firebrick;">Not supported</span>||
+|\strictif|$\strictif$||
+|\strictfi|$\strictfi$||
 |\style|<span style="color:firebrick;">Not supported</span>|Non standard|
 |\sub|$\sub$||
 |{subarray}|<span style="color:firebrick;">Not supported</span>||

--- a/docs/supported.md
+++ b/docs/supported.md
@@ -471,8 +471,9 @@ $\stackrel{!}{=}$ `\stackrel{!}{=}`
 | $\dblcolon$ `\dblcolon` or<br>   `\coloncolon` | $\leq$ `\leq` | $\simeq$ `\simeq` | $\vDash$ `\vDash` |
 | $\doteq$ `\doteq` | $\leqq$ `\leqq` | $\smallfrown$ `\smallfrown` | $\Vdash$ `\Vdash` |
 | $\Doteq$ `\Doteq` | $\leqslant$ `\leqslant` | $\smallsmile$ `\smallsmile` | $\Vvdash$ `\Vvdash` |
+|$\strictif$ `\strictif`|$\strictfi$ `\strictfi`|||
 
-Direct Input: $= < > : ∈ ∋ ∝ ∼ ∽ ≂ ≃ ≅ ≈ ≊ ≍ ≎ ≏ ≐ ≑ ≒ ≓ ≖ ≗ ≜ ≡ ≤ ≥ ≦ ≧ ≫ ≬ ≳ ≷ ≺ ≻ ≼ ≽ ≾ ≿ ⊂ ⊃ ⊆ ⊇ ⊏ ⊐ ⊑ ⊒ ⊢ ⊣ ⊩ ⊪ ⊸ ⋈ ⋍ ⋐ ⋑ ⋔ ⋙ ⋛ ⋞ ⋟ ⌢ ⌣ ⩾ ⪆ ⪌ ⪕ ⪖ ⪯ ⪰ ⪷ ⪸ ⫅ ⫆ ≲ ⩽ ⪅ ≶ ⋚ ⪋ ⟂ ⊨ ⊶ ⊷$ `≔ ≕ ⩴`
+Direct Input: $= < > : ∈ ∋ ∝ ∼ ∽ ≂ ≃ ≅ ≈ ≊ ≍ ≎ ≏ ≐ ≑ ≒ ≓ ≖ ≗ ≜ ≡ ≤ ≥ ≦ ≧ ≫ ≬ ≳ ≷ ≺ ≻ ≼ ≽ ≾ ≿ ⊂ ⊃ ⊆ ⊇ ⊏ ⊐ ⊑ ⊒ ⊢ ⊣ ⊩ ⊪ ⊸ ⋈ ⋍ ⋐ ⋑ ⋔ ⋙ ⋛ ⋞ ⋟ ⌢ ⌣ ⩾ ⪆ ⪌ ⪕ ⪖ ⪯ ⪰ ⪷ ⪸ ⫅ ⫆ ≲ ⩽ ⪅ ≶ ⋚ ⪋ ⟂ ⊨ ⊶ ⊷$ `≔ ≕ ⩴` ⥽ ⥼
 
 ### Negated Relations
 

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -396,6 +396,8 @@ defineSymbol(math, ams, bin, "\u22b3", "\\rhd");
 defineSymbol(math, ams, rel, "\u2242", "\\eqsim", true);
 defineSymbol(math, main, rel, "\u22c8", "\\Join");
 defineSymbol(math, ams, rel, "\u2251", "\\Doteq", true);
+defineSymbol(math, ams, rel, "\u297d", "\\strictif", true);
+defineSymbol(math, ams, rel, "\u297c", "\\strictfi", true);
 
 // AMS Binary Operators
 defineSymbol(math, ams, bin, "\u2214", "\\dotplus", true);

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -3767,7 +3767,7 @@ describe("Unicode", function() {
     });
 
     it("should build relations", function() {
-        expect`∈∋∝∼∽≂≃≅≈≊≍≎≏≐≑≒≓≖≗≜≡≤≥≦≧≪≫≬≳≷≺≻≼≽≾≿∴∵∣≔≕⩴⋘⋙⟂⊨∌`.toBuild(strictSettings);
+        expect`∈∋∝∼∽≂≃≅≈≊≍≎≏≐≑≒≓≖≗≜≡≤≥≦≧≪≫≬≳≷≺≻≼≽≾≿∴∵∣≔≕⩴⋘⋙⟂⊨∌⥽⥼`.toBuild(strictSettings);
     });
 
     it("should parse relations", function() {


### PR DESCRIPTION
<!-- PR title should follow Angular Commit Message Conventions (https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines) -->

**What is the previous behavior before this PR?**

There's no symbols for `/strictif` (⥽) and `/strictfi` (⥼) for strict implication

**What is the new behavior after this PR?**

Added them.

ps. some of the links in CONTRIBUTING.md were dead (https://github.com/KaTeX/KaTeX/pull/3525), and I didn't find correct way to contribute (adding symbols), so I referenced #2283 . Please let me know if there are any problems.

<!-- If this PR contains a breaking change, please uncomment following line -->
<!-- BREAKING CHANGE: describe its impact and migration methods -->

<!-- If this PR fixes or closes issues, please uncomment following line and change the issue number -->
<!-- Fixes #1, Closes #2 -->
