### PR TITLE
feat: Add commonly used physics macros

### DIFF
--- a/docs/support_table.md
+++ b/docs/support_table.md
@@ -69,6 +69,8 @@ $\gdef\VERT{|}$
 |\aa|$\text{\aa}$|`\text{\aa}`|
 |\above|${a \above{2pt} b+1}$|`{a \above{2pt} b+1}`|
 |\abovewithdelims|<span style="color:firebrick;">Not supported</span>||
+|\abs|$\abs{a}$|`$\abs{a}$`|
+|\Abs|$\Abs{a}$|`$\Abs{a}$`|
 |\acute|$\acute e$|`\acute e`|
 |\AE|$\text{\AE}$|`\text{\AE}`|
 |\ae|$\text{\ae}$|`\text{\ae}`|
@@ -281,12 +283,14 @@ use `\ce` instead|
 |\cotg|$\cotg$||
 |\coth|$\coth$||
 |\cr|$\begin{matrix} a & b\cr c & d \end{matrix}$|`\begin{matrix}`<br>&nbsp;&nbsp;&nbsp;`a & b \cr`<br>&nbsp;&nbsp;&nbsp;`c & d`<br>`\end{matrix}`|
+|\crossproduct|$\crossproduct$|
 |\csc|$\csc$||
 |\cssId|<span style="color:firebrick;">Not supported</span>|A PR is pending.
 |\ctg|$\ctg$||
 |\cth|$\cth$||
 |\Cup|$\Cup$||
 |\cup|$\cup$||
+|\curl|$\curl{E}$|`\curl{E}`|
 |\curlyeqprec|$\curlyeqprec$||
 |\curlyeqsucc|$\curlyeqsucc$||
 |\curlyvee|$\curlyvee$||
@@ -312,6 +316,7 @@ use `\ce` instead|
 |\dbinom|$\dbinom n k$|`\dbinom n k`|
 |\dblcolon|$\dblcolon$||
 |{dcases}|$\begin{dcases}a&\text{if }b\\c&\text{if }d\end{dcases}$|`\begin{dcases}`<br>&nbsp;&nbsp;&nbsp;`a &\text{if } b  \\`<br>&nbsp;&nbsp;&nbsp;`c &\text{if } d`<br>`\end{dcases}`|
+|\dd|$\dd$||
 |\ddag|$\ddag$||
 |\ddagger|$\ddagger$||
 |\ddddot|<span style="color:firebrick;">Not supported</span>||
@@ -339,12 +344,14 @@ use `\ce` instead|
 |\displaylines|<span style="color:firebrick;">Not supported</span>||
 |\displaystyle|$\displaystyle\sum_0^n$|`\displaystyle\sum_0^n`|
 |\div|$\div$||
+|\divergence|$\divergence{B}$|`\divergence{B}`|
 |\divideontimes|$\divideontimes$||
 |\dot|$\dot x$|`\dot x`|
 |\Doteq|$\Doteq$||
 |\doteq|$\doteq$||
 |\doteqdot|$\doteqdot$||
 |\dotplus|$\dotplus$||
+|\dotproduct|$\dotproduct$||
 |\dots|$x_1 + \dots + x_n$|`x_1 + \dots + x_n`|
 |\dotsb|$x_1 +\dotsb + x_n$|`x_1 +\dotsb + x_n`|
 |\dotsc|$x,\dotsc,y$|`x,\dotsc,y`|
@@ -399,6 +406,7 @@ use `\ce` instead|
 |\eta|$\eta$||
 |\eth|$\eth$||
 |\euro|<span style="color:firebrick;">Not supported</span>||
+|\eval|$f(x)\eval{0}{1}$|`$f(x)\eval{0}{1}$`|
 |\exist|$\exist$||
 |\exists|$\exists$||
 |\exp|$\exp$||
@@ -446,6 +454,7 @@ use `\ce` instead|
 |\gggtr|$\gggtr$||
 |\gimel|$\gimel$||
 |\global|$\global\def\add#1#2{#1+#2} \add 2 3$|`\global\def\add#1#2{#1+#2} \add 2 3`|
