### PR TITLE
docs: add dark-mode logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# [<img src="https://katex.org/img/katex-logo-black.svg" width="130" alt="KaTeX">](https://katex.org/)
+<h1><a href="https://katex.org/">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://katex.org/img/katex-logo.svg">
+    <img alt="KaTeX" width=130 src="https://katex.org/img/katex-logo-black.svg">
+  </picture>
+</a></h1>
+
 [![npm](https://img.shields.io/npm/v/katex.svg)](https://www.npmjs.com/package/katex)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 [![CI](https://github.com/KaTeX/KaTeX/workflows/CI/badge.svg?branch=main&event=push)](https://github.com/KaTeX/KaTeX/actions?query=workflow%3ACI)


### PR DESCRIPTION
Adds a light logo to header to appear in dark mode so it doesn't appear almost empty.

<!-- PR title should follow Angular Commit Message Conventions (https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines) -->

**What is the previous behavior before this PR?**

Logo virtually disappears if user is browsing in dark mode:

![Screenshot_2023-05-17-07-16-25-80_3aea4af51f236e4932235fdada7d1643](https://github.com/KaTeX/KaTeX/assets/10906554/315793f9-98e3-4367-b2da-31a5b1fede51)

**What is the new behavior after this PR?**

Logo is clearly visible if user is browsing in dark mode:

![Screenshot_2023-05-17-07-29-11-10_3aea4af51f236e4932235fdada7d1643](https://github.com/KaTeX/KaTeX/assets/10906554/904fca54-3d8e-4209-8a49-bd5ce4d8d184)

<!-- If this PR contains a breaking change, please uncomment following line -->
<!-- BREAKING CHANGE: describe its impact and migration methods -->

<!-- If this PR fixes or closes issues, please uncomment following line and change the issue number -->
<!-- Fixes #1, Closes #2 -->