### PR TITLE
fix: \hline after \cr

### DIFF
--- a/src/environments/array.js
+++ b/src/environments/array.js
@@ -39,6 +39,11 @@ function getHLines(parser: Parser): boolean[] {
     const hlineInfo = [];
     parser.consumeSpaces();
     let nxt = parser.fetch().text;
+    if (nxt === "\\relax") { // \relax is an artifact of the \cr macro below
+        parser.consume();
+        parser.consumeSpaces();
+        nxt = parser.fetch().text;
+    }
     while (nxt === "\\hline" || nxt === "\\hdashline") {
         parser.consume();
         hlineInfo.push(nxt === "\\hdashline");

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -1266,6 +1266,7 @@ describe("A begin/end parser", function() {
 
     it("should parse an environment with hlines", function() {
         expect`\begin{matrix}\hline a&b\\ \hline c&d\end{matrix}`.toParse();
+        expect`\begin{matrix}\hline a&b\cr \hline c&d\end{matrix}`.toParse();
         expect`\begin{matrix}\hdashline a&b\\ \hdashline c&d\end{matrix}`.toParse();
     });
 


### PR DESCRIPTION
Support `\hline` when it occurs after a `\cr` within an environment. Fixes #3734.