+|\gradient|$\gradient{\psi}$|`\gradient{\psi}`|
 |\gnapprox|$\gnapprox$||
 |\gneq|$\gneq$||
 |\gneqq|$\gneqq$||
@@ -519,6 +528,7 @@ use `\ce` instead|
 |\infin|$\infin$||
 |\infty|$\infty$||
 |\injlim|$\injlim$| `\injlim` |
+|\innerproduct|$\innerproduct{u}{v}$| `\innerproduct{u}{v}` |
 |\int|$\int$||
 |\intercal|$\intercal$||
 |\intop|$\intop$||
@@ -557,6 +567,7 @@ use `\ce` instead|
 |\land|$\land$||
 |\lang|$\lang A\rangle$|`\lang A\rangle`|
 |\langle|$\langle A\rangle$|`\langle A\rangle`|
+|\laplacian|$\laplacian{\psi}$|`\laplacian{\psi}`|
 |\Larr|$\Larr$||
 |\lArr|$\lArr$||
 |\larr|$\larr$||
@@ -752,6 +763,8 @@ use `\ce` instead|
 |\noexpand|||
 |\nolimits|$\lim\nolimits_x$|`\lim\nolimits_x`|
 |\nonumber|$$\begin{align}a&=b+c\nonumber\\d+e&=f\end{align}$$|`\begin{align}`<br>&nbsp;&nbsp;&nbsp;`a&=b+c \nonumber\\`<br>&nbsp;&nbsp;&nbsp;`d+e&=f`<br>`\end{align}`|
+|\norm|$\norm{a}$||
+|\Norm|$\Norm{a}$||
 |\normalfont|<span style="color:firebrick;">Not supported</span>||
 |\normalsize|$\normalsize normalsize$|`\normalsize normalsize`|
 |\not|$\not =$|`\not =`|
@@ -811,6 +824,7 @@ use `\ce` instead|
 |\origof|$\origof$||
 |\oslash|$\oslash$||
 |\otimes|$\otimes$||
+|\outerproduct|$\outerproduct{u}{v}$| `\outerproduct{u}{v}` |
 |\over|${a+1 \over b+2}+c$|`{a+1 \over b+2}+c`|
 |\overbrace|$\overbrace{x+⋯+x}^{n\text{ times}}$|`\overbrace{x+⋯+x}^{n\text{ times}}`|
 |\overbracket|<span style="color:firebrick;">Not supported</span>||
@@ -888,6 +902,7 @@ use `\ce` instead|
 |\rang|$\langle A\rang$|`\langle A\rang`|
 |\rangle|$\langle A\rangle$|`\langle A\rangle`|
 |\Rarr|$\Rarr$||
+|\rank|$\rank$||
 |\rArr|$\rArr$||
 |\rarr|$\rarr$||
 |\ratio|$\ratio$||
@@ -897,6 +912,7 @@ use `\ce` instead|
 |{rcases}|$\begin{rcases}a&\text{if }b\\c&\text{if }d\end{rcases}$|`\begin{rcases}`<br>&nbsp;&nbsp;&nbsp;`a &\text{if } b  \\`<br>&nbsp;&nbsp;&nbsp;`c &\text{if } d`<br>`\end{rcases}`|
 |\rceil|$\rceil$||
 |\Re|$\Re$||
+|\Res|$\Res||
 |\real|$\real$||
 |\Reals|$\Reals$||
 |\reals|$\reals$||
@@ -1110,6 +1126,9 @@ use `\ce` instead|
 |\to|$\to$||
 |\toggle|<span style="color:firebrick;">Not supported</span>||
 |\top|$\top$||
+|\tr|$\tr$||
+|\Tr|$\Tr$||
+|\trace|$\trace$||
 |\triangle|$\triangle$||
 |\triangledown|$\triangledown$||
 |\triangleleft|$\triangleleft$||
@@ -1201,6 +1220,7 @@ use `\ce` instead|
 |\vartriangleright|$\vartriangleright$||
 |\varUpsilon|$\varUpsilon$||
 |\varXi|$\varXi$||
