### PR TITLE
Made backslash escape starting delimiters.

### DIFF
--- a/contrib/auto-render/splitAtDelimiters.js
+++ b/contrib/auto-render/splitAtDelimiters.js
@@ -46,15 +46,24 @@ const splitAtDelimiters = function(text, delimiters) {
         if (index === -1) {
             break;
         }
+
+        const escaped = index > 0 && text[index - 1] === "\\";
         if (index > 0) {
             data.push({
                 type: "text",
-                data: text.slice(0, index),
+                data: text.slice(0, index - (escaped ? 1 : 0)),
             });
             text = text.slice(index); // now text starts with delimiter
         }
         // ... so this always succeeds:
         const i = delimiters.findIndex((delim) => text.startsWith(delim.left));
+
+        if (escaped) {
+            data[data.length - 1].data += text.slice(0, delimiters[i].left.length);
+            text = text.slice(delimiters[i].left.length);
+            continue;
+        }
+
         index = findEndOfMath(delimiters[i].right, text, delimiters[i].left.length);
         if (index === -1) {
             break;

--- a/contrib/auto-render/test/auto-render-spec.js
+++ b/contrib/auto-render/test/auto-render-spec.js
@@ -305,6 +305,24 @@ describe("A delimiter splitter", function() {
                     rawData: "$$boo$$", display: true},
             ]);
     });
+
+    it("correctly escapes start symbols", function() {
+        expect(splitAtDelimiters("test \\$40 for $foobar$$$bla$$\\$$boo",
+            [
+                {left:"$$", right:"$$", display:true},
+                {left:"$", right:"$", display:false},
+            ])).toEqual(
+            [
+                {type: "text", data: "test $"},
+                {type: "text", data: "40 for "},
+                {type: "math", data: "foobar",
+                    rawData: "$foobar$", display: false},
+                {type: "math", data: "bla",
+                    rawData: "$$bla$$", display: true},
+                {type: "text", data: "$$"},
+                {type: "text", data: "boo"},
+            ]);
+    });
 });
 
 describe("Pre-process callback", function() {

--- a/docs/autorender.md
+++ b/docs/autorender.md
@@ -115,6 +115,12 @@ in addition to five auto-render-specific keys:
   ]
   ```
 
+  Note that if a left delimiter is preceded by a backslash (`\`), the backslash
+  is stripped and the delimiter is ignored (math mode is not entered). So `\$40
+  is greater than \$30` gets transformed to `$40 is greater than $30`, if `$` is
+  configured to be a left delimiter. If it is not, the backslashes are left
+  untouched.
+
 - `ignoredTags`: This is a list of DOM node types to ignore when recursing
   through. The default value is
   `["script", "noscript", "style", "textarea", "pre", "code", "option"]`.


### PR DESCRIPTION
<!-- PR title should follow Angular Commit Message Conventions (https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines) -->

**What is the previous behavior before this PR?**

Backslashes before starting delimiters are treated as plain text.

**What is the new behavior after this PR?**

If a left delimiter is preceded by a backslash (`\`), the backslash is stripped and the delimiter is ignored (math mode is not entered). So `\$40 is greater than \$30` gets transformed to `$40 is greater than $30`, if `$` is configured to be a starting delimiter. If it is not, the backslashes are left untouched.

<!-- If this PR contains a breaking change, please uncomment following line -->
BREAKING CHANGE: The only way existing users are affected by this is if they have a backslash **immediately** (no whitespace or anything) followed by a delimiter that enters math mode. I can't think of any scenario where one would want that, and if one still does one can do `\<span></span>$` or `&bsol;$` (or a variety of other methods, zero-width spaces, etc).

<!-- If this PR fixes or closes issues, please uncomment following line and change the issue number -->
Fixes https://github.com/KaTeX/KaTeX/issues/437.
