### PR TITLE
Fix svg if katex in bootstrap's modal in katex.scss

### DIFF
--- a/src/styles/katex.scss
+++ b/src/styles/katex.scss
@@ -442,7 +442,7 @@ $version: "" !default;
     svg {
         display: block;
         position: absolute; // absolute relative to parent
-        z-index: 1;
+        z-index: auto;
         width: 100%;
         height: inherit;
 

--- a/src/styles/katex.scss
+++ b/src/styles/katex.scss
@@ -442,6 +442,7 @@ $version: "" !default;
     svg {
         display: block;
         position: absolute; // absolute relative to parent
+        z-index: 1;
         width: 100%;
         height: inherit;
 


### PR DESCRIPTION
add z-index: 1;

<!-- PR title should follow Angular Commit Message Conventions (https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines) -->

**What is the previous behavior before this PR?**
![image](https://github.com/user-attachments/assets/d20d5f33-36d0-4be9-af04-c4b6360878d6)


**What is the new behavior after this PR?**
![image](https://github.com/user-attachments/assets/a10b4f89-d20c-424d-8e88-8c1f810be20e)

<!-- If this PR contains a breaking change, please uncomment following line -->
<!-- BREAKING CHANGE: describe its impact and migration methods -->

<!-- If this PR fixes or closes issues, please uncomment following line and change the issue number -->
<!-- Fixes #1, Closes #2 -->