+|\vb|$\vb{a}$|`\vb{a}`|
 |\vcentcolon|$\mathrel{\vcentcolon =}$|`\mathrel{\vcentcolon =}`|
 |\vcenter|$a+\left(\vcenter{\frac{\frac a b}c}\right)$|`a+\left(\vcenter{\hbox{$\frac{\frac a b}c$}}\right)`<br>TeX (strict) syntax|
 |\vcenter|$a+\left(\vcenter{\frac{\frac a b}c}\right)$|`a+\left(\vcenter{\frac{\frac a b}c}\right)`<br>non-strict syntax|
@@ -1209,6 +1229,9 @@ use `\ce` instead|
 |\vdash|$\vdash$||
 |\vdots|$\vdots$||
 |\vec|$\vec{F}$|`\vec{F}`|
+|\vectorarrow|$\vectorarrow{a}$|`\vectorarrow{a}`|
+|\vectorbold|$\vectorbold{a}$|`\vectorbold{a}`|
+|\vectorunit|$\vectorunit{a}$|`\vectorunit{a}`|
 |\vee|$\vee$||
 |\veebar|$\veebar$||
 |\verb|$\verb!\frac a b!$|`\verb!\frac a b!`|

--- a/docs/support_table.md
+++ b/docs/support_table.md
@@ -69,8 +69,8 @@ $\gdef\VERT{|}$
 |\aa|$\text{\aa}$|`\text{\aa}`|
 |\above|${a \above{2pt} b+1}$|`{a \above{2pt} b+1}`|
 |\abovewithdelims|<span style="color:firebrick;">Not supported</span>||
-|\abs|$\abs{a}$|`$\abs{a}$`|
-|\Abs|$\Abs{a}$|`$\Abs{a}$`|
+|\abs|$\abs{a}$|`\abs{a}`|
+|\Abs|$\Abs{\frac{a}{b}}$|`\Abs{\frac{a}{b}}`|
 |\acute|$\acute e$|`\acute e`|
 |\AE|$\text{\AE}$|`\text{\AE}`|
 |\ae|$\text{\ae}$|`\text{\ae}`|
@@ -283,7 +283,7 @@ use `\ce` instead|
 |\cotg|$\cotg$||
 |\coth|$\coth$||
 |\cr|$\begin{matrix} a & b\cr c & d \end{matrix}$|`\begin{matrix}`<br>&nbsp;&nbsp;&nbsp;`a & b \cr`<br>&nbsp;&nbsp;&nbsp;`c & d`<br>`\end{matrix}`|
-|\crossproduct|$\crossproduct$|
+|\crossproduct|$\crossproduct$||
 |\csc|$\csc$||
 |\cssId|<span style="color:firebrick;">Not supported</span>|A PR is pending.
 |\ctg|$\ctg$||
@@ -406,7 +406,7 @@ use `\ce` instead|
 |\eta|$\eta$||
 |\eth|$\eth$||
 |\euro|<span style="color:firebrick;">Not supported</span>||
-|\eval|$f(x)\eval{0}{1}$|`$f(x)\eval{0}{1}$`|
+|\eval|$f(x)\eval{0}{1}$|`f(x)\eval{0}{1}`|
 |\exist|$\exist$||
 |\exists|$\exists$||
 |\exp|$\exp$||
@@ -762,8 +762,8 @@ use `\ce` instead|
 |\noexpand|||
 |\nolimits|$\lim\nolimits_x$|`\lim\nolimits_x`|
 |\nonumber|$$\begin{align}a&=b+c\nonumber\\d+e&=f\end{align}$$|`\begin{align}`<br>&nbsp;&nbsp;&nbsp;`a&=b+c \nonumber\\`<br>&nbsp;&nbsp;&nbsp;`d+e&=f`<br>`\end{align}`|
-|\norm|$\norm{a}$||
-|\Norm|$\Norm{a}$||
+|\norm|$\norm{a}$|`\norm{a}`|
+|\Norm|$\Norm{\frac{a}{b}}$|`\Norm{\frac{a}{b}}`|
 |\normalfont|<span style="color:firebrick;">Not supported</span>||
 |\normalsize|$\normalsize normalsize$|`\normalsize normalsize`|
 |\not|$\not =$|`\not =`|

