### PR TITLE
MakeSymbolNode#toNode and SymbolNode#toMarkup have consistent margin

### DIFF
--- a/src/domTree.js
+++ b/src/domTree.js
@@ -451,7 +451,7 @@ export class SymbolNode implements HtmlDomNode {
         let styles = "";
 
         if (this.italic > 0) {
-            styles += "margin-right:" + this.italic + "em;";
+            styles += "margin-right:" + makeEm(this.italic);
         }
         for (const style in this.style) {
             if (this.style.hasOwnProperty(style)) {

--- a/test/__snapshots__/katex-spec.js.snap
+++ b/test/__snapshots__/katex-spec.js.snap
@@ -1174,7 +1174,7 @@ exports[`Newlines via \\\\ and \\newline \\\\ causes newline, even after mrel an
       >
       </span>
       <span class="mord mathnormal"
-            style="margin-right:0.10903em;"
+            style="margin-right:0.109em"
       >
         M
       </span>


### PR DESCRIPTION
**What is the previous behavior before this PR?**
Previously `SymbolNode#toMarkup()` would return an un-rounded margin-right value whereas `SymbolNode#toNode()`would use `makeEm` and have a rounded value making them behave inconsistently. Am guessing that the `#toNode()` is the correct behaviour (with rounding).

**What is the new behavior after this PR?**
 Changed `SymbolNode#toMarkup()` to use `makeEm` to round it's `margin-right` value when `this.italic` has a value.

**Note**
Wasn't sure if I should add a new test for this or not since there was a snapshot test that caught this change and had to be updated, please advise.