### PR TITLE
feat: add support for browser-supplied math font (#4119)

### DIFF
--- a/src/styles/fonts.scss
+++ b/src/styles/fonts.scss
@@ -2,6 +2,8 @@ $font-folder: "../../fonts" !default;
 $use-woff2: true !default;
 $use-woff: true !default;
 $use-ttf: true !default;
+$use-browser-math-font: false !default;
+$math-prefix: if($use-browser-math-font, math, null);
 $font-display: block !default;
 
 @function generate-src($family, $family-suffix) {
@@ -39,15 +41,18 @@ $font-display: block !default;
 }
 
 @mixin font-face($family, $weight, $style) {
-    $suffix: generate-suffix($weight, $style);
-    $src: generate-src($family, $suffix);
+    @if not $use-browser-math-font {
+        $suffix: generate-suffix($weight, $style);
+        $src: generate-src($family, $suffix);
+    
 
-    @font-face {
-        font-family: 'KaTeX_#{$family}';
-        src: $src;
-        font-weight: $weight;
-        font-style: $style;
-        font-display: $font-display;
+        @font-face {
+            font-family: 'KaTeX_#{$family}';
+            src: $src;
+            font-weight: $weight;
+            font-style: $style;
+            font-display: $font-display;
+        }
     }
 }
 

--- a/src/styles/fonts.scss
+++ b/src/styles/fonts.scss
@@ -3,7 +3,6 @@ $use-woff2: true !default;
 $use-woff: true !default;
 $use-ttf: true !default;
 $use-browser-math-font: false !default;
-$math-prefix: if($use-browser-math-font, math, ());
 $font-display: block !default;
 
 @function generate-src($family, $family-suffix) {
@@ -44,7 +43,6 @@ $font-display: block !default;
     @if not $use-browser-math-font {
         $suffix: generate-suffix($weight, $style);
         $src: generate-src($family, $suffix);
-    
 
         @font-face {
             font-family: 'KaTeX_#{$family}';

--- a/src/styles/fonts.scss
+++ b/src/styles/fonts.scss
@@ -3,7 +3,7 @@ $use-woff2: true !default;
 $use-woff: true !default;
 $use-ttf: true !default;
 $use-browser-math-font: false !default;
-$math-prefix: if($use-browser-math-font, math, null);
+$math-prefix: if($use-browser-math-font, math, ());
 $font-display: block !default;
 
 @function generate-src($family, $family-suffix) {

--- a/src/styles/katex.scss
+++ b/src/styles/katex.scss
@@ -11,9 +11,15 @@ $version: "" !default;
 $display-margin: 1em 0 !default;
 
 .katex {
-    font: normal 1.21em $math-prefix, KaTeX_Main, Times New Roman, serif;
-    line-height: 1.2;
+    @if $use-browser-math-font {
+        font: normal 1.21em math, KaTeX_Main, Times New Roman, serif;
+    }
 
+    @else {
+        font: normal 1.21em KaTeX_Main, Times New Roman, serif;
+    }
+
+    line-height: 1.2;
     // Protect elements inside .katex from inheriting text-indent.
     text-indent: 0;
 
@@ -90,7 +96,14 @@ $display-margin: 1em 0 !default;
 
     // Math fonts.
     .mathnormal {
-        font-family: $math-prefix, KaTeX_Math;
+        @if $use-browser-math-font {
+            font-family: math, KaTeX_Math;
+        }
+
+        @else {
+            font-family: KaTeX_Math;
+        }
+
         font-style: italic;
     }
 
@@ -104,8 +117,15 @@ $display-margin: 1em 0 !default;
     }
 
     .mathbf {
-        font-family: $math-prefix, KaTeX_Main;
-        font-weight: bold;
+        @if $use-browser-math-font {
+            font-family: math, KaTeX_Math;
+        }
+
+        @else {
+            font-family: KaTeX_Math;
+        }
+
+        font-style: bold;
     }
 
     .boldsymbol {

--- a/src/styles/katex.scss
+++ b/src/styles/katex.scss
@@ -11,7 +11,7 @@ $version: "" !default;
 $display-margin: 1em 0 !default;
 
 .katex {
-    font: normal 1.21em KaTeX_Main, Times New Roman, serif;
+    font: normal 1.21em $math-prefix, KaTeX_Main, Times New Roman, serif;
     line-height: 1.2;
 
     // Protect elements inside .katex from inheriting text-indent.
@@ -90,7 +90,7 @@ $display-margin: 1em 0 !default;
 
     // Math fonts.
     .mathnormal {
-        font-family: KaTeX_Math;
+        font-family: $math-prefix, KaTeX_Math;
         font-style: italic;
     }
 
@@ -104,7 +104,7 @@ $display-margin: 1em 0 !default;
     }
 
     .mathbf {
-        font-family: KaTeX_Main;
+        font-family: $math-prefix, KaTeX_Main;
         font-weight: bold;
     }
 


### PR DESCRIPTION
<!-- PR title should follow Angular Commit Message Conventions (https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines) -->

**What is the previous behavior before this PR?**
Previously, KaTeX always required downloading and using its own web fonts (KaTeX_Main, KaTeX_Math, etc.) to render math symbols correctly. There was no built-in option to utilize the native font-family: math supported by modern browsers, which could lead to unnecessary network requests for users who prefer system math fonts.

**What is the new behavior after this PR?**
This PR introduces a new Sass variable $use-browser-math-font (defaulting to false). When set to true:

-  It prepends the math keyword to font-family declarations for .katex, .mathnormal, and .mathbf classes.

-  It suppresses @font-face declarations to prevent the browser from downloading KaTeX web fonts, reducing the initial page load weight.

- Browsers supporting the math family will use the system's math font, while others will fallback to standard system fonts (serif).

Closes #4119