--- a/docs/support_table.md
+++ b/docs/support_table.md
@@ -528,7 +528,6 @@ use `\ce` instead|
 |\infin|$\infin$||
 |\infty|$\infty$||
 |\injlim|$\injlim$| `\injlim` |
-|\innerproduct|$\innerproduct{u}{v}$| `\innerproduct{u}{v}` |
 |\int|$\int$||
 |\intercal|$\intercal$||
 |\intop|$\intop$||
@@ -824,7 +823,6 @@ use `\ce` instead|
 |\origof|$\origof$||
 |\oslash|$\oslash$||
 |\otimes|$\otimes$||
-|\outerproduct|$\outerproduct{u}{v}$| `\outerproduct{u}{v}` |
 |\over|${a+1 \over b+2}+c$|`{a+1 \over b+2}+c`|
 |\overbrace|$\overbrace{x+⋯+x}^{n\text{ times}}$|`\overbrace{x+⋯+x}^{n\text{ times}}`|
 |\overbracket|<span style="color:firebrick;">Not supported</span>||

--- a/docs/supported.md
+++ b/docs/supported.md
@@ -415,14 +415,17 @@ Direct Input: $+ - / * ⋅ ∘ ∙ ± × ÷ ∓ ∔ ∧ ∨ ∩ ∪ ≀ ⊎ ⊓ 
 
 |||||
 |:--------------------|:--------------------|:----------------|:--------------|
-| $\arcsin$ `\arcsin` | $\cosec$ `\cosec`   | $\deg$ `\deg`   | $\sec$ `\sec` |
-| $\arccos$ `\arccos` | $\cosh$ `\cosh`     | $\dim$ `\dim`   | $\sin$ `\sin` |
-| $\arctan$ `\arctan` | $\cot$ `\cot`       | $\exp$ `\exp`   | $\sinh$ `\sinh` |
-| $\arctg$ `\arctg`   | $\cotg$ `\cotg`     | $\hom$ `\hom`   | $\sh$ `\sh` |
-| $\arcctg$ `\arcctg` | $\coth$ `\coth`     | $\ker$ `\ker`   | $\tan$ `\tan` |
-| $\arg$ `\arg`       | $\csc$ `\csc`       | $\lg$ `\lg`     | $\tanh$ `\tanh` |
-| $\ch$ `\ch`         | $\ctg$ `\ctg`       | $\ln$ `\ln`     | $\tg$ `\tg` |
-| $\cos$ `\cos`       | $\cth$ `\cth`       | $\log$ `\log`   | $\th$ `\th` |
+| $\abs{a}$ `\abs{a}` | $\cosh$ `\cosh`     | $f(x)\eval{0}{1}$ `f(x)\eval{0}{1}` | $\sin$ `\sin` |
+| $\Abs{a}$ `\Abs{a}` | $\cot$ `\cot`       | $\hom$ `\hom`   | $\sinh$ `\sinh` |
+| $\arcsin$ `\arcsin` | $\cotg$ `\cotg`     | $\ker$ `\ker`   | $\sh$ `\sh`   |
+| $\arccos$ `\arccos` | $\coth$ `\coth`     | $\lg$ `\lg`     | $\tan$ `\tan` |
+| $\arctan$ `\arctan` | $\csc$ `\csc`       | $\ln$ `\ln`     | $\tanh$ `\tanh` |
+| $\arctg$ `\arctg`   | $\ctg$ `\ctg`       | $\log$ `\log`   | $\tg$ `\tg`   |
+| $\arcctg$ `\arcctg` | $\cth$ `\cth`       | $\norm{a}$ `\norm{a}` | $\th$ `\th`   |
+| $\arg$ `\arg`       | $\deg$ `\deg`       | $\Norm{a}$ `\Norm{a}` | $\tr$ `\tr`   |
+| $\ch$ `\ch`         | $\dim$ `\dim`       | $\rank$ `\rank` | $\Tr$ `\Tr`   |
+| $\cos$ `\cos`       | $\dd$ `\dd`         | $\Res$ `\Res`   | $\trace$ `\trace` |
+| $\cosec$ `\cosec`   | $\exp$ `\exp`       | $\sec$ `\sec`   ||
 | $\operatorname{f}$ `\operatorname{f}`     | |||
 | $\argmax$ `\argmax` | $\injlim$ `\injlim` | $\min$ `\min`   | $\varinjlim$ `\varinjlim` |
 | $\argmin$ `\argmin` | $\lim$ `\lim`       | $\plim$ `\plim` | $\varliminf$ `\varliminf` |
