### PR TITLE
fix: space should prevent optional argument to \\

### DIFF
--- a/src/functions/cr.js
+++ b/src/functions/cr.js
@@ -13,13 +13,13 @@ defineFunction({
     names: ["\\\\"],
     props: {
         numArgs: 0,
-        numOptionalArgs: 1,
-        argTypes: ["size"],
+        numOptionalArgs: 0,
         allowedInText: true,
     },
 
     handler({parser}, args, optArgs) {
-        const size = optArgs[0];
+        const size = parser.gullet.future().text === "[" ?
+            parser.parseSizeGroup(true) : null;
         const newLine = !parser.settings.displayMode ||
             !parser.settings.useStrictBehavior(
                 "newLineInDisplayMode", "In LaTeX, \\\\ or \\newline " +

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -1309,6 +1309,11 @@ describe("A begin/end parser", function() {
         expect`\begin{matrix}a&b\cr[c]&d\end{matrix}`.toParse();
     });
 
+    it("should not treat [ after space as optional argument to \\\\", function() {
+        expect`\begin{matrix}a&b\\ [c]&d\end{matrix}`.toParse();
+        expect`a\\ [b]`.toParse();
+    });
+
     it("should eat a final newline", function() {
         const m3 = getParsed`\begin{matrix}a&b\\ c&d \\ \end{matrix}`[0];
         expect(m3.body).toHaveLength(2);


### PR DESCRIPTION
Fix `src/functions/cr.js`'s definition of `\\` to manually look for an optional argument via `future()` instead of `numOptionalArgs`, so that it does *not* skip over spaces.  This matches the existing behavior of `\\` in `src/environments/array.js` and AMSMath's behavior of `\math@cr` via `\new@ifnextchar`.

Fixes #3745; see that for details.