### PR TITLE
chore(ci): Disable caching in release job.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,6 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '20'
-        cache: yarn
 
     - name: Install dependencies
       run: yarn --immutable


### PR DESCRIPTION
<!-- PR title should follow Angular Commit Message Conventions (https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines) -->

**What is the previous behavior before this PR?**

The release workflow consumes the GitHub Actions cache, which is subject to tampering by an external attacker (given the accepted risks from other workflows).

**What is the new behavior after this PR?**

The release workflow will not consume the cache, preventing an attacker from stealing the NPM token.

<!-- If this PR contains a breaking change, please uncomment following line -->
<!-- BREAKING CHANGE: describe its impact and migration methods -->

<!-- If this PR fixes or closes issues, please uncomment following line and change the issue number -->
<!-- Fixes #1, Closes #2 -->
