### PR TITLE
docs: Adds Doctave to list of users

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -31,6 +31,11 @@ const users = [
         infoLink: 'https://cocalc.com/',
     },
     {
+        caption: 'Doctave',
+        image: 'https://www.doctave.com/assets/img/katex-integration-logo.webp',
+        infoLink: 'https://www.doctave.com/',
+    },
+    {
         caption: 'Dropbox Paper',
         image: 'https://aem.dropbox.com/cms/content/dam/dropbox/www/en-us/branding/app-paper-ios@2x.png',
         infoLink: 'https://paper.dropbox.com/',


### PR DESCRIPTION
<!-- PR title should follow Angular Commit Message Conventions (https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines) -->

Adds [Doctave](https://www.doctave.com) to list of KaTeX users. Doctave has native support now: https://docs.doctave.com/components/math

Thanks for all your work building KaTeX! ❤️ 

<!-- If this PR contains a breaking change, please uncomment following line -->
<!-- BREAKING CHANGE: describe its impact and migration methods -->

<!-- If this PR fixes or closes issues, please uncomment following line and change the issue number -->
<!-- Fixes #1, Closes #2 -->
