### PR TITLE
fix: Actually publish TypeScript type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "cli.js",
     "src/",
     "contrib/",
-    "dist/"
+    "dist/",
+    "types/"
   ],
   "license": "MIT",
   "packageManager": "yarn@4.1.1",


### PR DESCRIPTION
**What is the previous behavior before this PR?**
#3846 added TypeScript type definitions, but they didn't actually get `npm publish`ed.

**What is the new behavior after this PR?**
Publish `types` directory to NPM

Fixes #3531 (again)