### PR TITLE
feat(auto-render): add option to ignore escaped special characters outside of LaTeX math mode (#437)

### DIFF
--- a/contrib/auto-render/splitAtDelimiters.js
+++ b/contrib/auto-render/splitAtDelimiters.js
@@ -27,19 +27,38 @@ const findEndOfMath = function(delimiter, text, startIndex) {
     return -1;
 };
 
-const escapeRegex = function(string) {
-    return string.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
+const escapeRegex = function(string, supportEscapedSpecialCharsInText) {
+    if (supportEscapedSpecialCharsInText) {
+        if (string === "$") {
+            /* negative lookbehind to find any dollar not preceded by a
+             backslash */
+            return "(?<!\\\\)\\$";
+        } else if (string === "(") {
+            /* negative lookbehind to find any parenthesis not preceded by a
+             backslash */
+            return "(?<!\\\\)\\(";
+        } else if (string === "\\(") {
+            return "\\\\\\(";
+        } else if (string === "\\$") {
+            return "\\\\\\$";
+        } else {
+            return string.replace(/[-/\\^$*+?.)|[\]{}]/g, "\\$&");
+        }
+    } else {
+        return string.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
+    }
 };
 
 const amsRegex = /^\\begin{/;
 
-const splitAtDelimiters = function(text, delimiters) {
+const splitAtDelimiters = function(text, delimiters,
+    supportEscapedSpecialCharsInText) {
     let index;
     const data = [];
 
-    const regexLeft = new RegExp(
-        "(" + delimiters.map((x) => escapeRegex(x.left)).join("|") + ")"
-    );
+    const regexLeft = new RegExp("(" + delimiters.map((x) =>
+        escapeRegex(x.left, supportEscapedSpecialCharsInText),
+    ).join("|") + ")");
 
     while (true) {
         index = text.search(regexLeft);

--- a/docs/autorender.md
+++ b/docs/autorender.md
@@ -128,6 +128,9 @@ in addition to five auto-render-specific keys:
 - `preProcess`: A callback function, `(math: string) => string`, used to process
   math expressions before rendering.
 
+- `supportEscapedSpecialCharsInText`: `boolean` (default: `false`). If `true`, `\$` are ignored outside of LaTeX math expressions.
+  For example: `Please enjoy this 2\$ coffee and I'll explain why $e = mc^2$.`
+
 The `displayMode` property of the options object is ignored, and is
 instead taken from the `display` key of the corresponding entry in the
 `delimiters` key.


### PR DESCRIPTION
feat(auto-render): add option to ignore escaped special characters outside of LaTeX math mode (#437)

**What is the previous behavior before this PR?**
Some escapable characters were not properly escaped in math LaTeX mode in auto-render.
For instance, in the following LaTeX string: 
$$
\\$100 + \\$100 = \\$200
$$
the "\\$" should be parsed as "$" symbols.

**What is the new behavior after this PR?**
This PR introduces a new option to auto-render:
- `supportEscapedSpecialCharsInText`: `boolean` (default: `false`). If `true`, `\$` are ignored outside of LaTeX math expressions.
  For example: `Please enjoy this 2\$ coffee and I'll explain why $e = mc^2$.`

When set to `true`, it fixes the issue and properly escape those LaTeX escapable characters.
When set to `false`, the existing behavior is kept to avoid breaking existing uses.

The tests have been updated accordingly, and some tests added to show those fixed behaviors.