### PR TITLE
specify `position: relative` for `.katex`

### DIFF
--- a/src/katex.less
+++ b/src/katex.less
@@ -8,6 +8,8 @@
 @version: "";
 
 .katex {
+    position: relative;
+
     font: normal 1.21em KaTeX_Main, Times New Roman, serif;
     line-height: 1.2;
 


### PR DESCRIPTION
<!-- PR title should follow Angular Commit Message Conventions (https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines) -->

**What is the previous behavior before this PR?**

The class `.katex-mathml` inside `.katex` has specified `position: absolute`, but since `.katex` has not specified `position: relative`, `.katex-mathml` will keep looking up layer by layer, potentially causing layout chaos.

**What is the new behavior after this PR?**

After specifying `position: relative` for `.katex`, the position of `.katex-mathml` has stabilized.


<!-- If this PR contains a breaking change, please uncomment following line -->
<!-- BREAKING CHANGE: describe its impact and migration methods -->

<!-- If this PR fixes or closes issues, please uncomment following line and change the issue number -->
<!-- Fixes #1, Closes #2 -->
