### PR TITLE
feat: support optional args with \newcommand

### DIFF
--- a/src/MacroExpander.js
+++ b/src/MacroExpander.js
@@ -219,10 +219,31 @@ export default class MacroExpander implements MacroContextInterface {
     }
 
     /**
-     * Consume the specified number of (delimited) arguments from the token
-     * stream and return the resulting array of arguments.
+     * Consume the specified number of (delimited *or* defaulted) arguments
+     * from the token stream and return the resulting array of arguments.
      */
-    consumeArgs(numArgs: number, delimiters?: string[][]): Token[][] {
+    consumeArgs(numArgs: number, delimiters?: string[][], defaultArgs?: Token[][]): Token[][] {
+        const args: Token[][] = [];
+        if (defaultArgs) {
+            let scanning = true;
+            let j = defaultArgs.length;
+            for (let i = 0; i < j; i++) {
+                if (scanning) {
+                    this.consumeSpaces(); // \@ifnextchar gobbles any space following it
+                    if (this.future().text !== "[") {
+                        scanning = false;
+                    }
+                }
+                if (scanning) {
+                    this.popToken(); // don't include [ in tokens
+                    args.push(this.consumeArg(["]"]).tokens);
+                } else {
+                    args.push(defaultArgs[i]);
+                }
+            }
+            numArgs = numArgs - j;
+        }
+
         if (delimiters) {
             if (delimiters.length !== numArgs + 1) {
                 throw new ParseError(
@@ -238,7 +259,6 @@ export default class MacroExpander implements MacroContextInterface {
             }
         }
 
-        const args: Token[][] = [];
         for (let i = 0; i < numArgs; i++) {
             args.push(this.consumeArg(delimiters && delimiters[i + 1]).tokens);
         }
@@ -290,7 +310,7 @@ export default class MacroExpander implements MacroContextInterface {
         }
         this.countExpansion(1);
         let tokens = expansion.tokens;
-        const args = this.consumeArgs(expansion.numArgs, expansion.delimiters);
+        const args = this.consumeArgs(expansion.numArgs, expansion.delimiters, expansion.defaultArgs);
         if (expansion.numArgs) {
             // paste arguments in place of the placeholders
             tokens = tokens.slice(); // make a shallow copy

--- a/src/defineMacro.js
+++ b/src/defineMacro.js
@@ -106,6 +106,7 @@ export type MacroExpansion = {
     numArgs: number,
     delimiters?: string[][],
     unexpandable?: boolean, // used in \let
+    defaultArgs?: Token[][],
 };
 
 export type MacroDefinition = string | MacroExpansion |

--- a/src/macros.js
+++ b/src/macros.js
@@ -143,9 +143,8 @@ defineMacro("\\char", function(context) {
     return `\\@char{${number}}`;
 });
 
-// \newcommand{\macro}[args]{definition}
-// \renewcommand{\macro}[args]{definition}
-// TODO: Optional arguments: \newcommand{\macro}[args][default]{definition}
+// \newcommand{\macro}[args][default]{definition}
+// \renewcommand{\macro}[args][default]{definition}
 const newcommand = (
     context, existsOK: boolean, nonexistsOK: boolean, skipIfExists: boolean
 ) => {
@@ -167,6 +166,8 @@ const newcommand = (
     }
 
     let numArgs = 0;
+    let defaultArgs = null;
+
     arg = context.consumeArg().tokens;
     if (arg.length === 1 && arg[0].text === "[") {
         let argText = '';
@@ -182,12 +183,17 @@ const newcommand = (
         numArgs = parseInt(argText);
         arg = context.consumeArg().tokens;
     }
+    if (arg.length === 1 && arg[0].text == "[") {
+        defaultArgs = [context.consumeArg("]").tokens];
+        arg = context.consumeArg().tokens;
+    }
 
     if (!(exists && skipIfExists)) {
         // Final arg is the expansion of the macro
         context.macros.set(name, {
             tokens: arg,
             numArgs,
+            defaultArgs
         });
     }
     return '';

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -3715,6 +3715,12 @@ describe("A macro expander", function() {
         expect`\newcommand\foo[1.5]{}`.not.toParse();
     });
 
+    it("\\newcommand accepts optional arguments", () => {
+        expect`\newcommand\foo[1][x]{#1^2}\foo +\foo[y]`.toParseLike`x^2+y^2`;
+        expect`\newcommand\foo[10][x]{#1^2}\foo 123456789`.toParseLike`x^2`;
+        expect`\newcommand\foo[10][x]{#1^2}\foo[0]123456789`.toParseLike`0^2`;
+    });
+
     // This may change in the future, if we support the extra features of
     // \hspace.
     it("should treat \\hspace, \\hskip like \\kern", function() {


### PR DESCRIPTION
<!-- PR title should follow Angular Commit Message Conventions (https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines) -->

**What is the previous behavior before this PR?**
A second optional argument to `\newcommand`, `\renewcommand`, or `\providecommand` causes parse failure.

**What is the new behavior after this PR?**
A second optional argument to `\newcommand`, `\renewcommand`, or `\providecommand` causes the defined macro's first argument to become optional with the provided argument as default value.

<!-- If this PR contains a breaking change, please uncomment following line -->
<!-- BREAKING CHANGE: describe its impact and migration methods -->

<!-- If this PR fixes or closes issues, please uncomment following line and change the issue number -->
Fixes #2228
