### PR TITLE
docs: New security reporting policy

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -18,4 +18,11 @@ with untrusted inputs; refer to [Options](options.md) for more details.
 The error message thrown by KaTeX may contain unescaped LaTeX source code.
 See [Handling Errors](error.md) for more details.
 
-> If you discovered a security issue, please let us know via https://hackerone.com/khanacademy
+## Reporting a Vulnerability
+
+If you have discovered a potential security issue with KaTeX:
+
+1. Please report the issue privately by emailing [katex-security@mit.edu](mailto:katex-security@mit.edu).
+2. We will create a [GitHub Security Advisory](https://docs.github.com/en/code-security/repository-security-advisories/about-github-security-advisories-for-repositories) and (if desired) invite you as a collaborator for further discussion about the vulnerability and how to fix them. Please let us know your GitHub.com username so that we can add you.
+3. We will evaluate the vulnerability and, if necessary, release a fix and security advisory. We will credit you in the report.
+4. Please do not disclose the vulnerability publicly until after a fix has been released.


### PR DESCRIPTION
**What is the previous behavior before this PR?**
Link to https://hackerone.com/khanacademy, which is awkward to interface with GitHub and not really maintained anymore.

**What is the new behavior after this PR?**
Link to new katex-security@mit.edu email address which will go to a small set of maintainers (currently @edemaine and @kevinbarabash).

I also fleshed out a policy for reporting vulnerabilities, as [recommended by GitHub](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository#about-security-policies). I based the policy roughly on [this template](https://github.com/dec0dOS/amazing-github-template/blob/main/%7B%7Bcookiecutter.repo_slug%7D%7D/docs/SECURITY.md). The policy will automatically appear at https://github.com/KaTeX/KaTeX/security/policy (formatted a bit funny, but seems fine) because our docs happen to use `security.md` for the filename.

Fixes #3709

Replaces #3717