### PR TITLE
fix: `\vdots` and `\rule` support in text mode

### DIFF
--- a/src/functions/rule.js
+++ b/src/functions/rule.js
@@ -11,6 +11,8 @@ defineFunction({
     props: {
         numArgs: 2,
         numOptionalArgs: 1,
+        allowedInText: true,
+        allowedInMath: true,
         argTypes: ["size", "size", "size"],
     },
     handler({parser}, args, optArgs) {

--- a/src/macros.js
+++ b/src/macros.js
@@ -341,7 +341,8 @@ defineMacro("\\lrcorner", "\\html@mathml{\\@lrcorner}{\\mathop{\\char\"231f}}");
 // \kern6\p@\hbox{.}\hbox{.}\hbox{.}}}
 // We'll call \varvdots, which gets a glyph from symbols.js.
 // The zero-width rule gets us an equivalent to the vertical 6pt kern.
-defineMacro("\\vdots", "\\mathord{\\varvdots\\rule{0pt}{15pt}}");
+defineMacro("\\vdots",
+            "\\TextOrMath{\\textvdots}{{\\varvdots\\rule{0pt}{15pt}}}\\relax");
 defineMacro("\u22ee", "\\vdots");
 
 //////////////////////////////////////////////////////////////////////

--- a/src/macros.js
+++ b/src/macros.js
@@ -341,8 +341,7 @@ defineMacro("\\lrcorner", "\\html@mathml{\\@lrcorner}{\\mathop{\\char\"231f}}");
 // \kern6\p@\hbox{.}\hbox{.}\hbox{.}}}
 // We'll call \varvdots, which gets a glyph from symbols.js.
 // The zero-width rule gets us an equivalent to the vertical 6pt kern.
-defineMacro("\\vdots",
-            "\\TextOrMath{\\textvdots}{{\\varvdots\\rule{0pt}{15pt}}}\\relax");
+defineMacro("\\vdots", "{\\varvdots\\rule{0pt}{15pt}}");
 defineMacro("\u22ee", "\\vdots");
 
 //////////////////////////////////////////////////////////////////////

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -674,6 +674,7 @@ defineSymbol(math, main, inner, "\u2026", "\\ldots", true);
 defineSymbol(math, main, inner, "\u22ef", "\\@cdots", true);
 defineSymbol(math, main, inner, "\u22f1", "\\ddots", true);
 defineSymbol(math, main, textord, "\u22ee", "\\varvdots"); // \vdots is a macro
+defineSymbol(text, main, textord, "\u22ee", "\\textvdots");
 defineSymbol(math, main, accent, "\u02ca", "\\acute");
 defineSymbol(math, main, accent, "\u02cb", "\\grave");
 defineSymbol(math, main, accent, "\u00a8", "\\ddot");

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -673,8 +673,9 @@ defineSymbol(text, main, inner, "\u2026", "\\ldots", true);
 defineSymbol(math, main, inner, "\u2026", "\\ldots", true);
 defineSymbol(math, main, inner, "\u22ef", "\\@cdots", true);
 defineSymbol(math, main, inner, "\u22f1", "\\ddots", true);
-defineSymbol(math, main, textord, "\u22ee", "\\varvdots"); // \vdots is a macro
-defineSymbol(text, main, textord, "\u22ee", "\\textvdots");
+// \vdots is a macro that uses one of these two symbols (with made-up names):
+defineSymbol(math, main, textord, "\u22ee", "\\varvdots");
+defineSymbol(text, main, textord, "\u22ee", "\\varvdots");
 defineSymbol(math, main, accent, "\u02ca", "\\acute");
 defineSymbol(math, main, accent, "\u02cb", "\\grave");
 defineSymbol(math, main, accent, "\u00a8", "\\ddot");

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -807,6 +807,10 @@ describe("A text parser", function() {
     it("should omit spaces after commands", function() {
         expect`\text{\textellipsis !}`.toParseLike`\text{\textellipsis!}`;
     });
+
+    it("should handle ⋮ and \\vdots", function() {
+        expect`\text{a \vdots b ⋮ d}`.toParse();
+    });
 });
 
 describe("A texvc builder", function() {

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -1069,6 +1069,10 @@ describe("A rule parser", function() {
         expect(parse.width.number).toBeCloseTo(-1);
         expect(parse.height.number).toBeCloseTo(-0.2);
     });
+
+    it("should parse in text mode", function() {
+        expect(r`\text{a\rule{1em}{2em}b}`).toParse();
+    });
 });
 
 describe("A kern parser", function() {


### PR DESCRIPTION
**What is the previous behavior before this PR?**
`\vdots` and `\rule` worked only in math mode.

**What is the new behavior after this PR?**
`\vdots` and `\rule` work in text mode too, like LaTeX. See https://github.com/KaTeX/KaTeX/pull/3991#pullrequestreview-2487118382

Fixes #3990. Replaces #3991 to work around GitHub permissions. Thanks to @ronkok and @pzinn for authoring the original version.