### PR TITLE
fix: Use SVGs for built-up stretchy delimiters

### DIFF
--- a/src/delimiter.js
+++ b/src/delimiter.js
@@ -25,7 +25,7 @@ import ParseError from "./ParseError";
 import Style from "./Style";
 
 import {PathNode, SvgNode, SymbolNode} from "./domTree";
-import {sqrtPath, innerPath} from "./svgGeometry";
+import {sqrtPath, innerPath, tallDelim} from "./svgGeometry";
 import buildCommon from "./buildCommon";
 import {getCharacterMetrics} from "./fontMetrics";
 import symbols from "./symbols";
@@ -229,6 +229,8 @@ const makeStackedDelim = function(
     let middle;
     let repeat;
     let bottom;
+    let svgLabel = "";
+    let viewBoxWidth = 0;
     top = repeat = bottom = delim;
     middle = null;
     // Also keep track of what font the delimiters are in
@@ -255,44 +257,64 @@ const makeStackedDelim = function(
         bottom = "\\Downarrow";
     } else if (utils.contains(verts, delim)) {
         repeat = "\u2223";
+        svgLabel = "vert";
+        viewBoxWidth = 333;
     } else if (utils.contains(doubleVerts, delim)) {
         repeat = "\u2225";
+        svgLabel = "doublevert";
+        viewBoxWidth = 556;
     } else if (delim === "[" || delim === "\\lbrack") {
         top = "\u23a1";
         repeat = "\u23a2";
         bottom = "\u23a3";
         font = "Size4-Regular";
+        svgLabel = "lbrack";
+        viewBoxWidth = 667;
     } else if (delim === "]" || delim === "\\rbrack") {
         top = "\u23a4";
         repeat = "\u23a5";
         bottom = "\u23a6";
         font = "Size4-Regular";
+        svgLabel = "rbrack"
+        viewBoxWidth = 667;
     } else if (delim === "\\lfloor" || delim === "\u230a") {
         repeat = top = "\u23a2";
         bottom = "\u23a3";
         font = "Size4-Regular";
+        svgLabel = "rfloor";
+        viewBoxWidth = 667;
     } else if (delim === "\\lceil" || delim === "\u2308") {
         top = "\u23a1";
         repeat = bottom = "\u23a2";
         font = "Size4-Regular";
+        svgLabel = "lceil";
+        viewBoxWidth = 667;
     } else if (delim === "\\rfloor" || delim === "\u230b") {
         repeat = top = "\u23a5";
         bottom = "\u23a6";
         font = "Size4-Regular";
+        svgLabel = "rfloor";
+        viewBoxWidth = 667;
     } else if (delim === "\\rceil" || delim === "\u2309") {
         top = "\u23a4";
         repeat = bottom = "\u23a5";
         font = "Size4-Regular";
+        svgLabel = "rceil";
+        viewBoxWidth = 667;
     } else if (delim === "(" || delim === "\\lparen") {
         top = "\u239b";
         repeat = "\u239c";
         bottom = "\u239d";
         font = "Size4-Regular";
+        svgLabel = "lparen";
+        viewBoxWidth = 875;
     } else if (delim === ")" || delim === "\\rparen") {
         top = "\u239e";
         repeat = "\u239f";
         bottom = "\u23a0";
         font = "Size4-Regular";
+        svgLabel = "rparen";
+        viewBoxWidth = 875;
     } else if (delim === "\\{" || delim === "\\lbrace") {
         top = "\u23a7";
         middle = "\u23a8";
@@ -365,6 +387,26 @@ const makeStackedDelim = function(
     // Calculate the depth
     const depth = realHeightTotal / 2 - axisHeight;
 
+    if (svgLabel.length > 0) {
+        // Instead of stacking glyphs, create a single SVG.
+        // This evades browser problems with imprecise positioning of spans.
+        const midHeight = realHeightTotal - topHeightTotal - bottomHeightTotal;
+        const viewBoxHeight = Math.round((group.height + group.depth)  * 1000);
+        const pathStr = tallDelim(svgLabel, Math.round(midHeight * 1000));
+        const path = new PathNode(pathStr);
+        const svg = new SvgNode([path], {
+            "width": viewBoxWidth / 1000 + "em",
+            "height": viewBoxHeight / 1000 + "em",
+            "viewBox": `0 0 ${viewBoxWidth} ${viewBoxHeight}`,
+        });
+        const span = buildCommon.makeSvgSpan([], [svg], options);
+        span.height = viewBoxHeight / 1000;
+        return buildCommon.makeVList({
+            positionType: "bottom",
+            positionData: group.depth,
+            children: [span],
+        }, options);
+    }
 
     // Now, we start building the pieces that will go into the vlist
     // Keep a list of the pieces of the stacked delimiter

--- a/src/svgGeometry.js
+++ b/src/svgGeometry.js
@@ -487,3 +487,37 @@ c4.7,-4.7,7,-9.3,7,-14c0,-9.3,-3.7,-15.3,-11,-18c-92.7,-56.7,-159,-133.7,-199,
 c-2,2.7,-1,9.7,3,21c15.3,42,36.7,81.8,64,119.5c27.3,37.7,58,69.2,92,94.5z
 M500 241 v40 H399408 v-40z M500 435 v40 H400000 v-40z`,
 };
+
+export const tallDelim = function(label: string, midHeight: number): string {
+    switch (label) {
+        case "lbrack": 
+            return `M403 1759 V84 H666 V0 H319 V1759 v${midHeight} v1759 h347 v-84
+H403z M403 1759 V0 H319 V1759 v${midHeight} v1759 h84z`
+        case "rbrack":
+            return `M347 1759 V0 H0 V84 H347 V1759 v${midHeight} v1759 H0 v84 H403z
+M403 1759 V0 H319 V1759 v${midHeight} v1759 h84z`
+        case "vert":
+            return `M188 642 V0 H145 V642 v${midHeight} v642 h43z
+M188 642 V0 H145 V642 v${midHeight} v642 h43z`
+        case "doublevert":
+            return `M188 642 V0 H145 V642 v${midHeight} v642 h43z M188 642 V0 H145
+V642 v${midHeight} v642 h43z M410 642 V0 H367 V642 v${midHeight} v642 h43z M410 642
+V0 H367 V642 v${midHeight} v642 h43z`
+        case "lfloor":
+            return ``
+        case "rfloor":
+            return ``
+        case "lceil":
+            return `M403 1759 V84 H666 V0 H319 V1759 v${midHeight} v602 h84z
+M403 1759 V0 H319 V1759 v${midHeight} v602 h84z`
+        case "rceil":
+            return `M347 1759 V0 H0 V84 H347 V1759 v${midHeight} v602 h84z
+M347 1759 V0 h-84 V1759 v${midHeight} v602 h84z`
+        case "lparen":
+            return ``
+        case "rparen":
+            return ``
+        default:
+           throw new Error("Unknown stretchy delimiter.")
+    }
+}


### PR DESCRIPTION
This PR will eventually write a single SVG for a built-up delimiter, replacing the current stack of glyphs and thereby evading browser imprecision of glyph location. I have not yet got very far with this PR because I cannot get anything to run in my local repository. Even the main branch is inoperative.

If I try to run `yarn start`, the error message is:

```
(node:7640) ExperimentalWarning: Custom ESM Loaders is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
node:internal/errors:477
    ErrorCaptureStackTrace(err);
    ^

Error [ERR_LOADER_CHAIN_INCOMPLETE]: "file:///C:/Users/Ronal/OneDrive/Documents/GitHub/KaTeX/.pnp.loader.mjs 'resolve'" did not call the next hook in its chain and did not explicitly signal a short circuit. If this is intentional, include `shortCircuit: true` in the hook's return.
    at new NodeError (node:internal/errors:387:5)
    at ESMLoader.resolve (node:internal/modules/esm/loader:860:13)
    at async ESMLoader.getModuleJob (node:internal/modules/esm/loader:439:7)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:541:24)
    at async loadESM (node:internal/process/esm_loader:91:5)
    at async handleMainPromise (node:internal/modules/run_main:65:12) {
  code: 'ERR_LOADER_CHAIN_INCOMPLETE'
}
```

I have no idea how to overcome this. Any help would be appreciated. @edemaine? @ylemkimon? Help?