### PR TITLE
refactor(Style): replace default export with named

### DIFF
--- a/src/Style.js
+++ b/src/Style.js
@@ -122,9 +122,7 @@ const cramp = [Dc, Dc, Tc, Tc, Sc, Sc, SSc, SSc];
 const text = [D, Dc, T, Tc, T, Tc, T, Tc];
 
 // We only export some of the styles.
-export default {
-    DISPLAY: (styles[D]: Style),
-    TEXT: (styles[T]: Style),
-    SCRIPT: (styles[S]: Style),
-    SCRIPTSCRIPT: (styles[SS]: Style),
-};
+export const DISPLAY = (styles[D]: Style);
+export const TEXT = (styles[T]: Style);
+export const SCRIPT = (styles[S]: Style);
+export const SCRIPTSCRIPT = (styles[SS]: Style);

--- a/src/buildHTML.js
+++ b/src/buildHTML.js
@@ -7,7 +7,7 @@
  */
 
 import ParseError from "./ParseError";
-import Style from "./Style";
+import {DISPLAY, TEXT, SCRIPT, SCRIPTSCRIPT} from "./Style";
 import buildCommon from "./buildCommon";
 import {Span, Anchor} from "./domTree";
 import utils from "./utils";
@@ -29,10 +29,10 @@ const binLeftCanceller = ["leftmost", "mbin", "mopen", "mrel", "mop", "mpunct"];
 const binRightCanceller = ["rightmost", "mrel", "mclose", "mpunct"];
 
 const styleMap = {
-    "display": Style.DISPLAY,
-    "text": Style.TEXT,
-    "script": Style.SCRIPT,
-    "scriptscript": Style.SCRIPTSCRIPT,
+    "display": DISPLAY,
+    "text": TEXT,
+    "script": SCRIPT,
+    "scriptscript": SCRIPTSCRIPT,
 };
 
 type Side = "left" | "right";

--- a/src/buildTree.js
+++ b/src/buildTree.js
@@ -4,14 +4,14 @@ import buildMathML from "./buildMathML";
 import buildCommon from "./buildCommon";
 import Options from "./Options";
 import Settings from "./Settings";
-import Style from "./Style";
+import {DISPLAY, TEXT} from "./Style";
 
 import type {AnyParseNode} from "./parseNode";
 import type {DomSpan} from "./domTree";
 
 const optionsFromSettings = function(settings: Settings) {
     return new Options({
-        style: (settings.displayMode ? Style.DISPLAY : Style.TEXT),
+        style: (settings.displayMode ? DISPLAY : TEXT),
         maxSize: settings.maxSize,
         minRuleThickness: settings.minRuleThickness,
     });

--- a/src/delimiter.js
+++ b/src/delimiter.js
@@ -22,7 +22,7 @@
  */
 
 import ParseError from "./ParseError";
-import Style from "./Style";
+import {TEXT, SCRIPT, SCRIPTSCRIPT} from "./Style";
 
 import {PathNode, SvgNode, SymbolNode} from "./domTree";
 import {sqrtPath, innerPath, tallDelim} from "./svgGeometry";
@@ -147,9 +147,9 @@ const makeLargeDelim = function(delim,
     const inner = mathrmSize(delim, size, mode, options);
     const span = styleWrap(
         buildCommon.makeSpan(["delimsizing", "size" + size], [inner], options),
-        Style.TEXT, options, classes);
+        TEXT, options, classes);
     if (center) {
-        centerSpan(span, options, Style.TEXT);
+        centerSpan(span, options, TEXT);
     }
     return span;
 };
@@ -441,7 +441,7 @@ const makeStackedDelim = function(
     }
 
     // Finally, build the vlist
