### PR TITLE
chore: upgrade actions/checkout action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         persist-credentials: false # minimize exposure and prevent accidental pushes
 
@@ -55,7 +55,7 @@ jobs:
     needs: test
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         persist-credentials: false
         fetch-depth: 0

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/.github/workflows/fonts.yml
+++ b/.github/workflows/fonts.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write # to remove label
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ format('refs/pull/{0}/merge', github.event.pull_request.number) }}
         persist-credentials: false # minimize exposure and prevent accidental pushes
@@ -89,7 +89,7 @@ jobs:
         password: ${{ secrets.GH_PACKAGES_TOKEN }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ format('refs/pull/{0}/merge', github.event.pull_request.number) }}
         persist-credentials: false

--- a/.github/workflows/screenshotter.yml
+++ b/.github/workflows/screenshotter.yml
@@ -70,7 +70,7 @@ jobs:
           -w /code \
           -e CI=true \
           node:20 \
-          /bin/bash -c 'yarn node dockers/screenshotter/screenshotter.js -b ${{ matrix.browser }} --verify --diff --new --katex-ip $HOSTNAME ${{ matrix.browserstack && format('--selenium-proxy http://selenium:4445/build --browserstack --selenium-capabilities ''\''''{0}''\', toJson(matrix.browserstack)) || '--selenium-ip selenium' }}'
+          /bin/bash -c 'corepack enable && yarn node dockers/screenshotter/screenshotter.js -b ${{ matrix.browser }} --verify --diff --new --katex-ip $HOSTNAME ${{ matrix.browserstack && format('--selenium-proxy http://selenium:4445/build --browserstack --selenium-capabilities ''\''''{0}''\', toJson(matrix.browserstack)) || '--selenium-ip selenium' }}'
         echo "::$TOKEN::"
       timeout-minutes: 10
 

--- a/.github/workflows/screenshotter.yml
+++ b/.github/workflows/screenshotter.yml
@@ -47,16 +47,12 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '20'
+        cache: yarn
 
-    - name: Restore cached dependencies # restore only to prevent cache poisoning
-      uses: ylemkimon/cache-restore@v2
-      with:
-        path: |
-          .yarn/cache
-          .pnp.js
-        key: yarn-deps-v1-${{ hashFiles('yarn.lock') }}
-        restore-keys: |
-          yarn-deps-v1-
+    - name: Install dependencies
+      run: yarn --immutable
+      env:
+        YARN_ENABLE_SCRIPTS: 0 # disable postinstall scripts
 
     - name: Run screenshotter
       run: |
@@ -72,10 +68,9 @@ jobs:
           -v "$PWD:/code" \
           -v "$PWD/.git:/code/.git:ro" \
           -w /code \
-          -e YARN_ENABLE_SCRIPTS=0 \
           -e CI=true \
           node:20 \
-          /bin/bash -c 'yarn --immutable && yarn node dockers/screenshotter/screenshotter.js -b ${{ matrix.browser }} --verify --diff --new --katex-ip $HOSTNAME ${{ matrix.browserstack && format('--selenium-proxy http://selenium:4445/build --browserstack --selenium-capabilities ''\''''{0}''\', toJson(matrix.browserstack)) || '--selenium-ip selenium' }}'
+          /bin/bash -c 'yarn node dockers/screenshotter/screenshotter.js -b ${{ matrix.browser }} --verify --diff --new --katex-ip $HOSTNAME ${{ matrix.browserstack && format('--selenium-proxy http://selenium:4445/build --browserstack --selenium-capabilities ''\''''{0}''\', toJson(matrix.browserstack)) || '--selenium-ip selenium' }}'
         echo "::$TOKEN::"
       timeout-minutes: 10
 

--- a/.github/workflows/screenshotter.yml
+++ b/.github/workflows/screenshotter.yml
@@ -47,7 +47,16 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '20'
-        cache: yarn
+
+    - name: Restore cached dependencies # restore only to prevent cache poisoning
+      uses: ylemkimon/cache-restore@v2
+      with:
+        path: |
+          .yarn/cache
+          .pnp.js
+        key: yarn-deps-v1-${{ hashFiles('yarn.lock') }}
+        restore-keys: |
+          yarn-deps-v1-
 
     - name: Run screenshotter
       run: |

--- a/.github/workflows/screenshotter.yml
+++ b/.github/workflows/screenshotter.yml
@@ -35,7 +35,7 @@ jobs:
           BROWSERSTACK_ACCESS_KEY: ${{ matrix.browserstack && secrets.BROWSERSTACK_ACCESS_KEY }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
         persist-credentials: false # do not persist credentials


### PR DESCRIPTION
Removes warning about Node 16 from every CI job

<!-- PR title should follow Angular Commit Message Conventions (https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines) -->

**What is the previous behavior before this PR?**

![image](https://github.com/KaTeX/KaTeX/assets/2218736/1880f3f1-1f90-4d71-8023-bba83057b1bb)

**What is the new behavior after this PR?**

Warnings should be removed.

---

Also, we're getting this error message from screenshotters:

![image](https://github.com/KaTeX/KaTeX/assets/2218736/f449264a-851a-4f7a-98b1-c413808034b5)
