### PR TITLE
chore(deps): update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/fonts.yml
+++ b/.github/workflows/fonts.yml
@@ -110,12 +110,12 @@ jobs:
         printf '[diff "font"]\n\tbinary = true\n\ttextconv = ttx -q -i -o -' >> ~/.gitconfig
         git diff --exit-code
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: fonts
         path: fonts
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: metrics

--- a/.github/workflows/screenshotter.yml
+++ b/.github/workflows/screenshotter.yml
@@ -81,12 +81,12 @@ jobs:
         docker logs ${{ job.services.selenium.id }}
         echo "::$TOKEN::"
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: new-${{ matrix.browser }}
         path: test/screenshotter/new
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: diff-${{ matrix.browser }}


### PR DESCRIPTION
**What is the previous behavior before this PR?**
actions/upload-artifact@v3 is now deprecated. This causes CI to crash. For example:
https://github.com/KaTeX/KaTeX/actions/runs/12695284748/job/35386858141?pr=4000

**What is the new behavior after this PR?**
actions/upload-artifact@v4 should just work in our case, because names are already distinct.

<!-- If this PR contains a breaking change, please uncomment following line -->
<!-- BREAKING CHANGE: describe its impact and migration methods -->

<!-- If this PR fixes or closes issues, please uncomment following line and change the issue number -->
<!-- Fixes #1, Closes #2 -->