-    const newOptions = options.havingBaseStyle(Style.TEXT);
+    const newOptions = options.havingBaseStyle(TEXT);
     const inner = buildCommon.makeVList({
         positionType: "bottom",
         positionData: depth,
@@ -450,7 +450,7 @@ const makeStackedDelim = function(
 
     return styleWrap(
         buildCommon.makeSpan(["delimsizing", "mult"], [inner], newOptions),
-        Style.TEXT, options, classes);
+        TEXT, options, classes);
 };
 
 // All surds have 0.08em padding above the vinculum inside the SVG.
@@ -651,9 +651,9 @@ type Delimiter =
 
 // Delimiters that never stack try small delimiters and large delimiters only
 const stackNeverDelimiterSequence = [
-    {type: "small", style: Style.SCRIPTSCRIPT},
-    {type: "small", style: Style.SCRIPT},
-    {type: "small", style: Style.TEXT},
+    {type: "small", style: SCRIPTSCRIPT},
+    {type: "small", style: SCRIPT},
+    {type: "small", style: TEXT},
     {type: "large", size: 1},
     {type: "large", size: 2},
     {type: "large", size: 3},
@@ -662,18 +662,18 @@ const stackNeverDelimiterSequence = [
 
 // Delimiters that always stack try the small delimiters first, then stack
 const stackAlwaysDelimiterSequence = [
-    {type: "small", style: Style.SCRIPTSCRIPT},
-    {type: "small", style: Style.SCRIPT},
-    {type: "small", style: Style.TEXT},
+    {type: "small", style: SCRIPTSCRIPT},
+    {type: "small", style: SCRIPT},
+    {type: "small", style: TEXT},
     {type: "stack"},
 ];
 
 // Delimiters that stack when large try the small and then large delimiters, and
 // stack afterwards
 const stackLargeDelimiterSequence = [
-    {type: "small", style: Style.SCRIPTSCRIPT},
-    {type: "small", style: Style.SCRIPT},
-    {type: "small", style: Style.TEXT},
+    {type: "small", style: SCRIPTSCRIPT},
+    {type: "small", style: SCRIPT},
+    {type: "small", style: TEXT},
     {type: "large", size: 1},
     {type: "large", size: 2},
     {type: "large", size: 3},

--- a/src/environments/array.js
+++ b/src/environments/array.js
@@ -1,6 +1,6 @@
 // @flow
 import buildCommon from "../buildCommon";
-import Style from "../Style";
+import {SCRIPT} from "../Style";
 import defineEnvironment from "../defineEnvironment";
 import {parseCD} from "./cd";
 import defineFunction from "../defineFunction";
@@ -299,7 +299,7 @@ const htmlBuilder: HtmlBuilder<"array"> = function(group, options) {
         // But that needs adjustment because LaTeX applies \scriptstyle to the
         // entire array, including the colspace, but this function applies
         // \scriptstyle only inside each element.
-        const localMultiplier = options.havingStyle(Style.SCRIPT).sizeMultiplier;
+        const localMultiplier = options.havingStyle(SCRIPT).sizeMultiplier;
         arraycolsep = 0.2778 * (localMultiplier / options.sizeMultiplier);
     }
 

--- a/src/functions/genfrac.js
+++ b/src/functions/genfrac.js
@@ -3,7 +3,7 @@ import defineFunction, {normalizeArgument} from "../defineFunction";
 import buildCommon from "../buildCommon";
 import delimiter from "../delimiter";
 import mathMLTree from "../mathMLTree";
-import Style from "../Style";
+import {DISPLAY, TEXT, SCRIPT, SCRIPTSCRIPT} from "../Style";
 import {assertNodeType} from "../parseNode";
 import {assert} from "../utils";
 
@@ -18,15 +18,15 @@ const adjustStyle = (size, originalStyle) => {
     if (size === "display") {
         // Get display style as a default.
         // If incoming style is sub/sup, use style.text() to get correct size.
-        style = style.id >= Style.SCRIPT.id ? style.text() : Style.DISPLAY;
+        style = style.id >= SCRIPT.id ? style.text() : DISPLAY;
     } else if (size === "text" &&
-        style.size === Style.DISPLAY.size) {
+        style.size === DISPLAY.size) {
         // We're in a \tfrac but incoming style is displaystyle, so:
-        style = Style.TEXT;
+        style = TEXT;
     } else if (size === "script") {
-        style = Style.SCRIPT;
+        style = SCRIPT;
     } else if (size === "scriptscript") {
-        style = Style.SCRIPTSCRIPT;
+        style = SCRIPTSCRIPT;
     }
     return style;
 };
@@ -76,7 +76,7 @@ const htmlBuilder = (group, options) => {
     let numShift;
     let clearance;
     let denomShift;
-    if (style.size === Style.DISPLAY.size || group.size === "display") {
+    if (style.size === DISPLAY.size || group.size === "display") {
         numShift = options.fontMetrics().num1;
         if (ruleWidth > 0) {
             clearance = 3 * ruleSpacing;
@@ -150,10 +150,10 @@ const htmlBuilder = (group, options) => {
 
     // Rule 15e
     let delimSize;
-    if (style.size === Style.DISPLAY.size) {
+    if (style.size === DISPLAY.size) {
         delimSize = options.fontMetrics().delim1;
-    } else if (style.size === Style.SCRIPTSCRIPT.size) {
-        delimSize = options.havingStyle(Style.SCRIPT).fontMetrics().delim2;
+    } else if (style.size === SCRIPTSCRIPT.size) {
+        delimSize = options.havingStyle(SCRIPT).fontMetrics().delim2;
     } else {
         delimSize = options.fontMetrics().delim2;
     }
@@ -202,7 +202,7 @@ const mathmlBuilder = (group, options) => {
     const style = adjustStyle(group.size, options.style);
     if (style.size !== options.style.size) {
         node = new mathMLTree.MathNode("mstyle", [node]);
-        const isDisplay = (style.size === Style.DISPLAY.size) ? "true" : "false";
+        const isDisplay = (style.size === DISPLAY.size) ? "true" : "false";
         node.setAttribute("displaystyle", isDisplay);
         node.setAttribute("scriptlevel", "0");
     }

--- a/src/functions/horizBrace.js
+++ b/src/functions/horizBrace.js
@@ -3,7 +3,7 @@ import defineFunction from "../defineFunction";
 import buildCommon from "../buildCommon";
 import mathMLTree from "../mathMLTree";
 import stretchy from "../stretchy";
-import Style from "../Style";
+import {DISPLAY} from "../Style";
 import {assertNodeType} from "../parseNode";
 
 import * as html from "../buildHTML";
@@ -34,7 +34,7 @@ export const htmlBuilder: HtmlBuilderSupSub<"horizBrace"> = (grp, options) => {
 
     // Build the base group
     const body = html.buildGroup(
-        group.base, options.havingBaseStyle(Style.DISPLAY));
+        group.base, options.havingBaseStyle(DISPLAY));
 
     // Create the stretchy element
     const braceBody = stretchy.svgSpan(group, options);

--- a/src/functions/mathchoice.js
+++ b/src/functions/mathchoice.js
@@ -1,7 +1,7 @@
 // @flow
 import defineFunction, {ordargument} from "../defineFunction";
 import buildCommon from "../buildCommon";
-import Style from "../Style";
+import {DISPLAY, TEXT, SCRIPT, SCRIPTSCRIPT} from "../Style";
 
 import * as html from "../buildHTML";
 import * as mml from "../buildMathML";
@@ -10,10 +10,10 @@ import type {ParseNode} from "../parseNode";
 
 const chooseMathStyle = (group: ParseNode<"mathchoice">, options) => {
     switch (options.style.size) {
-        case Style.DISPLAY.size: return group.display;
-        case Style.TEXT.size: return group.text;
-        case Style.SCRIPT.size: return group.script;
-        case Style.SCRIPTSCRIPT.size: return group.scriptscript;
+        case DISPLAY.size: return group.display;
+        case TEXT.size: return group.text;
+        case SCRIPT.size: return group.script;
+        case SCRIPTSCRIPT.size: return group.scriptscript;
         default: return group.text;
     }
 };

--- a/src/functions/op.js
+++ b/src/functions/op.js
@@ -5,7 +5,7 @@ import buildCommon from "../buildCommon";
 import {SymbolNode} from "../domTree";
 import * as mathMLTree from "../mathMLTree";
 import utils from "../utils";
-import Style from "../Style";
+import {DISPLAY} from "../Style";
 import {assembleSupSub} from "./utils/assembleSupSub";
 import {assertNodeType} from "../parseNode";
 import {makeEm} from "../units";
@@ -44,7 +44,7 @@ export const htmlBuilder: HtmlBuilderSupSub<"op"> = (grp, options) => {
     const style = options.style;
 
     let large = false;
-    if (style.size === Style.DISPLAY.size &&
+    if (style.size === DISPLAY.size &&
         group.symbol &&
         !utils.contains(noSuccessor, group.name)) {
 

--- a/src/functions/sqrt.js
+++ b/src/functions/sqrt.js
@@ -3,7 +3,7 @@ import defineFunction from "../defineFunction";
 import buildCommon from "../buildCommon";
 import mathMLTree from "../mathMLTree";
 import delimiter from "../delimiter";
-import Style from "../Style";
+import {TEXT, SCRIPTSCRIPT} from "../Style";
 import {makeEm} from "../units";
 
 import * as html from "../buildHTML";
@@ -46,7 +46,7 @@ defineFunction({
         const theta = metrics.defaultRuleThickness;
 
         let phi = theta;
-        if (options.style.id < Style.TEXT.id) {
+        if (options.style.id < TEXT.id) {
             phi = options.fontMetrics().xHeight;
         }
 
@@ -90,7 +90,7 @@ defineFunction({
             // Handle the optional root index
 
             // The index is always in scriptscript style
-            const newOptions = options.havingStyle(Style.SCRIPTSCRIPT);
+            const newOptions = options.havingStyle(SCRIPTSCRIPT);
             const rootm = html.buildGroup(group.index, newOptions, options);
 
             // The amount the index is shifted by. This is taken from the TeX

--- a/src/functions/styling.js
+++ b/src/functions/styling.js
@@ -1,16 +1,16 @@
 // @flow
 import defineFunction from "../defineFunction";
 import mathMLTree from "../mathMLTree";
-import Style from "../Style";
+import {DISPLAY, TEXT, SCRIPT, SCRIPTSCRIPT} from "../Style";
 import {sizingGroup} from "./sizing";
 
 import * as mml from "../buildMathML";
 
 const styleMap = {
-    "display": Style.DISPLAY,
-    "text": Style.TEXT,
-    "script": Style.SCRIPT,
-    "scriptscript": Style.SCRIPTSCRIPT,
+    "display": DISPLAY,
+    "text": TEXT,
+    "script": SCRIPT,
+    "scriptscript": SCRIPTSCRIPT,
 };
 
 defineFunction({

--- a/src/functions/supsub.js
+++ b/src/functions/supsub.js
@@ -5,7 +5,7 @@ import {SymbolNode} from "../domTree";
 import mathMLTree from "../mathMLTree";
 import utils from "../utils";
 import {makeEm} from "../units";
-import Style from "../Style";
+import {DISPLAY} from "../Style";
 
 import * as html from "../buildHTML";
 import * as mml from "../buildMathML";
@@ -37,12 +37,12 @@ const htmlBuilderDelegate = function(
         // Operators handle supsubs differently when they have limits
         // (e.g. `\displaystyle\sum_2^3`)
         const delegate = base.limits &&
-            (options.style.size === Style.DISPLAY.size ||
+            (options.style.size === DISPLAY.size ||
             base.alwaysHandleSupSub);
         return delegate ? op.htmlBuilder : null;
     } else if (base.type === "operatorname") {
         const delegate = base.alwaysHandleSupSub &&
-            (options.style.size === Style.DISPLAY.size || base.limits);
+            (options.style.size === DISPLAY.size || base.limits);
         return delegate ? operatorname.htmlBuilder : null;
     } else if (base.type === "accent") {
         return utils.isCharacterBox(base.base) ? accent.htmlBuilder : null;
@@ -101,7 +101,7 @@ defineFunctionBuilders({
 
         // Rule 18c
         let minSupShift;
-        if (options.style === Style.DISPLAY) {
+        if (options.style === DISPLAY) {
             minSupShift = metrics.sup1;
         } else if (options.style.cramped) {
             minSupShift = metrics.sup3;
@@ -226,11 +226,11 @@ defineFunctionBuilders({
         } else if (!group.sub) {
             const base = group.base;
             if (base && base.type === "op" && base.limits &&
-                (options.style === Style.DISPLAY || base.alwaysHandleSupSub)) {
+                (options.style === DISPLAY || base.alwaysHandleSupSub)) {
                 nodeType = "mover";
             } else if (base && base.type === "operatorname" &&
                 base.alwaysHandleSupSub &&
-                (base.limits || options.style === Style.DISPLAY)) {
+                (base.limits || options.style === DISPLAY)) {
                 nodeType = "mover";
             } else {
                 nodeType = "msup";
@@ -238,11 +238,11 @@ defineFunctionBuilders({
         } else if (!group.sup) {
             const base = group.base;
             if (base && base.type === "op" && base.limits &&
-                (options.style === Style.DISPLAY || base.alwaysHandleSupSub)) {
+                (options.style === DISPLAY || base.alwaysHandleSupSub)) {
                 nodeType = "munder";
             } else if (base && base.type === "operatorname" &&
                 base.alwaysHandleSupSub &&
-                (base.limits || options.style === Style.DISPLAY)) {
+                (base.limits || options.style === DISPLAY)) {
                 nodeType = "munder";
             } else {
                 nodeType = "msub";
@@ -250,11 +250,11 @@ defineFunctionBuilders({
         } else {
             const base = group.base;
             if (base && base.type === "op" && base.limits &&
-                options.style === Style.DISPLAY) {
+                options.style === DISPLAY) {
                 nodeType = "munderover";
             } else if (base && base.type === "operatorname" &&
                 base.alwaysHandleSupSub &&
-                (options.style === Style.DISPLAY || base.limits)) {
+                (options.style === DISPLAY || base.limits)) {
                 nodeType = "munderover";
             } else {
                 nodeType = "msubsup";

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -7,14 +7,14 @@ import parseTree from "../src/parseTree";
 import Options from "../src/Options";
 import ParseError from "../src/ParseError";
 import Settings from "../src/Settings";
-import Style from "../src/Style";
+import {TEXT} from "../src/Style";
 import {
     strictSettings, nonstrictSettings, trustSettings, r,
     getBuilt, getParsed, stripPositions,
 } from "./helpers";
 
 const defaultOptions = new Options({
-    style: Style.TEXT,
+    style: TEXT,
     size: 5,
     maxSize: Infinity,
 });

--- a/test/mathml-spec.js
+++ b/test/mathml-spec.js
@@ -2,12 +2,12 @@ import buildMathML from "../src/buildMathML";
 import parseTree from "../src/parseTree";
 import Options from "../src/Options";
 import Settings from "../src/Settings";
-import Style from "../src/Style";
+import {DISPLAY, TEXT} from "../src/Style";
 
 const getMathML = function(expr, settings = new Settings()) {
-    let startStyle = Style.TEXT;
+    let startStyle = TEXT;
     if (settings.displayMode) {
-        startStyle = Style.DISPLAY;
+        startStyle = DISPLAY;
     }
 
     // Setup the default options


### PR DESCRIPTION
<!-- PR title should follow Angular Commit Message Conventions (https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines) -->
This PR is done in assumption, that only some files require all for exported Style types and for most of them only subset they use would be sufficient, and unused instances wouldn't be imported, reducing bundle size. It is indeed **slightly** smaller, from 608.07 KB to 607.53 KB based on `yarn analyze` (parsed). 

I feel like maybe if this done at the scale it could reduce bundle more ~~significantly~~, but I'm interested in maintainers opinion about this, is it worth checking all default exports or do you prefer them over the named?

**What is the previous behavior before this PR?**
`export default` was used

**What is the new behavior after this PR?**
`export const` is used now

<!-- If this PR contains a breaking change, please uncomment following line -->
<!-- BREAKING CHANGE: describe its impact and migration methods -->

<!-- If this PR fixes or closes issues, please uncomment following line and change the issue number -->
<!-- Fixes #1, Closes #2 -->
