### PR TITLE
fix(css): fefault to font-display: swap; closes #2242

### DIFF
--- a/src/fonts.less
+++ b/src/fonts.less
@@ -2,6 +2,7 @@
 @use-ttf: true;
 @use-woff: true;
 @use-woff2: true;
+@font-display: swap;
 
 .use-woff2(@family, @family-suffix) when (@use-woff2 = true) {
     src+: url('@{font-folder}/KaTeX_@{family}-@{family-suffix}.woff2') format('woff2')
@@ -37,6 +38,7 @@
         .use-ttf(@family, @suffix);
         font-weight: @weight;
         font-style: @style;
+        font-display: @font-display;
     }
 }
 


### PR DESCRIPTION
Google fonts seem to default to swap, and mixing them with katex makes it so that katex is invisible briefly on page load, unlike google fonts which make use of fallbacks while loading. This would unify their behavior.

Ideally there'd be an option for this, and a ?display=swap in the cdn url (like google fonts: https://developers.google.com/fonts/docs/css2#use_font-display), but I don't know if jsdelivr supports that!

**What is the previous behavior before this PR?**
Katex fonts would be invisible until loaded

**What is the new behavior after this PR?**
Katex fonts will now render a fallback until fonts have been loaded

BREAKING CHANGE: changes font loading behavior to font-display: swap,
which means equations will render a fallback before loaded
instead of being invisible

Closes #2242 