### PR TITLE
stlye: improve links (http -> https)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -68,7 +68,7 @@ members of the project's leadership.
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at [http://contributor-covenant.org/version/1/4][version]
+available at [https://www.contributor-covenant.org/version/1/4/code-of-conduct/][version]
 
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/
+[homepage]: https://www.contributor-covenant.org/
+[version]: https://www.contributor-covenant.org/version/1/4/code-of-conduct/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ KaTeX doesn't currently support. The documentation has pages listing
 [supported functions](https://katex.org/docs/supported.html) and
 [functions that KaTeX supports and some that it doesn't support](https://katex.org/docs/support_table.html).
 You can check them to see if we don't support a function you like, or try your
-function in the interactive demo at [http://katex.org/](http://katex.org/).
+function in the interactive demo at [https://katex.org](https://katex.org).
 The wiki has a page that describes how to [examine TeX commands and where to find
 rules](https://github.com/KaTeX/KaTeX/wiki/Examining-TeX) which can be quite
 useful when adding new commands.
@@ -157,4 +157,4 @@ In order to contribute to KaTeX, you must first sign the CLA, found at www.khana
 
 ## License
 
-KaTeX is licenced under the [MIT License](http://opensource.org/licenses/MIT).
+KaTeX is licenced under the [MIT License](https://opensource.org/licenses/MIT).

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 KaTeX is a fast, easy-to-use JavaScript library for TeX math rendering on the web.
 
- * **Fast:** KaTeX renders its math synchronously and doesn't need to reflow the page. See how it compares to a competitor in [this speed test](http://www.intmath.com/cg5/katex-mathjax-comparison.php).
+ * **Fast:** KaTeX renders its math synchronously and doesn't need to reflow the page. See how it compares to a competitor in [this speed test](https://www.intmath.com/cg5/katex-mathjax-comparison.php).
  * **Print quality:** KaTeX's layout is based on Donald Knuth's TeX, the gold standard for math typesetting.
  * **Self contained:** KaTeX has no dependencies and can easily be bundled with your website resources.
  * **Server side rendering:** KaTeX produces the same output regardless of browser or environment, so you can pre-render expressions using Node.js and send them as plain HTML.
@@ -116,4 +116,4 @@ Support this project with your organization. Your logo will show up here with a 
 
 ## License
 
-KaTeX is licensed under the [MIT License](http://opensource.org/licenses/MIT).
+KaTeX is licensed under the [MIT License](https://opensource.org/licenses/MIT).

--- a/docs/support_table.md
+++ b/docs/support_table.md
@@ -4,7 +4,7 @@ title: Support Table
 ---
 This is a list of TeX functions, sorted alphabetically. This list includes functions that KaTeX supports and some that it doesn't support. There is a similar page, with functions [sorted by type](supported.md).
 
-If you know the shape of a character, but not its name, [Detexify](http://detexify.kirelabs.org/classify.html) can help.
+If you know the shape of a character, but not its name, [Detexify](https://detexify.kirelabs.org/classify.html) can help.
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.15.3/dist/katex.min.css" integrity="sha384-KiWOvVjnN8qwAZbuQyWDIbfCLFhLXNETzBQjA/92pIowpC0d2O3nppDGQVgwd2nB" crossorigin="anonymous">
 <style>


### PR DESCRIPTION
**What is the previous behavior before this PR?**

Several links were called with `http` protocol.

**What is the new behavior after this PR?**

Links are now called with `https` protocol.