### PR TITLE
chore(gh-actions): bump GitHub workflow actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         persist-credentials: false # minimize exposure and prevent accidental pushes
 
-    - name: Use Node.js 16
-      uses: actions/setup-node@v3
+    - name: Use Node.js 18
+      uses: actions/setup-node@v4
       with:
-        node-version: '16'
+        node-version: '18'
         cache: yarn
 
     - name: Install dependencies
@@ -52,15 +52,15 @@ jobs:
     needs: test
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         persist-credentials: false
         fetch-depth: 0
 
-    - name: Use Node.js 16
-      uses: actions/setup-node@v3
+    - name: Use Node.js 18
+      uses: actions/setup-node@v4
       with:
-        node-version: '16'
+        node-version: '18'
         cache: yarn
 
     - name: Install dependencies

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/.github/workflows/fonts.yml
+++ b/.github/workflows/fonts.yml
@@ -16,13 +16,13 @@ jobs:
       pull-requests: write # to remove label
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ format('refs/pull/{0}/merge', github.event.pull_request.number) }}
         persist-credentials: false # minimize exposure and prevent accidental pushes
 
     - name: Remove label
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
@@ -35,7 +35,7 @@ jobs:
 
     - name: Check image
       id: check-image
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         # https://github.community/t/github-token-has-no-access-to-new-container-rest-apis/170395
         github-token: ${{ secrets.GH_PACKAGES_TOKEN }}
@@ -63,7 +63,7 @@ jobs:
 
     - name: Login to GitHub Container Registry
       if: ${{ !fromJSON(steps.check-image.outputs.exists) }}
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: KaTeX-bot
@@ -72,7 +72,7 @@ jobs:
 
     - name: Build and push
       if: ${{ !fromJSON(steps.check-image.outputs.exists) }}
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v5
       with:
         context: dockers/fonts
         tags: ${{ steps.check-image.outputs.result }}
@@ -89,7 +89,7 @@ jobs:
         password: ${{ secrets.GH_PACKAGES_TOKEN }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ format('refs/pull/{0}/merge', github.event.pull_request.number) }}
         persist-credentials: false
@@ -110,12 +110,12 @@ jobs:
         printf '[diff "font"]\n\tbinary = true\n\ttextconv = ttx -q -i -o -' >> ~/.gitconfig
         git diff --exit-code
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: fonts
         path: fonts
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: metrics

--- a/.github/workflows/screenshotter.yml
+++ b/.github/workflows/screenshotter.yml
@@ -34,15 +34,15 @@ jobs:
           BROWSERSTACK_ACCESS_KEY: ${{ matrix.browserstack && secrets.BROWSERSTACK_ACCESS_KEY }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
         persist-credentials: false # do not persist credentials
 
-    - name: Use Node.js 14
-      uses: actions/setup-node@v3
+    - name: Use Node.js 18
+      uses: actions/setup-node@v4
       with:
-        node-version: '14'
+        node-version: '18'
 
     - name: Restore cached dependencies # restore only to prevent cache poisoning
       uses: ylemkimon/cache-restore@v2
@@ -82,12 +82,12 @@ jobs:
         docker logs ${{ job.services.selenium.id }}
         echo "::$TOKEN::"
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: new-${{ matrix.browser }}
         path: test/screenshotter/new
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: diff-${{ matrix.browser }}


### PR DESCRIPTION
This PR bumps GitHub workflow actions to their latest versions. it also updates node version used in these workflows.