### PR TITLE
fix: \mathop followed by integral symbol

### DIFF
--- a/src/functions/op.js
+++ b/src/functions/op.js
@@ -313,6 +313,7 @@ defineFunction({
     ],
     props: {
         numArgs: 0,
+        allowedInArgument: true,
     },
     handler({parser, funcName}) {
         let fName = funcName;

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -1579,6 +1579,8 @@ describe("An op symbol builder", function() {
         expect`\oint\nolimits_i^n`.toBuild();
         expect`\oiint\nolimits_i^n`.toBuild();
         expect`\oiiint\nolimits_i^n`.toBuild();
+        expect`\mathop{\int}`.toBuild();
+        expect`\mathop \int`.toBuild();
     });
 });
 


### PR DESCRIPTION
Fixes issue #4111.