### PR TITLE
feat: add non-ascii letters

### DIFF
--- a/docs/support_table.md
+++ b/docs/support_table.md
@@ -326,6 +326,8 @@ use `\ce` instead|
 |\delta|$\delta$||
 |\Delta|$\Delta$||
 |\det|$\det$||
+|\DH|$\text{\DH}$|`\text{\DH}`|
+|\dh|$\text{\dh}$|`\text{\dh}`|
 |\Digamma|<span style="color:firebrick;">Not supported</span>||
 |\digamma|$\digamma$||
 |\dfrac|$\dfrac{a-1}{b-1}$|`\dfrac{a-1}{b-1}`|
@@ -340,6 +342,8 @@ use `\ce` instead|
 |\displaystyle|$\displaystyle\sum_0^n$|`\displaystyle\sum_0^n`|
 |\div|$\div$||
 |\divideontimes|$\divideontimes$||
+|\DJ|$\text{\DJ}$|`\text{\DJ}`|
+|\dj|$\text{\dj}$|`\text{\dj}`|
 |\dot|$\dot x$|`\dot x`|
 |\Doteq|$\Doteq$||
 |\doteq|$\doteq$||
@@ -549,8 +553,8 @@ use `\ce` instead|
 
 |Symbol/Function |  Rendered   | Source or Comment|
 |:---------------|:------------|:-----------------|
-|\L|<span style="color:firebrick;">Not supported</span>||
-|\l|<span style="color:firebrick;">Not supported</span>||
+|\L|$\text{\L}$|`\text{\L}`|
+|\l|$\text{\l}$|`\text{\l}`|
 |\Lambda|$\Lambda$||
 |\lambda|$\lambda$||
 |\label|<span style="color:firebrick;">Not supported</span>||
@@ -733,6 +737,8 @@ use `\ce` instead|
 |\Newextarrow|<span style="color:firebrick;">Not supported</span>||
 |\newline|$a\newline b$|`a\newline b`|
 |\nexists|$\nexists$||
+|\NG|$\text{\NG}$|`\text{\NG}`|
+|\ng|$\text{\ng}$|`\text{\ng}`|
 |\ngeq|$\ngeq$||
 |\ngeqq|$\ngeqq$||
 |\ngeqslant|$\ngeqslant$||

--- a/docs/supported.md
+++ b/docs/supported.md
@@ -178,16 +178,16 @@ $\allowbreak α β γ δ ϵ ζ η θ ι κ λ μ ν ξ o π \allowbreak ρ σ τ
 **Other Letters**
 
 ||||||
-|:----------|:----------|:----------|:----------|:----------|
-|$\imath$ `\imath`|$\nabla$ `\nabla`|$\Im$ `\Im`|$\Reals$ `\Reals`|$\text{\OE}$ `\text{\OE}`
-|$\jmath$ `\jmath`|$\partial$ `\partial`|$\image$ `\image`|$\wp$ `\wp`|$\text{\o}$ `\text{\o}`
-|$\aleph$ `\aleph`|$\Game$ `\Game`|$\Bbbk$ `\Bbbk`|$\weierp$ `\weierp`|$\text{\O}$ `\text{\O}`
-|$\alef$ `\alef`|$\Finv$ `\Finv`|$\N$ `\N`|$\Z$ `\Z`|$\text{\ss}$ `\text{\ss}`
-|$\alefsym$ `\alefsym`|$\cnums$ `\cnums`|$\natnums$ `\natnums`|$\text{\aa}$ `\text{\aa}`|$\text{\i}$ `\text{\i}`
+|:----------|:----------|:----------|:----------|:----------|:----------|
+|$\imath$ `\imath`|$\nabla$ `\nabla`|$\Im$ `\Im`|$\Reals$ `\Reals`|$\text{\OE}$ `\text{\OE}`|$\text{\DH}$ `\text{\DH}`
+|$\jmath$ `\jmath`|$\partial$ `\partial`|$\image$ `\image`|$\wp$ `\wp`|$\text{\o}$ `\text{\o}`|$\text{\dj}$ `\text{\dj}`
+|$\aleph$ `\aleph`|$\Game$ `\Game`|$\Bbbk$ `\Bbbk`|$\weierp$ `\weierp`|$\text{\O}$ `\text{\O}`|$\text{\DJ}$ `\text{\DJ}`
+|$\alef$ `\alef`|$\Finv$ `\Finv`|$\N$ `\N`|$\Z$ `\Z`|$\text{\ss}$ `\text{\ss}`|$\text{\ng}$ `\text{\ng}`
+|$\alefsym$ `\alefsym`|$\cnums$ `\cnums`|$\natnums$ `\natnums`|$\text{\aa}$ `\text{\aa}`|$\text{\i}$ `\text{\i}`|$\text{\NG}$ `\text{\NG}`
 |$\beth$ `\beth`|$\Complex$ `\Complex`|$\R$ `\R`|$\text{\AA}$ `\text{\AA}`|$\text{\j}$ `\text{\j}`
