### PR TITLE
chore: use tagged literals in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ website/.yarn/*
 fonts.tar
 fonts.tar.gz
 temp/
+.idea/

--- a/docs/api.md
+++ b/docs/api.md
@@ -13,7 +13,7 @@ katex.render("c = \\pm\\sqrt{a^2 + b^2}", element, {
 
 To avoid escaping the backslash (double backslash), you can use
 [`String.raw`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/raw)
-(but beware that `${`, `\u` and `\x` may still need escaping):
+(but beware that escaping `${` and backtick is not possible while using `String.raw`).
 ```js
 katex.render(String.raw`c = \pm\sqrt{a^2 + b^2}`, element, {
     throwOnError: false

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -812,7 +812,7 @@ describe("A text parser", function() {
 describe("A texvc builder", function() {
     it("should not fail", function() {
         expect`\lang\N\darr\R\dArr\Z\Darr\alef\rang`.toBuild();
-        expect("\\alefsym\\uarr\\Alpha\\uArr\\Beta\\Uarr\\Chi").toBuild();
+        expect`\alefsym\uarr\Alpha\uArr\Beta\Uarr\Chi`.toBuild();
         expect`\clubs\diamonds\hearts\spades\cnums\Complex`.toBuild();
         expect`\Dagger\empty\harr\Epsilon\hArr\Eta\Harr\exist`.toBuild();
         expect`\image\larr\infin\lArr\Iota\Larr\isin\Kappa`.toBuild();
@@ -2211,7 +2211,7 @@ describe("An accent parser", function() {
         expect`\vec{x^2}`.toParse();
         expect`\vec{x}^2`.toParse();
         expect`\vec x`.toParse();
-        expect("\\underbar{X}").toParse();
+        expect`\underbar{X}`.toParse();
     });
 
     it("should produce accents", function() {
@@ -2299,20 +2299,20 @@ describe("A stretchy MathML builder", function() {
 
 describe("An under-accent parser", function() {
     it("should not fail", function() {
-        expect("\\underrightarrow{x}").toParse();
-        expect("\\underrightarrow{x^2}").toParse();
-        expect("\\underrightarrow{x}^2").toParse();
-        expect("\\underrightarrow x").toParse();
+        expect`\underrightarrow{x}`.toParse();
+        expect`\underrightarrow{x^2}`.toParse();
+        expect`\underrightarrow{x}^2`.toParse();
+        expect`\underrightarrow x`.toParse();
     });
 
     it("should produce accentUnder", function() {
-        const parse = getParsed("\\underrightarrow x")[0];
+        const parse = getParsed`\underrightarrow x`[0];
 
         expect(parse.type).toEqual("accentUnder");
     });
 
     it("should be grouped more tightly than supsubs", function() {
-        const parse = getParsed("\\underrightarrow x^2")[0];
+        const parse = getParsed`\underrightarrow x^2`[0];
 
         expect(parse.type).toEqual("supsub");
     });
@@ -2320,18 +2320,18 @@ describe("An under-accent parser", function() {
 
 describe("An under-accent builder", function() {
     it("should not fail", function() {
-        expect("\\underrightarrow{x}").toBuild();
-        expect("\\underrightarrow{x}^2").toBuild();
-        expect("\\underrightarrow{x}_2").toBuild();
-        expect("\\underrightarrow{x}_2^2").toBuild();
+        expect`\underrightarrow{x}`.toBuild();
+        expect`\underrightarrow{x}^2`.toBuild();
+        expect`\underrightarrow{x}_2`.toBuild();
+        expect`\underrightarrow{x}_2^2`.toBuild();
     });
 
     it("should produce mords", function() {
-        expect(getBuilt("\\underrightarrow x")[0].classes).toContain("mord");
-        expect(getBuilt("\\underrightarrow +")[0].classes).toContain("mord");
-        expect(getBuilt("\\underrightarrow +")[0].classes).not.toContain("mbin");
-        expect(getBuilt("\\underrightarrow )^2")[0].classes).toContain("mord");
-        expect(getBuilt("\\underrightarrow )^2")[0].classes)
+        expect(getBuilt`\underrightarrow x`[0].classes).toContain("mord");
+        expect(getBuilt`\underrightarrow +`[0].classes).toContain("mord");
+        expect(getBuilt`\underrightarrow +`[0].classes).not.toContain("mbin");
+        expect(getBuilt`\underrightarrow )^2`[0].classes).toContain("mord");
+        expect(getBuilt`\underrightarrow )^2`[0].classes)
             .not.toContain("mclose");
     });
 });
@@ -2383,8 +2383,8 @@ describe("A horizontal brace parser", function() {
         expect`\overbrace{x^2}`.toParse();
         expect`\overbrace{x}^2`.toParse();
         expect`\overbrace x`.toParse();
-        expect("\\underbrace{x}_2").toParse();
-        expect("\\underbrace{x}_2^2").toParse();
+        expect`\underbrace{x}_2`.toParse();
+        expect`\underbrace{x}_2^2`.toParse();
     });
 
     it("should produce horizBrace", function() {
@@ -2404,8 +2404,8 @@ describe("A horizontal brace builder", function() {
     it("should not fail", function() {
         expect`\overbrace{x}`.toBuild();
         expect`\overbrace{x}^2`.toBuild();
-        expect("\\underbrace{x}_2").toBuild();
-        expect("\\underbrace{x}_2^2").toBuild();
+        expect`\underbrace{x}_2`.toBuild();
+        expect`\underbrace{x}_2^2`.toBuild();
     });
 
     it("should produce mords", function() {
@@ -2916,29 +2916,27 @@ describe("operatorname support", function() {
 });
 
 describe("href and url commands", function() {
-    // We can't use raw strings for \url because \u is for Unicode escapes.
-
     it("should parse its input", function() {
         expect`\href{http://example.com/}{\sin}`.toBuild(trustSettings);
-        expect("\\url{http://example.com/}").toBuild(trustSettings);
+        expect`\url{http://example.com/}`.toBuild(trustSettings);
     });
 
     it("should allow empty URLs", function() {
         expect`\href{}{example here}`.toBuild(trustSettings);
-        expect("\\url{}").toBuild(trustSettings);
+        expect`\url{}`.toBuild(trustSettings);
     });
 
     it("should allow single-character URLs", () => {
         expect`\href%end`.toParseLike("\\href{%}end", trustSettings);
-        expect("\\url%end").toParseLike("\\url{%}end", trustSettings);
+        expect`\url%end`.toParseLike("\\url{%}end", trustSettings);
         expect("\\url%%end\n").toParseLike("\\url{%}", trustSettings);
-        expect("\\url end").toParseLike("\\url{e}nd", trustSettings);
-        expect("\\url%end").toParseLike("\\url {%}end", trustSettings);
+        expect`\url end`.toParseLike("\\url{e}nd", trustSettings);
+        expect`\url%end`.toParseLike("\\url {%}end", trustSettings);
     });
 
     it("should allow spaces single-character URLs", () => {
         expect`\href %end`.toParseLike("\\href{%}end", trustSettings);
-        expect("\\url %end").toParseLike("\\url{%}end", trustSettings);
+        expect`\url %end`.toParseLike("\\url{%}end", trustSettings);
     });
 
     it("should allow letters [#$%&~_^] without escaping", function() {
@@ -2960,8 +2958,8 @@ describe("href and url commands", function() {
     it("should not allow unbalanced brace(s) in url", function() {
         expect`\href{http://example.com/{a}{bar}`.not.toParse();
         expect`\href{http://example.com/}a}{bar}`.not.toParse();
-        expect`\\url{http://example.com/{a}`.not.toParse();
-        expect`\\url{http://example.com/}a}`.not.toParse();
+        expect`\url{http://example.com/{a}`.not.toParse();
+        expect`\url{http://example.com/}a}`.not.toParse();
     });
 
     it("should allow escape for letters [#$%&~_^{}]", function() {
@@ -3322,7 +3320,7 @@ describe("A macro expander", function() {
 
     it("should build \\overset and \\underset", function() {
         expect`\overset{f}{\rightarrow} Y`.toBuild();
-        expect("\\underset{f}{\\rightarrow} Y").toBuild();
+        expect`\underset{f}{\rightarrow} Y`.toBuild();
     });
 
     it("should build \\iff, \\implies, \\impliedby", function() {

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -104,8 +104,8 @@ describe("A rel parser", function() {
 
 describe("A mathinner parser", function() {
     it("should not fail", function() {
-        expect("\\mathinner{\\langle{\\psi}\\rangle}").toParse();
-        expect("\\frac 1 {\\mathinner{\\langle{\\psi}\\rangle}}").toParse();
+        expect`\mathinner{\langle{\psi}\rangle}`.toParse();
+        expect`\frac 1 {\mathinner{\langle{\psi}\rangle}}`.toParse();
     });
 
     it("should return one group, not a fragment", function() {
@@ -278,7 +278,7 @@ describe("A subscript and superscript parser", function() {
     });
 
     it("should work with Unicode (sub|super)script characters", function() {
-        expect`A² + B²⁺³ + ¹²C + E₂³ + F₂₊₃`.toParseLike("A^{2} + B^{2+3} + ^{12}C + E_{2}^{3} + F_{2+3}");
+        expect`A² + B²⁺³ + ¹²C + E₂³ + F₂₊₃`.toParseLike`A^{2} + B^{2+3} + ^{12}C + E_{2}^{3} + F_{2+3}`;
     });
 });
 
@@ -654,24 +654,24 @@ describe("An over/brace/brack parser", function() {
 
 describe("A genfrac builder", function() {
     it("should not fail", function() {
-        expect("\\frac{x}{y}").toBuild();
-        expect("\\dfrac{x}{y}").toBuild();
-        expect("\\tfrac{x}{y}").toBuild();
-        expect("\\cfrac{x}{y}").toBuild();
-        expect("\\genfrac ( ] {0.06em}{0}{a}{b+c}").toBuild();
-        expect("\\genfrac ( ] {0.8pt}{}{a}{b+c}").toBuild();
-        expect("\\genfrac {} {} {0.8pt}{}{a}{b+c}").toBuild();
-        expect("\\genfrac [ {} {0.8pt}{}{a}{b+c}").toBuild();
+        expect`\frac{x}{y}`.toBuild();
+        expect`\dfrac{x}{y}`.toBuild();
+        expect`\tfrac{x}{y}`.toBuild();
+        expect`\cfrac{x}{y}`.toBuild();
+        expect`\genfrac ( ] {0.06em}{0}{a}{b+c}`.toBuild();
+        expect`\genfrac ( ] {0.8pt}{}{a}{b+c}`.toBuild();
+        expect`\genfrac {} {} {0.8pt}{}{a}{b+c}`.toBuild();
+        expect`\genfrac [ {} {0.8pt}{}{a}{b+c}`.toBuild();
     });
 });
 
 describe("A infix builder", function() {
     it("should not fail", function() {
-        expect("a \\over b").toBuild();
-        expect("a \\atop b").toBuild();
-        expect("a \\choose b").toBuild();
-        expect("a \\brace b").toBuild();
-        expect("a \\brack b").toBuild();
+        expect`a \over b`.toBuild();
+        expect`a \atop b`.toBuild();
+        expect`a \choose b`.toBuild();
+        expect`a \brace b`.toBuild();
+        expect`a \brack b`.toBuild();
     });
 });
 
@@ -748,7 +748,7 @@ describe("A text parser", function() {
     });
 
     it("should handle backslash followed by newline", () => {
-        expect("\\text{\\ \t\r \n \t\r  }").toParseLike("\\text{\\ }");
+        expect("\\text{\\ \t\r \n \t\r  }").toParseLike`\text{\ }`;
     });
 
     it("should accept math mode tokens after its argument", function() {
@@ -811,15 +811,15 @@ describe("A text parser", function() {
 
 describe("A texvc builder", function() {
     it("should not fail", function() {
-        expect("\\lang\\N\\darr\\R\\dArr\\Z\\Darr\\alef\\rang").toBuild();
-        expect("\\alefsym\\uarr\\Alpha\\uArr\\Beta\\Uarr\\Chi").toBuild();
-        expect("\\clubs\\diamonds\\hearts\\spades\\cnums\\Complex").toBuild();
-        expect("\\Dagger\\empty\\harr\\Epsilon\\hArr\\Eta\\Harr\\exist").toBuild();
-        expect("\\image\\larr\\infin\\lArr\\Iota\\Larr\\isin\\Kappa").toBuild();
-        expect("\\Mu\\lrarr\\natnums\\lrArr\\Nu\\Lrarr\\Omicron").toBuild();
-        expect("\\real\\rarr\\plusmn\\rArr\\reals\\Rarr\\Reals\\Rho").toBuild();
-        expect("\\text{\\sect}\\sdot\\sub\\sube\\supe").toBuild();
-        expect("\\Tau\\thetasym\\weierp\\Zeta").toBuild();
+        expect`\lang\N\darr\R\dArr\Z\Darr\alef\rang`.toBuild();
+        expect`\alefsym\uarr\Alpha\uArr\Beta\Uarr\Chi`.toBuild();
+        expect`\clubs\diamonds\hearts\spades\cnums\Complex`.toBuild();
+        expect`\Dagger\empty\harr\Epsilon\hArr\Eta\Harr\exist`.toBuild();
+        expect`\image\larr\infin\lArr\Iota\Larr\isin\Kappa`.toBuild();
+        expect`\Mu\lrarr\natnums\lrArr\Nu\Lrarr\Omicron`.toBuild();
+        expect`\real\rarr\plusmn\rArr\reals\Rarr\Reals\Rho`.toBuild();
+        expect`\text{\sect}\sdot\sub\sube\supe`.toBuild();
+        expect`\Tau\thetasym\weierp\Zeta`.toBuild();
     });
 });
 
@@ -900,7 +900,7 @@ describe("A color parser", function() {
 });
 
 describe("A tie parser", function() {
-    const mathTie = "a~b";
+    const mathTie = `a~b`;
     const textTie = r`\text{a~ b}`;
 
     it("should parse ties in math mode", function() {
@@ -1161,8 +1161,7 @@ describe("A non-braced kern parser", function() {
     });
 
     it("should handle whitespace", function() {
-        const abKern = "a\\mkern\t-\r1  \n mu\nb";
-        const abParse = getParsed(abKern);
+        const abParse = getParsed("a\\mkern\t-\r1  \n mu\nb");
 
         expect(abParse).toHaveLength(3);
         expect(abParse[0].text).toEqual("a");
@@ -1326,14 +1325,14 @@ describe("A begin/end parser", function() {
     });
 
     it("should allow an optional argument in {matrix*} and company.", function() {
-        expect("\\begin{matrix*}[r] a & -1 \\\\ -1 & d \\end{matrix*}").toBuild();
-        expect("\\begin{pmatrix*}[r] a & -1 \\\\ -1 & d \\end{pmatrix*}").toBuild();
-        expect("\\begin{bmatrix*}[r] a & -1 \\\\ -1 & d \\end{bmatrix*}").toBuild();
-        expect("\\begin{Bmatrix*}[r] a & -1 \\\\ -1 & d \\end{Bmatrix*}").toBuild();
-        expect("\\begin{vmatrix*}[r] a & -1 \\\\ -1 & d \\end{vmatrix*}").toBuild();
-        expect("\\begin{Vmatrix*}[r] a & -1 \\\\ -1 & d \\end{Vmatrix*}").toBuild();
-        expect("\\begin{matrix*} a & -1 \\\\ -1 & d \\end{matrix*}").toBuild();
-        expect("\\begin{matrix*}[] a & -1 \\\\ -1 & d \\end{matrix*}").not.toParse();
+        expect`\begin{matrix*}[r] a & -1 \\ -1 & d \end{matrix*}`.toBuild();
+        expect`\begin{pmatrix*}[r] a & -1 \\ -1 & d \end{pmatrix*}`.toBuild();
+        expect`\begin{bmatrix*}[r] a & -1 \\ -1 & d \end{bmatrix*}`.toBuild();
+        expect`\begin{Bmatrix*}[r] a & -1 \\ -1 & d \end{Bmatrix*}`.toBuild();
+        expect`\begin{vmatrix*}[r] a & -1 \\ -1 & d \end{vmatrix*}`.toBuild();
+        expect`\begin{Vmatrix*}[r] a & -1 \\ -1 & d \end{Vmatrix*}`.toBuild();
+        expect`\begin{matrix*} a & -1 \\ -1 & d \end{matrix*}`.toBuild();
+        expect`\begin{matrix*}[] a & -1 \\ -1 & d \end{matrix*}`.not.toParse();
     });
 
     it("should allow blank columns", () => {
@@ -1363,16 +1362,16 @@ describe("A sqrt parser", function() {
     });
 
     it("should build sized square roots", function() {
-        expect("\\Large\\sqrt[3]{x}").toBuild();
+        expect`\Large\sqrt[3]{x}`.toBuild();
     });
 
     it("should expand argument if optional argument doesn't exist", function() {
-        expect("\\sqrt\\foo").toParseLike("\\sqrt123",
+        expect`\sqrt\foo`.toParseLike("\\sqrt123",
             new Settings({macros: {"\\foo": "123"}}));
     });
 
     it("should not expand argument if optional argument exists", function() {
-        expect("\\sqrt[2]\\foo").toParseLike("\\sqrt[2]{123}",
+        expect`\sqrt[2]\foo`.toParseLike("\\sqrt[2]{123}",
             new Settings({macros: {"\\foo": "123"}}));
     });
 });
@@ -1523,18 +1522,18 @@ describe("A TeX-compliant parser", function() {
 
 describe("An op symbol builder", function() {
     it("should not fail", function() {
-        expect("\\int_i^n").toBuild();
-        expect("\\iint_i^n").toBuild();
-        expect("\\iiint_i^n").toBuild();
-        expect("\\int\nolimits_i^n").toBuild();
-        expect("\\iint\nolimits_i^n").toBuild();
-        expect("\\iiint\nolimits_i^n").toBuild();
-        expect("\\oint_i^n").toBuild();
-        expect("\\oiint_i^n").toBuild();
-        expect("\\oiiint_i^n").toBuild();
-        expect("\\oint\nolimits_i^n").toBuild();
-        expect("\\oiint\nolimits_i^n").toBuild();
-        expect("\\oiiint\nolimits_i^n").toBuild();
+        expect`\int_i^n`.toBuild();
+        expect`\iint_i^n`.toBuild();
+        expect`\iiint_i^n`.toBuild();
+        expect`\int\nolimits_i^n`.toBuild();
+        expect`\iint\nolimits_i^n`.toBuild();
+        expect`\iiint\nolimits_i^n`.toBuild();
+        expect`\oint_i^n`.toBuild();
+        expect`\oiint_i^n`.toBuild();
+        expect`\oiiint_i^n`.toBuild();
+        expect`\oint\nolimits_i^n`.toBuild();
+        expect`\oiint\nolimits_i^n`.toBuild();
+        expect`\oiiint\nolimits_i^n`.toBuild();
     });
 });
 
@@ -1671,42 +1670,42 @@ describe("A font parser", function() {
 
 describe("A \\pmb builder", function() {
     it("should not fail", function() {
-        expect("\\pmb{\\mu}").toBuild();
-        expect("\\pmb{=}").toBuild();
-        expect("\\pmb{+}").toBuild();
-        expect("\\pmb{\\frac{x^2}{x_1}}").toBuild();
-        expect("\\pmb{}").toBuild();
-        expect("\\def\\x{1}\\pmb{\\x\\def\\x{2}}").toParseLike("\\pmb{1}");
+        expect`\pmb{\\mu}`.toBuild();
+        expect`\pmb{=}`.toBuild();
+        expect`\pmb{+}`.toBuild();
+        expect`\pmb{\\frac{x^2}{x_1}}`.toBuild();
+        expect`\pmb{}`.toBuild();
+        expect`\def\x{1}\pmb{\x\def\x{2}}`.toParseLike`\pmb{1}`;
     });
 });
 
 describe("A raise parser", function() {
     it("should parse and build text in \\raisebox", function() {
-        expect("\\raisebox{5pt}{text}").toBuild(strictSettings);
-        expect("\\raisebox{-5pt}{text}").toBuild(strictSettings);
+        expect`\raisebox{5pt}{text}`.toBuild(strictSettings);
+        expect`\raisebox{-5pt}{text}`.toBuild(strictSettings);
     });
 
     it("should parse and build math in non-strict \\vcenter", function() {
-        expect("\\vcenter{\\frac a b}").toBuild(nonstrictSettings);
+        expect`\vcenter{\frac a b}`.toBuild(nonstrictSettings);
     });
 
     it("should fail to parse math in \\raisebox", function() {
-        expect("\\raisebox{5pt}{\\frac a b}").not.toParse(nonstrictSettings);
-        expect("\\raisebox{-5pt}{\\frac a b}").not.toParse(nonstrictSettings);
+        expect`\raisebox{5pt}{\frac a b}`.not.toParse(nonstrictSettings);
+        expect`\raisebox{-5pt}{\frac a b}`.not.toParse(nonstrictSettings);
     });
 
     it("should fail to parse math in an \\hbox", function() {
-        expect("\\hbox{\\frac a b}").not.toParse(nonstrictSettings);
+        expect`\hbox{\frac a b}`.not.toParse(nonstrictSettings);
     });
 
     it("should fail to build, given an unbraced length", function() {
-        expect("\\raisebox5pt{text}").not.toBuild(strictSettings);
-        expect("\\raisebox-5pt{text}").not.toBuild(strictSettings);
+        expect`\raisebox5pt{text}`.not.toBuild(strictSettings);
+        expect`\raisebox-5pt{text}`.not.toBuild(strictSettings);
     });
 
 
     it("should build math in an hbox when math mode is set", function() {
-        expect("a + \\vcenter{\\hbox{$\\frac{\\frac a b}c$}}").toBuild(strictSettings);
+        expect`a + \vcenter{\hbox{$\frac{\frac a b}c$}}`.toBuild(strictSettings);
     });
 });
 
@@ -2300,20 +2299,20 @@ describe("A stretchy MathML builder", function() {
 
 describe("An under-accent parser", function() {
     it("should not fail", function() {
-        expect("\\underrightarrow{x}").toParse();
-        expect("\\underrightarrow{x^2}").toParse();
-        expect("\\underrightarrow{x}^2").toParse();
-        expect("\\underrightarrow x").toParse();
+        expect`\underrightarrow{x}`.toParse();
+        expect`\underrightarrow{x^2}`.toParse();
+        expect`\underrightarrow{x}^2`.toParse();
+        expect`\underrightarrow x`.toParse();
     });
 
     it("should produce accentUnder", function() {
-        const parse = getParsed("\\underrightarrow x")[0];
+        const parse = getParsed`\underrightarrow x`[0];
 
         expect(parse.type).toEqual("accentUnder");
     });
 
     it("should be grouped more tightly than supsubs", function() {
-        const parse = getParsed("\\underrightarrow x^2")[0];
+        const parse = getParsed`\underrightarrow x^2`[0];
 
         expect(parse.type).toEqual("supsub");
     });
@@ -2321,38 +2320,38 @@ describe("An under-accent parser", function() {
 
 describe("An under-accent builder", function() {
     it("should not fail", function() {
-        expect("\\underrightarrow{x}").toBuild();
-        expect("\\underrightarrow{x}^2").toBuild();
-        expect("\\underrightarrow{x}_2").toBuild();
-        expect("\\underrightarrow{x}_2^2").toBuild();
+        expect`\underrightarrow{x}`.toBuild();
+        expect`\underrightarrow{x}^2`.toBuild();
+        expect`\underrightarrow{x}_2`.toBuild();
+        expect`\underrightarrow{x}_2^2`.toBuild();
     });
 
     it("should produce mords", function() {
-        expect(getBuilt("\\underrightarrow x")[0].classes).toContain("mord");
-        expect(getBuilt("\\underrightarrow +")[0].classes).toContain("mord");
-        expect(getBuilt("\\underrightarrow +")[0].classes).not.toContain("mbin");
-        expect(getBuilt("\\underrightarrow )^2")[0].classes).toContain("mord");
-        expect(getBuilt("\\underrightarrow )^2")[0].classes).not.toContain("mclose");
+        expect(getBuilt`\underrightarrow x`[0].classes).toContain("mord");
+        expect(getBuilt`\underrightarrow +`[0].classes).toContain("mord");
+        expect(getBuilt`\underrightarrow +`[0].classes).not.toContain("mbin");
+        expect(getBuilt`\underrightarrow )^2`[0].classes).toContain("mord");
+        expect(getBuilt`\underrightarrow )^2`[0].classes).not.toContain("mclose");
     });
 });
 
 describe("An extensible arrow parser", function() {
     it("should not fail", function() {
-        expect("\\xrightarrow{x}").toParse();
-        expect("\\xrightarrow{x^2}").toParse();
-        expect("\\xrightarrow{x}^2").toParse();
-        expect("\\xrightarrow x").toParse();
-        expect("\\xrightarrow[under]{over}").toParse();
+        expect`\xrightarrow{x}`.toParse();
+        expect`\xrightarrow{x^2}`.toParse();
+        expect`\xrightarrow{x}^2`.toParse();
+        expect`\xrightarrow x`.toParse();
+        expect`\xrightarrow[under]{over}`.toParse();
     });
 
     it("should produce xArrow", function() {
-        const parse = getParsed("\\xrightarrow x")[0];
+        const parse = getParsed`\xrightarrow x`[0];
 
         expect(parse.type).toEqual("xArrow");
     });
 
     it("should be grouped more tightly than supsubs", function() {
-        const parse = getParsed("\\xrightarrow x^2")[0];
+        const parse = getParsed`\xrightarrow x^2`[0];
 
         expect(parse.type).toEqual("supsub");
     });
@@ -2360,20 +2359,20 @@ describe("An extensible arrow parser", function() {
 
 describe("An extensible arrow builder", function() {
     it("should not fail", function() {
-        expect("\\xrightarrow{x}").toBuild();
-        expect("\\xrightarrow{x}^2").toBuild();
-        expect("\\xrightarrow{x}_2").toBuild();
-        expect("\\xrightarrow{x}_2^2").toBuild();
-        expect("\\xrightarrow[under]{over}").toBuild();
+        expect`\xrightarrow{x}`.toBuild();
+        expect`\xrightarrow{x}^2`.toBuild();
+        expect`\xrightarrow{x}_2`.toBuild();
+        expect`\xrightarrow{x}_2^2`.toBuild();
+        expect`\xrightarrow[under]{over}`.toBuild();
     });
 
     it("should produce mrell", function() {
-        expect(getBuilt("\\xrightarrow x")[0].classes).toContain("mrel");
-        expect(getBuilt("\\xrightarrow [under]{over}")[0].classes).toContain("mrel");
-        expect(getBuilt("\\xrightarrow +")[0].classes).toContain("mrel");
-        expect(getBuilt("\\xrightarrow +")[0].classes).not.toContain("mbin");
-        expect(getBuilt("\\xrightarrow )^2")[0].classes).toContain("mrel");
-        expect(getBuilt("\\xrightarrow )^2")[0].classes).not.toContain("mclose");
+        expect(getBuilt`\xrightarrow x`[0].classes).toContain("mrel");
+        expect(getBuilt`\xrightarrow [under]{over}`[0].classes).toContain("mrel");
+        expect(getBuilt`\xrightarrow +`[0].classes).toContain("mrel");
+        expect(getBuilt`\xrightarrow +`[0].classes).not.toContain("mbin");
+        expect(getBuilt`\xrightarrow )^2`[0].classes).toContain("mrel");
+        expect(getBuilt`\xrightarrow )^2`[0].classes).not.toContain("mclose");
     });
 });
 
@@ -2383,8 +2382,8 @@ describe("A horizontal brace parser", function() {
         expect`\overbrace{x^2}`.toParse();
         expect`\overbrace{x}^2`.toParse();
         expect`\overbrace x`.toParse();
-        expect("\\underbrace{x}_2").toParse();
-        expect("\\underbrace{x}_2^2").toParse();
+        expect`\underbrace{x}_2`.toParse();
+        expect`\underbrace{x}_2^2`.toParse();
     });
 
     it("should produce horizBrace", function() {
@@ -2404,8 +2403,8 @@ describe("A horizontal brace builder", function() {
     it("should not fail", function() {
         expect`\overbrace{x}`.toBuild();
         expect`\overbrace{x}^2`.toBuild();
-        expect("\\underbrace{x}_2").toBuild();
-        expect("\\underbrace{x}_2^2").toBuild();
+        expect`\underbrace{x}_2`.toBuild();
+        expect`\underbrace{x}_2^2`.toBuild();
     });
 
     it("should produce mords", function() {
@@ -2906,12 +2905,12 @@ describe("The CD environment", function() {
 
 describe("operatorname support", function() {
     it("should not fail", function() {
-        expect("\\operatorname{x*Π∑\\Pi\\sum\\frac a b}").toBuild();
-        expect("\\operatorname*{x*Π∑\\Pi\\sum\\frac a b}").toBuild();
-        expect("\\operatorname*{x*Π∑\\Pi\\sum\\frac a b}_y x").toBuild();
-        expect("\\operatorname*{x*Π∑\\Pi\\sum\\frac a b}\\limits_y x").toBuild();
+        expect`\operatorname{x*Π∑\Pi\sum\frac a b}`.toBuild();
+        expect`\operatorname*{x*Π∑\Pi\sum\frac a b}`.toBuild();
+        expect`\operatorname*{x*Π∑\Pi\sum\frac a b}_y x`.toBuild();
+        expect`\operatorname*{x*Π∑\Pi\sum\frac a b}\limits_y x`.toBuild();
         // The following does not actually render with limits. But it does not crash either.
-        expect("\\operatorname{sn}\\limits_{b>c}(b+c)").toBuild();
+        expect`\operatorname{sn}\limits_{b>c}(b+c)`.toBuild();
     });
 });
 
@@ -2920,25 +2919,25 @@ describe("href and url commands", function() {
 
     it("should parse its input", function() {
         expect`\href{http://example.com/}{\sin}`.toBuild(trustSettings);
-        expect("\\url{http://example.com/}").toBuild(trustSettings);
+        expect`\url{http://example.com/}`.toBuild(trustSettings);
     });
 
     it("should allow empty URLs", function() {
         expect`\href{}{example here}`.toBuild(trustSettings);
-        expect("\\url{}").toBuild(trustSettings);
+        expect`\url{}`.toBuild(trustSettings);
     });
 
     it("should allow single-character URLs", () => {
         expect`\href%end`.toParseLike("\\href{%}end", trustSettings);
-        expect("\\url%end").toParseLike("\\url{%}end", trustSettings);
+        expect`\url%end`.toParseLike("\\url{%}end", trustSettings);
         expect("\\url%%end\n").toParseLike("\\url{%}", trustSettings);
-        expect("\\url end").toParseLike("\\url{e}nd", trustSettings);
-        expect("\\url%end").toParseLike("\\url {%}end", trustSettings);
+        expect`\url end`.toParseLike("\\url{e}nd", trustSettings);
+        expect`\url%end`.toParseLike("\\url {%}end", trustSettings);
     });
 
     it("should allow spaces single-character URLs", () => {
         expect`\href %end`.toParseLike("\\href{%}end", trustSettings);
-        expect("\\url %end").toParseLike("\\url{%}end", trustSettings);
+        expect`\url %end`.toParseLike("\\url{%}end", trustSettings);
     });
 
     it("should allow letters [#$%&~_^] without escaping", function() {
@@ -2988,7 +2987,7 @@ describe("href and url commands", function() {
     });
 
     it("should forbid relative URLs when trust option is false", () => {
-        const parsed = getParsed("\\href{relative}{foo}");
+        const parsed = getParsed`\href{relative}{foo}`;
         expect(parsed).toMatchSnapshot();
     });
 
@@ -3049,7 +3048,7 @@ describe("href and url commands", function() {
 
 describe("A raw text parser", function() {
     it("should return null for a omitted optional string", function() {
-        expect("\\includegraphics{https://cdn.kastatic.org/images/apple-touch-icon-57x57-precomposed.new.png}").toParse();
+        expect`\includegraphics{https://cdn.kastatic.org/images/apple-touch-icon-57x57-precomposed.new.png}`.toParse();
     });
 });
 
@@ -3096,12 +3095,12 @@ describe("A parser that does not throw on unsupported commands", function() {
     });
 
     it("should build katex-error span for other type of KaTeX error", function() {
-        const built = getBuilt("2^2^2", noThrowSettings);
+        const built = getBuilt(`2^2^2`, noThrowSettings);
         expect(built).toMatchSnapshot();
     });
 
     it("should properly escape LaTeX in errors", function() {
-        const html = katex.renderToString("2^&\"<>", noThrowSettings);
+        const html = katex.renderToString(`2^&"<>`, noThrowSettings);
         expect(html).toMatchSnapshot();
     });
 });
@@ -3410,27 +3409,27 @@ describe("A macro expander", function() {
 
     it("\\char produces literal characters", () => {
         expect("\\char`a").toParseLike("\\char`\\a");
-        expect("\\char`\\%").toParseLike("\\char37");
-        expect("\\char`\\%").toParseLike("\\char'45");
-        expect("\\char`\\%").toParseLike('\\char"25');
-        expect("\\char").not.toParse();
-        expect("\\char`").not.toParse();
-        expect("\\char'").not.toParse();
-        expect('\\char"').not.toParse();
-        expect("\\char'a").not.toParse();
-        expect('\\char"g').not.toParse();
-        expect('\\char"g').not.toParse();
+        expect("\\char`\\%").toParseLike`\char37`;
+        expect("\\char`\\%").toParseLike`\char'45`;
+        expect("\\char`\\%").toParseLike`\char"25`;
+        expect`\char`.not.toParse();
+        expect`\char\``.not.toParse();
+        expect`\char'`.not.toParse();
+        expect`\char"`.not.toParse();
+        expect`\char'a`.not.toParse();
+        expect`\char"g`.not.toParse();
+        expect`\char"g`.not.toParse();
     });
 
     it("\\char escapes ~ correctly", () => {
-        const parsedBare = getParsed("~");
+        const parsedBare = getParsed`~`;
         expect(parsedBare[0].type).toEqual("spacing");
         const parsedChar = getParsed("\\char`\\~");
         expect(parsedChar[0].type).toEqual("textord");
     });
 
     it("\\char handles >16-bit characters", () => {
-        const parsed = getParsed('\\char"1d7d9');
+        const parsed = getParsed`\char"1d7d9`;
         expect(parsed[0].type).toEqual("textord");
         expect(parsed[0].text).toEqual("𝟙");
     });
@@ -3489,19 +3488,15 @@ describe("A macro expander", function() {
     });
 
     it("\\def works locally", () => {
-        expect("\\def\\x{1}\\x{\\def\\x{2}\\x{\\def\\x{3}\\x}\\x}\\x")
-            .toParseLike`1{2{3}2}1`;
-        expect("\\def\\x{1}\\x\\def\\x{2}\\x{\\def\\x{3}\\x\\def\\x{4}\\x}\\x")
-            .toParseLike`12{34}2`;
+        expect`\def\x{1}\x{\def\x{2}\x{\def\x{3}\x}\x}\x`.toParseLike`1{2{3}2}1`;
+        expect`\def\x{1}\x\def\x{2}\x{\def\x{3}\x\def\x{4}\x}\x`.toParseLike`12{34}2`;
     });
 
     it("\\gdef overrides at all levels", () => {
-        expect("\\def\\x{1}\\x{\\def\\x{2}\\x{\\gdef\\x{3}\\x}\\x}\\x")
-            .toParseLike`1{2{3}3}3`;
-        expect("\\def\\x{1}\\x{\\def\\x{2}\\x{\\global\\def\\x{3}\\x}\\x}\\x")
-            .toParseLike`1{2{3}3}3`;
-        expect("\\def\\x{1}\\x{\\def\\x{2}\\x{\\gdef\\x{3}\\x\\def\\x{4}\\x}" +
-            "\\x\\def\\x{5}\\x}\\x").toParseLike`1{2{34}35}3`;
+        expect`\def\x{1}\x{\def\x{2}\x{\gdef\x{3}\x}\x}\x`.toParseLike`1{2{3}3}3`;
+        expect`\def\x{1}\x{\def\x{2}\x{\global\def\x{3}\x}\x}\x`.toParseLike`1{2{3}3}3`;
+        expect`\def\x{1}\x{\def\x{2}\x{\gdef\x{3}\x\def\x{4}\x}\x\def\x{5}\x}\x`
+            .toParseLike`1{2{34}35}3`;
     });
 
     it("\\global needs to followed by macro prefixes, \\def or \\edef", () => {
@@ -3522,18 +3517,15 @@ describe("A macro expander", function() {
     });
 
     it("Macro arguments do not generate groups", () => {
-        expect("\\def\\x{1}\\x\\def\\foo#1{#1}\\foo{\\x\\def\\x{2}\\x}\\x")
-            .toParseLike`1122`;
+        expect`\def\x{1}\x\def\foo#1{#1}\foo{\x\def\x{2}\x}\x`.toParseLike`1122`;
     });
 
     it("\\textbf arguments do generate groups", () => {
-        expect("\\def\\x{1}\\x\\textbf{\\x\\def\\x{2}\\x}\\x")
-            .toParseLike`1\textbf{12}1`;
+        expect`\def\x{1}\x\textbf{\x\def\x{2}\x}\x`.toParseLike`1\textbf{12}1`;
     });
 
     it("\\sqrt optional arguments generate groups", () => {
-        expect("\\def\\x{1}\\def\\y{1}\\x\\y" +
-            "\\sqrt[\\def\\x{2}\\x]{\\def\\y{2}\\y}\\x\\y")
+        expect`\def\x{1}\def\y{1}\x\y\sqrt[\def\x{2}\x]{\def\y{2}\y}\x\y`
             .toParseLike`11\sqrt[2]{2}11`;
     });
 
@@ -3593,7 +3585,7 @@ describe("A macro expander", function() {
     });
 
     it("macros argument can simulate \\let", () => {
-        expect("\\int").toParseLike("\\int\\limits", {macros: {
+        expect`\int`.toParseLike("\\int\\limits", {macros: {
             "\\Oldint": {
                 tokens: [{text: "\\int", noexpand: true}],
                 numArgs: 0,
@@ -3807,18 +3799,18 @@ describe("leqno and fleqn rendering options", () => {
 
 describe("\\@binrel automatic bin/rel/ord", () => {
     it("should generate proper class", () => {
-        expect("L\\@binrel+xR").toParseLike("L\\mathbin xR");
-        expect("L\\@binrel=xR").toParseLike("L\\mathrel xR");
-        expect("L\\@binrel xxR").toParseLike("L\\mathord xR");
-        expect("L\\@binrel{+}{x}R").toParseLike("L\\mathbin{x}R");
-        expect("L\\@binrel{=}{x}R").toParseLike("L\\mathrel{x}R");
-        expect("L\\@binrel{x}{x}R").toParseLike("L\\mathord{x}R");
+        expect`L\@binrel+xR`.toParseLike`L\mathbin xR`;
+        expect`L\@binrel=xR`.toParseLike`L\mathrel xR`;
+        expect`L\@binrel xxR`.toParseLike`L\mathord xR`;
+        expect`L\@binrel{+}{x}R`.toParseLike`L\mathbin{x}R`;
+        expect`L\@binrel{=}{x}R`.toParseLike`L\mathrel{x}R`;
+        expect`L\@binrel{x}{x}R`.toParseLike`L\mathord{x}R`;
     });
 
     it("should base on just first character in group", () => {
-        expect("L\\@binrel{+x}xR").toParseLike("L\\mathbin xR");
-        expect("L\\@binrel{=x}xR").toParseLike("L\\mathrel xR");
-        expect("L\\@binrel{xx}xR").toParseLike("L\\mathord xR");
+        expect`L\@binrel{+x}xR`.toParseLike`L\mathbin xR`;
+        expect`L\@binrel{=x}xR`.toParseLike`L\mathrel xR`;
+        expect`L\@binrel{xx}xR`.toParseLike`L\mathord xR`;
     });
 });
 

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -812,7 +812,7 @@ describe("A text parser", function() {
 describe("A texvc builder", function() {
     it("should not fail", function() {
         expect`\lang\N\darr\R\dArr\Z\Darr\alef\rang`.toBuild();
-        expect`\alefsym\uarr\Alpha\uArr\Beta\Uarr\Chi`.toBuild();
+        expect("\\alefsym\\uarr\\Alpha\\uArr\\Beta\\Uarr\\Chi").toBuild();
         expect`\clubs\diamonds\hearts\spades\cnums\Complex`.toBuild();
         expect`\Dagger\empty\harr\Epsilon\hArr\Eta\Harr\exist`.toBuild();
         expect`\image\larr\infin\lArr\Iota\Larr\isin\Kappa`.toBuild();
@@ -1670,10 +1670,10 @@ describe("A font parser", function() {
 
 describe("A \\pmb builder", function() {
     it("should not fail", function() {
-        expect`\pmb{\\mu}`.toBuild();
+        expect`\pmb{\mu}`.toBuild();
         expect`\pmb{=}`.toBuild();
         expect`\pmb{+}`.toBuild();
-        expect`\pmb{\\frac{x^2}{x_1}}`.toBuild();
+        expect`\pmb{\frac{x^2}{x_1}}`.toBuild();
         expect`\pmb{}`.toBuild();
         expect`\def\x{1}\pmb{\x\def\x{2}}`.toParseLike`\pmb{1}`;
     });
@@ -1703,9 +1703,9 @@ describe("A raise parser", function() {
         expect`\raisebox-5pt{text}`.not.toBuild(strictSettings);
     });
 
-
     it("should build math in an hbox when math mode is set", function() {
-        expect`a + \vcenter{\hbox{$\frac{\frac a b}c$}}`.toBuild(strictSettings);
+        expect`a + \vcenter{\hbox{$\frac{\frac a b}c$}}`
+            .toBuild(strictSettings);
     });
 });
 
@@ -2299,20 +2299,20 @@ describe("A stretchy MathML builder", function() {
 
 describe("An under-accent parser", function() {
     it("should not fail", function() {
-        expect`\underrightarrow{x}`.toParse();
-        expect`\underrightarrow{x^2}`.toParse();
-        expect`\underrightarrow{x}^2`.toParse();
-        expect`\underrightarrow x`.toParse();
+        expect("\\underrightarrow{x}").toParse();
+        expect("\\underrightarrow{x^2}").toParse();
+        expect("\\underrightarrow{x}^2").toParse();
+        expect("\\underrightarrow x").toParse();
     });
 
     it("should produce accentUnder", function() {
-        const parse = getParsed`\underrightarrow x`[0];
+        const parse = getParsed("\\underrightarrow x")[0];
 
         expect(parse.type).toEqual("accentUnder");
     });
 
     it("should be grouped more tightly than supsubs", function() {
-        const parse = getParsed`\underrightarrow x^2`[0];
+        const parse = getParsed("\\underrightarrow x^2")[0];
 
         expect(parse.type).toEqual("supsub");
     });
@@ -2320,18 +2320,19 @@ describe("An under-accent parser", function() {
 
 describe("An under-accent builder", function() {
     it("should not fail", function() {
-        expect`\underrightarrow{x}`.toBuild();
-        expect`\underrightarrow{x}^2`.toBuild();
-        expect`\underrightarrow{x}_2`.toBuild();
-        expect`\underrightarrow{x}_2^2`.toBuild();
+        expect("\\underrightarrow{x}").toBuild();
+        expect("\\underrightarrow{x}^2").toBuild();
+        expect("\\underrightarrow{x}_2").toBuild();
+        expect("\\underrightarrow{x}_2^2").toBuild();
     });
 
     it("should produce mords", function() {
-        expect(getBuilt`\underrightarrow x`[0].classes).toContain("mord");
-        expect(getBuilt`\underrightarrow +`[0].classes).toContain("mord");
-        expect(getBuilt`\underrightarrow +`[0].classes).not.toContain("mbin");
-        expect(getBuilt`\underrightarrow )^2`[0].classes).toContain("mord");
-        expect(getBuilt`\underrightarrow )^2`[0].classes).not.toContain("mclose");
+        expect(getBuilt("\\underrightarrow x")[0].classes).toContain("mord");
+        expect(getBuilt("\\underrightarrow +")[0].classes).toContain("mord");
+        expect(getBuilt("\\underrightarrow +")[0].classes).not.toContain("mbin");
+        expect(getBuilt("\\underrightarrow )^2")[0].classes).toContain("mord");
+        expect(getBuilt("\\underrightarrow )^2")[0].classes)
+            .not.toContain("mclose");
     });
 });
 
@@ -2382,8 +2383,8 @@ describe("A horizontal brace parser", function() {
         expect`\overbrace{x^2}`.toParse();
         expect`\overbrace{x}^2`.toParse();
         expect`\overbrace x`.toParse();
-        expect`\underbrace{x}_2`.toParse();
-        expect`\underbrace{x}_2^2`.toParse();
+        expect("\\underbrace{x}_2").toParse();
+        expect("\\underbrace{x}_2^2").toParse();
     });
 
     it("should produce horizBrace", function() {
@@ -2403,8 +2404,8 @@ describe("A horizontal brace builder", function() {
     it("should not fail", function() {
         expect`\overbrace{x}`.toBuild();
         expect`\overbrace{x}^2`.toBuild();
-        expect`\underbrace{x}_2`.toBuild();
-        expect`\underbrace{x}_2^2`.toBuild();
+        expect("\\underbrace{x}_2").toBuild();
+        expect("\\underbrace{x}_2^2").toBuild();
     });
 
     it("should produce mords", function() {
@@ -2919,25 +2920,25 @@ describe("href and url commands", function() {
 
     it("should parse its input", function() {
         expect`\href{http://example.com/}{\sin}`.toBuild(trustSettings);
-        expect`\url{http://example.com/}`.toBuild(trustSettings);
+        expect("\\url{http://example.com/}").toBuild(trustSettings);
     });
 
     it("should allow empty URLs", function() {
         expect`\href{}{example here}`.toBuild(trustSettings);
-        expect`\url{}`.toBuild(trustSettings);
+        expect("\\url{}").toBuild(trustSettings);
     });
 
     it("should allow single-character URLs", () => {
         expect`\href%end`.toParseLike("\\href{%}end", trustSettings);
-        expect`\url%end`.toParseLike("\\url{%}end", trustSettings);
+        expect("\\url%end").toParseLike("\\url{%}end", trustSettings);
         expect("\\url%%end\n").toParseLike("\\url{%}", trustSettings);
-        expect`\url end`.toParseLike("\\url{e}nd", trustSettings);
-        expect`\url%end`.toParseLike("\\url {%}end", trustSettings);
+        expect("\\url end").toParseLike("\\url{e}nd", trustSettings);
+        expect("\\url%end").toParseLike("\\url {%}end", trustSettings);
     });
 
     it("should allow spaces single-character URLs", () => {
         expect`\href %end`.toParseLike("\\href{%}end", trustSettings);
-        expect`\url %end`.toParseLike("\\url{%}end", trustSettings);
+        expect("\\url %end").toParseLike("\\url{%}end", trustSettings);
     });
 
     it("should allow letters [#$%&~_^] without escaping", function() {
@@ -3413,7 +3414,7 @@ describe("A macro expander", function() {
         expect("\\char`\\%").toParseLike`\char'45`;
         expect("\\char`\\%").toParseLike`\char"25`;
         expect`\char`.not.toParse();
-        expect`\char\``.not.toParse();
+        expect("\\char`").not.toParse();
         expect`\char'`.not.toParse();
         expect`\char"`.not.toParse();
         expect`\char'a`.not.toParse();
@@ -3488,13 +3489,17 @@ describe("A macro expander", function() {
     });
 
     it("\\def works locally", () => {
-        expect`\def\x{1}\x{\def\x{2}\x{\def\x{3}\x}\x}\x`.toParseLike`1{2{3}2}1`;
-        expect`\def\x{1}\x\def\x{2}\x{\def\x{3}\x\def\x{4}\x}\x`.toParseLike`12{34}2`;
+        expect`\def\x{1}\x{\def\x{2}\x{\def\x{3}\x}\x}\x`
+            .toParseLike`1{2{3}2}1`;
+        expect`\def\x{1}\x\def\x{2}\x{\def\x{3}\x\def\x{4}\x}\x`
+            .toParseLike`12{34}2`;
     });
 
     it("\\gdef overrides at all levels", () => {
-        expect`\def\x{1}\x{\def\x{2}\x{\gdef\x{3}\x}\x}\x`.toParseLike`1{2{3}3}3`;
-        expect`\def\x{1}\x{\def\x{2}\x{\global\def\x{3}\x}\x}\x`.toParseLike`1{2{3}3}3`;
+        expect`\def\x{1}\x{\def\x{2}\x{\gdef\x{3}\x}\x}\x`
+            .toParseLike`1{2{3}3}3`;
+        expect`\def\x{1}\x{\def\x{2}\x{\global\def\x{3}\x}\x}\x`
+            .toParseLike`1{2{3}3}3`;
         expect`\def\x{1}\x{\def\x{2}\x{\gdef\x{3}\x\def\x{4}\x}\x\def\x{5}\x}\x`
             .toParseLike`1{2{34}35}3`;
     });
@@ -3517,7 +3522,8 @@ describe("A macro expander", function() {
     });
 
     it("Macro arguments do not generate groups", () => {
-        expect`\def\x{1}\x\def\foo#1{#1}\foo{\x\def\x{2}\x}\x`.toParseLike`1122`;
+        expect`\def\x{1}\x\def\foo#1{#1}\foo{\x\def\x{2}\x}\x`
+            .toParseLike`1122`;
     });
 
     it("\\textbf arguments do generate groups", () => {


### PR DESCRIPTION
<!-- PR title should follow Angular Commit Message Conventions (https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines) -->
https://github.com/KaTeX/KaTeX/pull/3902 looks abandoned, so I've decided to try to finish it.

**What is the previous behavior before this PR?**
`expect("\\mathinner{\\langle{\\psi}\\rangle}").toParse();`

**What is the new behavior after this PR?**
``expect`\mathinner{\langle{\psi}\rangle}`.toParse();``

<!-- If this PR contains a breaking change, please uncomment following line -->
<!-- BREAKING CHANGE: describe its impact and migration methods -->

<!-- If this PR fixes or closes issues, please uncomment following line and change the issue number -->
<!-- Fixes #1, Closes #2 -->
Fixes https://github.com/KaTeX/KaTeX/issues/1717