### PR TITLE
fix: @font-face Adds the font-display attribute to optimize FOIT in SEO

### DIFF
--- a/src/fonts.less
+++ b/src/fonts.less
@@ -37,6 +37,7 @@
         .use-ttf(@family, @suffix);
         font-weight: @weight;
         font-style: @style;
+        font-display: swap;
     }
 }
 


### PR DESCRIPTION
**What is the previous behavior before this PR?**
When I used Chrom's Lighthose tool to test site SEO, Lighthose suggested this
![image](https://user-images.githubusercontent.com/31126771/179364460-c5aa739a-8f73-4562-af87-12e96e7789c7.png)
Here's what Google suggests
https://web.dev/font-display/?utm_source=lighthouse&utm_medium=devtools#how-to-avoid-showing-invisible-text
<img width="781" alt="image" src="https://user-images.githubusercontent.com/31126771/179364648-77f38364-6463-43e9-8390-0e440d2931b6.png">
<img width="803" alt="image" src="https://user-images.githubusercontent.com/31126771/179364690-1cc15264-9340-47b4-a714-4844b24ef148.png">

**What is the new behavior after this PR?**
Ensure text remains visible during webfont load
