### PR TITLE
Fix broken markup returned by Img#toMarkup

### DIFF
--- a/src/domTree.js
+++ b/src/domTree.js
@@ -314,7 +314,7 @@ export class Img implements VirtualNode {
     }
 
     toMarkup(): string {
-        let markup = `<img  src='${this.src} 'alt='${this.alt}' `;
+        let markup = `<img class="mord" src='${this.src}' alt='${this.alt}' `;
 
         // Add the styles, after hyphenation
         let styles = "";
@@ -327,7 +327,7 @@ export class Img implements VirtualNode {
             markup += ` style="${utils.escape(styles)}"`;
         }
 
-        markup += "'/>";
+        markup += "/>";
         return markup;
     }
 }

--- a/test/__snapshots__/katex-spec.js.snap
+++ b/test/__snapshots__/katex-spec.js.snap
@@ -1037,6 +1037,44 @@ exports[`An includegraphics builder should not render without trust setting 1`] 
 ]
 `;
 
+exports[`An includegraphics builder should properly render markup 1`] = `
+<span class="katex">
+  <span class="katex-mathml">
+    <math xmlns="http://www.w3.org/1998/Math/MathML">
+      <semantics>
+        <mrow>
+          <mglyph alt="KA logo"
+                  valign="0em"
+                  height="0.9em"
+                  width="0.9em"
+                  src="https://cdn.kastatic.org/images/apple-touch-icon-57x57-precomposed.new.png"
+          >
+          </mglyph>
+        </mrow>
+        <annotation encoding="application/x-tex">
+          \\includegraphics[height=0.9em, totalheight=0.9em, width=0.9em, alt=KA logo]{https://cdn.kastatic.org/images/apple-touch-icon-57x57-precomposed.new.png}
+        </annotation>
+      </semantics>
+    </math>
+  </span>
+  <span class="katex-html"
+        aria-hidden="true"
+  >
+    <span class="base">
+      <span class="strut"
+            style="height:0.9em;"
+      >
+      </span>
+      <img class="mord"
+           src="https://cdn.kastatic.org/images/apple-touch-icon-57x57-precomposed.new.png"
+           alt="KA logo"
+           style="height:0.9em;width:0.9em;"
+      >
+    </span>
+  </span>
+</span>
+`;
+
 exports[`An includegraphics builder should render with trust setting 1`] = `
 [
   {

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -2076,6 +2076,11 @@ describe("An includegraphics builder", function() {
         expect(img).toBuild(trustSettings);
     });
 
+    it("should properly render markup", function () {
+        const markup = katex.renderToString(img, {trust: true});
+        expect(markup).toMatchSnapshot();
+    });
+
     it("should produce mords", function() {
         expect(getBuilt(img, trustSettings)[0].classes).toContain("mord");
     });


### PR DESCRIPTION
**What is the previous behavior before this PR?**
Previously, calling `Img#toMarkup` would return invalid & inconsistent markup:
- There was an extra space at the end of the `src` attr value
- There was an extra single quote being added to the end up the tag
- The resulting markup lacked the "mord" class which is returned in `Img#toNode`.

**What is the new behavior after this PR?**

- Remove extra space at end of `src` attr value
- Fix extra single quote at img tag close delimiter
- Add missing "mord" class name

Example diff (before/after fix):

```diff
-      <img src="https://cdn.kastatic.org/images/apple-touch-icon-57x57-precomposed.new.png "
            alt="KA logo"
            style="height:0.9em;width:0.9em;"
-           '
+      <img class="mord"
+           src="https://cdn.kastatic.org/images/apple-touch-icon-57x57-precomposed.new.png"
            alt="KA logo"
            style="height:0.9em;width:0.9em;"
```