### PR TITLE
fix: MathML combines multidigit numbers with sup/subscript, comma separators, and multicharacter text when outputting to DOM

### DIFF
--- a/src/buildMathML.js
+++ b/src/buildMathML.js
@@ -129,7 +129,9 @@ export const getVariant = function(
 };
 
 /**
- * Check for <mi>.</mi> which is how a dot renders in MathML
+ * Check for <mi>.</mi> which is how a dot renders in MathML,
+ * or <mo separator="true" lspace="0em" rspace="0em">,</mo>
+ * which is how a braced comma {,} renders in MathML
  */
 function isNumberPunctuation(group: ?MathNode): boolean {
     if (!group) {

--- a/src/mathMLTree.js
+++ b/src/mathMLTree.js
@@ -95,7 +95,17 @@ export class MathNode implements MathDomNode {
         }
 
         for (let i = 0; i < this.children.length; i++) {
-            node.appendChild(this.children[i].toNode());
+            // Combine multiple TextNodes into one TextNode, to prevent
+            // screen readers from reading each as a separate word [#3995]
+            if (this.children[i] instanceof TextNode) {
+                let text = this.children[i].toText();
+                while (this.children[i + 1] instanceof TextNode) {
+                    text += this.children[++i].toText();
+                }
+                node.appendChild(new TextNode(text).toNode());
+            } else {
+                node.appendChild(this.children[i].toNode());
+            }
         }
 
         return node;

--- a/src/mathMLTree.js
+++ b/src/mathMLTree.js
@@ -97,8 +97,9 @@ export class MathNode implements MathDomNode {
         for (let i = 0; i < this.children.length; i++) {
             // Combine multiple TextNodes into one TextNode, to prevent
             // screen readers from reading each as a separate word [#3995]
-            if (this.children[i] instanceof TextNode) {
-                let text = this.children[i].toText();
+            if (this.children[i] instanceof TextNode &&
+                this.children[i + 1] instanceof TextNode) {
+                let text = this.children[i].toText() + this.children[++i].toText();
                 while (this.children[i + 1] instanceof TextNode) {
                     text += this.children[++i].toText();
                 }

--- a/test/__snapshots__/mathml-spec.js.snap
+++ b/test/__snapshots__/mathml-spec.js.snap
@@ -428,9 +428,35 @@ exports[`A MathML builder should concatenate digits into single <mn> 1`] = `
       <mn>
         0.34
       </mn>
+      <mo>
+        =
+      </mo>
+      <msup>
+        <mn>
+          .34
+        </mn>
+        <mn>
+          1
+        </mn>
+      </msup>
     </mrow>
     <annotation encoding="application/x-tex">
-      \\sin{\\alpha}=0.34
+      \\sin{\\alpha}=0.34=.34^1
+    </annotation>
+  </semantics>
+</math>
+`;
+
+exports[`A MathML builder should concatenate digits into single <mn> 2`] = `
+<math xmlns="http://www.w3.org/1998/Math/MathML">
+  <semantics>
+    <mrow>
+      <mn>
+        1,000,000
+      </mn>
+    </mrow>
+    <annotation encoding="application/x-tex">
+      1{,}000{,}000
     </annotation>
   </semantics>
 </math>

--- a/test/mathml-spec.js
+++ b/test/mathml-spec.js
@@ -29,7 +29,8 @@ describe("A MathML builder", function() {
     });
 
     it('should concatenate digits into single <mn>', () => {
-        expect(getMathML("\\sin{\\alpha}=0.34")).toMatchSnapshot();
+        expect(getMathML("\\sin{\\alpha}=0.34=.34^1")).toMatchSnapshot();
+        expect(getMathML("1{,}000{,}000")).toMatchSnapshot();
     });
 
     it('should make prime operators into <mo> nodes', () => {


### PR DESCRIPTION
<!-- PR title should follow Angular Commit Message Conventions (https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines) -->

**What is the previous behavior before this PR?**

When rendering MathML directly to the DOM (as opposed to a string), such as on the katex.org front-page demo, consecutive digits and text characters get rendered as multiple text children of an `<mn>` or `<mtext>` elements:

![image](https://github.com/user-attachments/assets/6bed3144-29a4-4531-a58e-13814c33c330)

**What is the new behavior after this PR?**

When rendering MathML directly to the DOM, we combine consecutive text children into one:

![image](https://github.com/user-attachments/assets/c20ae6cc-f5bc-43e9-b015-b444b1bd4dd4)

Fixes #3995 which reports that this causes screen-reading issues.

---

Merging of consecutive `<mtext>` and `<mn>` elements is already done here:

https://github.com/KaTeX/KaTeX/blob/2d1fec9f989723c5a24f5ae5ab7d89bd7f7081e0/src/buildMathML.js#L157-L167

And when rendering to a string, this was enough. Indeed, we don't have a great way of testing this, without a virtual DOM setup. But the inspect screenshots above confirm that this PR fixes the issue.