-|$\gimel$ `\gimel`|$\ell$ `\ell`|$\Re$ `\Re`|$\text{\ae}$ `\text{\ae}`
-|$\daleth$ `\daleth`|$\hbar$ `\hbar`|$\real$ `\real`|$\text{\AE}$ `\text{\AE}`
-|$\eth$ `\eth`|$\hslash$ `\hslash`|$\reals$ `\reals`|$\text{\oe}$ `\text{\oe}`
+|$\gimel$ `\gimel`|$\ell$ `\ell`|$\Re$ `\Re`|$\text{\ae}$ `\text{\ae}`|$\text{\l}$ `\text{\l}`
+|$\daleth$ `\daleth`|$\hbar$ `\hbar`|$\real$ `\real`|$\text{\AE}$ `\text{\AE}`|$\text{\L}$ `\text{\L}`
+|$\eth$ `\eth`|$\hslash$ `\hslash`|$\reals$ `\reals`|$\text{\oe}$ `\text{\oe}`|$\text{\dh}$ `\text{\dh}`
 
 Direct Input: $∂ ∇ ℑ Ⅎ ℵ ℶ ℷ ℸ ⅁ ℏ ð − ∗$
 ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖÙÚÛÜÝÞßàáâãäåçèéêëìíîïðñòóôöùúûüýþÿ

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -701,6 +701,17 @@ defineSymbol(text, main, textord, "\u00f8", "\\o", true);
 defineSymbol(text, main, textord, "\u00c6", "\\AE", true);
 defineSymbol(text, main, textord, "\u0152", "\\OE", true);
 defineSymbol(text, main, textord, "\u00d8", "\\O", true);
+defineSymbol(text, main, textord, "\u00f0", "\\dh", true);
+defineSymbol(text, main, textord, "\u00d0", "\\DH", true);
+defineSymbol(text, main, textord, "\u0111", "\\dj", true);
+defineSymbol(text, main, textord, "\u0110", "\\DJ", true);
+defineSymbol(text, main, textord, "\u0142", "\\l", true);
+defineSymbol(text, main, textord, "\u0141", "\\L", true);
+defineSymbol(text, main, textord, "\u014b", "\\ng", true);
+defineSymbol(text, main, textord, "\u014a", "\\NG", true);
+// TODO: Can't use function '\th' in text mode
+// defineSymbol(text, main, textord, "\u00fe", "\\th", true);
+// defineSymbol(text, main, textord, "\u00de", "\\TH", true);
 defineSymbol(text, main, accent, "\u02ca", "\\'"); // acute
 defineSymbol(text, main, accent, "\u02cb", "\\`"); // grave
 defineSymbol(text, main, accent, "\u02c6", "\\^"); // circumflex

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -4151,7 +4151,7 @@ describe("Symbols", function() {
     });
 
     it("should render ligature commands like their unicode characters", () => {
-        expect`\text{\ae\AE\oe\OE\o\O\ss}`.toBuildLike(r`\text{æÆœŒøØß}`, strictSettings);
+        expect`\text{\ae\AE\dh\DH\dj\DJ\l\L\ng\NG\oe\OE\o\O\ss}`.toBuildLike(r`\text{æÆðÐđĐłŁŋŊœŒøØß}`, strictSettings);
     });
 });
 


### PR DESCRIPTION
Unfortunately, there is a function `\th`, so `\th`(Þ) cannot be added with simple `defineSymbol`.

Maybe it's better to create a separate issue to fix this problem?

**What is the previous behavior before this PR?**
Some symbols listed in #2889 are not available

**What is the new behavior after this PR?**
You can use `\L` or other symbols in text mode

Closes #2889