### PR TITLE
Update "No character metrics" documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ whether your spacing matches the spacing that TeX produces.
 
 Once your symbol works, check the JavaScript console to make sure you don't get
 a message like `No character metrics for '_'` when you render your symbol.
-If you do, check out [extract_ttfs.py](metrics/extract_ttfs.py).
+If you do, check out [dockers/fonts](dockers/fonts) which generates fonts and metrics.
 
 #### Adding new functions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ your symbol in TeX surrounded by other different kinds of symbols, and seeing
 whether your spacing matches the spacing that TeX produces.
 
 Once your symbol works, check the JavaScript console to make sure you don't get
-a message like "Can't find character metrics for \_" when you render your symbol.
+a message like `No character metrics for '_'` when you render your symbol.
 If you do, check out [extract_ttfs.py](metrics/extract_ttfs.py).
 
 #### Adding new functions


### PR DESCRIPTION
1. This page didn't appear for me when searching for "No character metrics". I then stumbled onto it, and it's quite useful
2. metrics/extract_ttfs.py does not exist, and it's not the "root" of the metric-generation stuff