@@ -567,6 +570,17 @@ Extensible arrows all can take an optional argument in the same manner<br>as `\x
 |:----------|:----------|:----------|
 |$\bra{\phi}$ `\bra{\phi}` |$\ket{\psi}$ `\ket{\psi}` |$\braket{\phi\VERT\psi}$ <code>\braket{\phi&#124;\psi}</code> |
 |$\Bra{\phi}$ `\Bra{\phi}` |$\Ket{\psi}$ `\Ket{\psi}` |$\Braket{ ϕ \VERT \frac{∂^2}{∂ t^2} \VERT ψ }$ <code>\Braket{ ϕ &#124; \frac{∂^2}{∂ t^2} &#124; ψ }</code>|
+
+**Physics Notation**
+
+|||
+|:----------------|:----------------|
+|$\vb{a}$ `\vb{a}`|$\vectorbold{a}$ `\vectorbold{a}`|
+|$\vectorarrow{a}$ `\vectorarrow{a}`|$\vectorunit{a}$ `\vectorunit{a}`|
+|$a \dotproduct b$ `a \dotproduct b`|$a \crossproduct b$ `a \crossproduct b`|
+|$\innerproduct{u}{v}$ `\innerproduct{u}{v}`|$\outerproduct{u}{v}$ `\outerproduct{u}{v}`|
+|$\gradient{\psi}$ `\gradient{\psi}`|$\laplacian{\psi}$ `\laplacian{\psi}`|
+|$\divergence{B}$ `\divergence{B}`|$\curl{E}$ `\curl{E}`|
 
 ## Style, Color, Size, and Font
 

--- a/docs/supported.md
+++ b/docs/supported.md
@@ -578,7 +578,6 @@ Extensible arrows all can take an optional argument in the same manner<br>as `\x
 |$\vb{a}$ `\vb{a}`|$\vectorbold{a}$ `\vectorbold{a}`|
 |$\vectorarrow{a}$ `\vectorarrow{a}`|$\vectorunit{a}$ `\vectorunit{a}`|
 |$a \dotproduct b$ `a \dotproduct b`|$a \crossproduct b$ `a \crossproduct b`|
-|$\innerproduct{u}{v}$ `\innerproduct{u}{v}`|$\outerproduct{u}{v}$ `\outerproduct{u}{v}`|
 |$\gradient{\psi}$ `\gradient{\psi}`|$\laplacian{\psi}$ `\laplacian{\psi}`|
 |$\divergence{B}$ `\divergence{B}`|$\curl{E}$ `\curl{E}`|
 

--- a/docs/supported.md
+++ b/docs/supported.md
@@ -415,7 +415,7 @@ Direct Input: $+ - / * ⋅ ∘ ∙ ± × ÷ ∓ ∔ ∧ ∨ ∩ ∪ ≀ ⊎ ⊓ 
 
 |||||
 |:--------------------|:--------------------|:----------------|:--------------|
-| $\abs{a}$ `\abs{a}` | $\cosh$ `\cosh`     | $f(x)\eval{0}{1}$ `f(x)\eval{0}{1}` | $\sin$ `\sin` |
+| $\abs{a}$ `\abs{a}` | $\cosh$ `\cosh`     | $f\eval{0}{1}$ `f\eval{0}{1}` | $\sin$ `\sin` |
 | $\Abs{a}$ `\Abs{a}` | $\cot$ `\cot`       | $\hom$ `\hom`   | $\sinh$ `\sinh` |
 | $\arcsin$ `\arcsin` | $\cotg$ `\cotg`     | $\ker$ `\ker`   | $\sh$ `\sh`   |
 | $\arccos$ `\arccos` | $\coth$ `\coth`     | $\lg$ `\lg`     | $\tan$ `\tan` |

