### PR TITLE
fix: Support `\def` with arguments via `macros` option

### DIFF
--- a/src/MacroExpander.js
+++ b/src/MacroExpander.js
@@ -10,6 +10,7 @@ import Lexer from "./Lexer";
 import {Token} from "./Token";
 import type {Mode} from "./types";
 import ParseError from "./ParseError";
+import SourceLocation from "./SourceLocation";
 import Namespace from "./Namespace";
 import macros from "./macros";
 
@@ -138,7 +139,7 @@ export default class MacroExpander implements MacroContextInterface {
         this.pushToken(new Token("EOF", end.loc));
 
         this.pushTokens(tokens);
-        return start.range(end, "");
+        return new Token("", SourceLocation.range(start, end));
     }
 
     /**

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -3656,6 +3656,18 @@ describe("A macro expander", function() {
         }});
     });
 
+    it("macros argument can simulate \\def with arguments", () => {
+        expect`\t x`.toParseLike("\\text{x}", {macros: {
+            "\\t": {
+                tokens: [
+                    {text: "}"}, {text: "1"}, {text: "#"}, {text: "{"},
+                    {text: "\\text"},
+                ],
+                numArgs: 1,
+            },
+        }});
+    });
+
     it("\\newcommand doesn't change settings.macros", () => {
         const macros = {};
         expect`\newcommand\foo{x^2}\foo+\foo`.toParse(new Settings({macros}));


### PR DESCRIPTION
**What is the previous behavior before this PR?**
Passing in `tokens` in a `macros` object sometimes caused the error `Uncaught TypeError: start.range is not a function`. It seems to occur when using arguments in the macro and braces are involved.

**What is the new behavior after this PR?**
No more errors, at least that I could find. Continuation of #3738.

We were somewhat abusing `Token.range` here anyway, and it doesn't work if our tokens didn't come from our text source, and instead came from the use via `macros`.