### PR TITLE
Update where to report vulnerabilities to in the docs

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -18,4 +18,4 @@ with untrusted inputs; refer to [Options](options.md) for more details.
 The error message thrown by KaTeX may contain unescaped LaTeX source code.
 See [Handling Errors](error.md) for more details.
 
-> If you discovered a security issue, please let us know via https://hackerone.com/khanacademy
+> If you discovered a security issue, please let us know via https://github.com/KaTeX/KaTeX/security/advisories


### PR DESCRIPTION
This is a minor change to security.md to link to the Security Advisories within in the KaTeX repo instead of Khan Academy's hackerone.com account.  This should streamline the reporting of vulnerabilities and make it easier for KaTeX maintainers to interact with reporters.