--- a/src/functions/op.js
+++ b/src/functions/op.js
@@ -262,8 +262,9 @@ defineFunction({
         "\\arcsin", "\\arccos", "\\arctan", "\\arctg", "\\arcctg",
         "\\arg", "\\ch", "\\cos", "\\cosec", "\\cosh", "\\cot", "\\cotg",
         "\\coth", "\\csc", "\\ctg", "\\cth", "\\deg", "\\dim", "\\exp",
-        "\\hom", "\\ker", "\\lg", "\\ln", "\\log", "\\sec", "\\sin",
-        "\\sinh", "\\sh", "\\tan", "\\tanh", "\\tg", "\\th",
+        "\\hom", "\\ker", "\\lg", "\\ln", "\\log", "\\rank", "\\Res",
+        "\\sec", "\\sin", "\\sinh", "\\sh", "\\tan", "\\tanh", "\\tr", "\\Tr",
+        "\\trace", "\\tg", "\\th",
     ],
     props: {
         numArgs: 0,

--- a/src/macros.js
+++ b/src/macros.js
@@ -961,6 +961,31 @@ defineMacro("\\set", "\\bra@set{\\{\\,}{\\mid}{}{\\,\\}}");
 // actuarialangle.dtx
 defineMacro("\\angln", "{\\angl n}");
 
+//////////////////////////////////////////////////////////////////////
+// physics.sty
+
+// This package contains some macros widely useful in physics.
+// https://ctan.math.washington.edu/tex-archive/macros/latex/contrib/physics/physics.pdf
+
+defineMacro("\\abs", "\\lvert{#1}\\rvert");
+defineMacro("\\Abs", "\\Big\\lvert{#1}\\Big\\rvert");
+defineMacro("\\norm", "\\lVert{#1}\\rVert");
+defineMacro("\\Norm", "\\Big\\lVert{#1}\\Big\\rVert");
+defineMacro("\\eval", "\\Big\\vert^{#1}_{#2}");
+defineMacro("\\vb", "\\bold{#1}");
+defineMacro("\\vectorbold", "\\vb{#1}");
+defineMacro("\\vectorarrow", "\\overrightarrow{\\vb{#1}}");
+defineMacro("\\vectorunit", "\\widehat{\\vb{#1}}");
+defineMacro("\\dotproduct", "\\cdot");
+defineMacro("\\crossproduct", "\\times");
+defineMacro("\\innerproduct", "\\mathinner{\\braket{{#1}\\vert{#2}}}");
+defineMacro("\\outerproduct", "\\mathinner{\\ket{#1}\\bra{#2}}");
+defineMacro("\\dd", "\\textnormal{d}");
+defineMacro("\\gradient", "\\mathinner{\\nabla{#1}}");
+defineMacro("\\laplacian", "\\mathinner{\\nabla^2{#1}}");
+defineMacro("\\divergence", "\\mathinner{\\nabla\\dotproduct{#1}}");
+defineMacro("\\curl", "\\mathinner{\\nabla\\crossproduct{#1}}");
+
 // Custom Khan Academy colors, should be moved to an optional package
 defineMacro("\\blue", "\\textcolor{##6495ed}{#1}");
 defineMacro("\\orange", "\\textcolor{##ffa500}{#1}");

--- a/src/macros.js
+++ b/src/macros.js
@@ -971,7 +971,7 @@ defineMacro("\\abs", "\\lvert{#1}\\rvert");
 defineMacro("\\Abs", "\\Big\\lvert{#1}\\Big\\rvert");
 defineMacro("\\norm", "\\lVert{#1}\\rVert");
 defineMacro("\\Norm", "\\Big\\lVert{#1}\\Big\\rVert");
-defineMacro("\\eval", "\\Big\\vert^{#1}_{#2}");
+defineMacro("\\eval", "\\Big\\vert_{#1}^{#2}");
 defineMacro("\\vb", "\\bold{#1}");
 defineMacro("\\vectorbold", "\\vb{#1}");
 defineMacro("\\vectorarrow", "\\overrightarrow{\\vb{#1}}");

--- a/src/macros.js
+++ b/src/macros.js
@@ -978,8 +978,6 @@ defineMacro("\\vectorarrow", "\\overrightarrow{\\vb{#1}}");
 defineMacro("\\vectorunit", "\\widehat{\\vb{#1}}");
 defineMacro("\\dotproduct", "\\cdot");
 defineMacro("\\crossproduct", "\\times");
-defineMacro("\\innerproduct", "\\mathinner{\\braket{{#1}\\vert{#2}}}");
-defineMacro("\\outerproduct", "\\mathinner{\\ket{#1}\\bra{#2}}");
 defineMacro("\\dd", "\\textnormal{d}");
 defineMacro("\\gradient", "\\mathinner{\\nabla{#1}}");
 defineMacro("\\laplacian", "\\mathinner{\\nabla^2{#1}}");


### PR DESCRIPTION
Support commonly used macros from the $\LaTeX$ [physics](https://ctan.org/tex-archive/macros/latex/contrib/physics) package. [Demo](https://imgur.com/a/Uqxevyt).

ops.js (['yarn start' URL](http://localhost:7936/?text=%5Crank%7BA%7D%20%5C%5C%0A%5CRes%7B%28f%2C%20c%29%7D%20%3D%20%5Clim_%7Bz%20%5Cto%20c%7D%28z-c%29f%28z%29%20%5C%5C%0A%5Ctr%7BM%7D%2C%20%5CTr%7BM%7D%2C%20%5Ctrace%7BM%7D)):
| ops     | explanation |
|:--------|:------------|
|`\rank`  | rank of matrices |
|`\Res`   | residue in complex analysis |
|`\tr`, `\Tr`, `\trace` | trace of matrices |

macros.js (['yarn start' URL](http://localhost:7936/?text=%5Cabs%7Ba%7D%2C%20%5CAbs%7B%5Cfrac%7Ba%7D%7Bb%7D%2B1%7D%2C%5Cnorm%7Ba%7D%2C%20%5CNorm%7B%5Cfrac%7Ba%7D%7Bb%7D%2B1%7D%20%5C%5C%0Af%28x%29%5Ceval%7B%5Cinfin%7D%7B1%7D%20%5C%5C%0A%5Calpha_1%5Cvb%7Ba_1%7D%2B%5Calpha_2%5Cvb%7Ba_2%7D%20%5C%5C%0A%5Calpha_1%5Cvectorarrow%7Ba_1%7D%2B%5Calpha_2%5Cvectorarrow%7Ba_2%7D%20%5C%5C%0A%5Calpha_1%5Cvectorunit%7Bu%7D%2B%5Calpha_2%5Cvectorunit%7Bv%7D%20%5C%5C%0A%5Cvb%7Ba%7D%5Cdotproduct%5Cvb%7Bb%7D%2C%20%0A%5Cvb%7Ba%7D%5Ccrossproduct%5Cvb%7Bb%7D%5Ccrossproduct%5Cvb%7Bc%7D%20%5C%5C%0A%5Cdd%7By%7D%3Df%5E%7B%5Cprime%7D%28x%29%5Cdd%7Bx%7D%20%5C%5C%0A%5Cgradient%7B%5Cpsi%7D%2C%20%5Claplacian%7B%5Cpsi%7D%20%5C%5C%0A%5Cdivergence%7BB%7D%20%3D%200%2C%0A%5Ccurl%7BE%7D%20%3D%20-%5Cfrac%7B%5Cpartial%20B%7D%7B%5Cpartial%20t%7D%20)):
| macros     | explanation |
|:--------|:------------|
|`\abs`, `\Abs`| absolute value |
|`\norm`, `\Norm` | norm |
|`\eval` | vertical bar of evaluation limits for integrals |
|`\vb`, `\vectorbold`| vector, bold font |
|`\vectorarrow` | vector, with an arrow |
|`\vectorunit` | unit vector, with a hat |
|`\dotproduct`, `\crossproduct` | dot and cross product of vectors |
|`\dd` | differential |
|`\gradient`, `\laplacian` | gradient and laplacian for scalar fields |
|`\divergence`, `\curl` | divergence and curl for vector fields |

* Already signed CLA.