### PR TITLE
refactor: switch buildCommon to named exports

### DIFF
--- a/katex.js
+++ b/katex.js
@@ -13,7 +13,7 @@ import Settings, {SETTINGS_SCHEMA} from "./src/Settings";
 
 import {buildTree, buildHTMLTree} from "./src/buildTree";
 import parseTree from "./src/parseTree";
-import buildCommon from "./src/buildCommon";
+import {makeSpan} from "./src/buildCommon";
 import {
     Span,
     Anchor,
@@ -97,7 +97,7 @@ const renderError = function(
     if (options.throwOnError || !(error instanceof ParseError)) {
         throw error;
     }
-    const node = buildCommon.makeSpan(["katex-error"],
+    const node = makeSpan(["katex-error"],
         [new SymbolNode(expression)]);
     node.setAttribute("title", error.toString());
     node.setAttribute("style", `color:${options.errorColor}`);

--- a/src/buildCommon.js
+++ b/src/buildCommon.js
@@ -50,7 +50,7 @@ const lookupSymbol = function(
  * should if present come first in `classes`.
  * TODO(#953): Make `options` mandatory and always pass it in.
  */
-const makeSymbol = function(
+export const makeSymbol = function(
     value: string,
     fontName: string,
     mode: Mode,
@@ -95,7 +95,7 @@ const makeSymbol = function(
  * Makes a symbol in Main-Regular or AMS-Regular.
  * Used for rel, bin, open, close, inner, and punct.
  */
-const mathsym = function(
+export const mathsym = function(
     value: string,
     mode: Mode,
     options: Options,
@@ -152,7 +152,7 @@ const boldsymbol = function(
 /**
  * Makes either a mathord or textord in the correct font and color.
  */
-const makeOrd = function<NODETYPE: "spacing" | "mathord" | "textord">(
+export const makeOrd = function<NODETYPE: "spacing" | "mathord" | "textord">(
     group: ParseNode<NODETYPE>,
     options: Options,
     type: "mathord" | "textord",
@@ -277,7 +277,7 @@ const canCombine = (prev: SymbolNode, next: SymbolNode) => {
  * Combine consecutive domTree.symbolNodes into a single symbolNode.
  * Note: this function mutates the argument.
  */
-const tryCombineChars = (chars: HtmlDomNode[]): HtmlDomNode[] => {
+export const tryCombineChars = (chars: HtmlDomNode[]): HtmlDomNode[] => {
     for (let i = 0; i < chars.length - 1; i++) {
         const prev = chars[i];
         const next = chars[i + 1];
@@ -336,7 +336,7 @@ const sizeElementFromChildren = function(
  * TODO: add a separate argument for math class (e.g. `mop`, `mbin`), which
  * should if present come first in `classes`.
  */
-const makeSpan = function(
+export const makeSpan = function(
     classes?: string[],
     children?: HtmlDomNode[],
     options?: Options,
@@ -351,14 +351,14 @@ const makeSpan = function(
 
 // SVG one is simpler -- doesn't require height, depth, max-font setting.
 // This is also a separate method for typesafety.
-const makeSvgSpan = (
+export const makeSvgSpan = (
     classes?: string[],
     children?: SvgNode[],
     options?: Options,
     style?: CssStyle,
 ): SvgSpan => new Span(classes, children, options, style);
 
-const makeLineSpan = function(
+export const makeLineSpan = function(
     className: string,
     options: Options,
     thickness?: number,
@@ -377,7 +377,7 @@ const makeLineSpan = function(
  * Makes an anchor with the given href, list of classes, list of children,
  * and options.
  */
-const makeAnchor = function(
+export const makeAnchor = function(
     href: string,
     classes: string[],
     children: HtmlDomNode[],
@@ -393,7 +393,7 @@ const makeAnchor = function(
 /**
  * Makes a document fragment with the given list of children.
  */
-const makeFragment = function(
+export const makeFragment = function(
     children: HtmlDomNode[],
 ): HtmlDocumentFragment {
     const fragment = new DocumentFragment(children);
@@ -407,7 +407,7 @@ const makeFragment = function(
  * Wraps group in a span if it's a document fragment, allowing to apply classes
  * and styles
  */
-const wrapFragment = function(
+export const wrapFragment = function(
     group: HtmlDomNode,
     options: Options,
 ): HtmlDomNode {
@@ -534,7 +534,7 @@ const getVListChildrenAndDepth = function(params: VListParam): {
  *
  * See VListParam documentation above.
  */
-const makeVList = function(params: VListParam, options: Options): DomSpan {
+export const makeVList = function(params: VListParam, options: Options): DomSpan {
     const {children, depth} = getVListChildrenAndDepth(params);
 
     // Create a strut that is taller than any list item. The strut is added to
@@ -626,7 +626,7 @@ const makeVList = function(params: VListParam, options: Options): DomSpan {
 // Glue is a concept from TeX which is a flexible space between elements in
 // either a vertical or horizontal list. In KaTeX, at least for now, it's
 // static space between elements in a horizontal layout.
-const makeGlue = (measurement: Measurement, options: Options): DomSpan => {
+export const makeGlue = (measurement: Measurement, options: Options): DomSpan => {
     // Make an empty span for the space
     const rule = makeSpan(["mspace"], [], options);
     const size = calculateSize(measurement, options);
@@ -678,7 +678,7 @@ const retrieveTextFontName = function(
  * - fontName: the "style" parameter to fontMetrics.getCharacterMetrics
  */
 // A map between tex font commands an MathML mathvariant attribute values
-const fontMap: {[string]: {| variant: FontVariant, fontName: string |}} = {
+export const fontMap: {[string]: {| variant: FontVariant, fontName: string |}} = {
     // styles
     "mathbf": {
         variant: "bold",
@@ -735,7 +735,7 @@ const fontMap: {[string]: {| variant: FontVariant, fontName: string |}} = {
     },
 };
 
-const svgData: {
+export const svgData: {
     [string]: ([string, number, number])
 } = {
      //   path, width, height
@@ -746,7 +746,7 @@ const svgData: {
     oiiintSize2: ["oiiintSize2", 1.98, 0.659],
 };
 
-const staticSvg = function(value: string, options: Options): SvgSpan {
+export const staticSvg = function(value: string, options: Options): SvgSpan {
     // Create a span with inline SVG for the element.
     const [pathName, width, height] = svgData[value];
     const path = new PathNode(pathName);
@@ -763,22 +763,4 @@ const staticSvg = function(value: string, options: Options): SvgSpan {
     span.style.height = makeEm(height);
     span.style.width = makeEm(width);
     return span;
-};
-
-export default {
-    fontMap,
-    makeSymbol,
-    mathsym,
-    makeSpan,
-    makeSvgSpan,
-    makeLineSpan,
-    makeAnchor,
-    makeFragment,
-    wrapFragment,
-    makeVList,
-    makeOrd,
-    makeGlue,
-    staticSvg,
-    svgData,
-    tryCombineChars,
 };

--- a/src/buildHTML.js
+++ b/src/buildHTML.js
@@ -8,7 +8,7 @@
 
 import ParseError from "./ParseError";
 import Style from "./Style";
-import buildCommon from "./buildCommon";
+import {makeGlue, makeSpan, tryCombineChars} from "./buildCommon";
 import {Span, Anchor} from "./domTree";
 import {makeEm} from "./units";
 import {spacings, tightSpacings} from "./spacingData";
@@ -18,8 +18,6 @@ import {DocumentFragment} from "./tree";
 import type Options from "./Options";
 import type {AnyParseNode} from "./parseNode";
 import type {HtmlDomNode, DomSpan} from "./domTree";
-
-const makeSpan = buildCommon.makeSpan;
 
 // Binary atoms (first class `mbin`) change into ordinary atoms (`mord`)
 // depending on their surroundings. See TeXbook pg. 442-446, Rules 5 and 6,
@@ -75,7 +73,7 @@ export const buildExpression = function(
     }
 
     // Combine consecutive domTree.symbolNodes into a single symbolNode.
-    buildCommon.tryCombineChars(groups);
+    tryCombineChars(groups);
 
     // If `expression` is a partial group, let the parent handle spacings
     // to avoid processing groups multiple times.
@@ -125,7 +123,7 @@ export const buildExpression = function(
             ? tightSpacings[prevType][type]
             : spacings[prevType][type]) : null;
         if (space) { // Insert glue (spacing) after the `prev`.
-            return buildCommon.makeGlue(space, glueOptions);
+            return makeGlue(space, glueOptions);
         }
     }, {node: dummyPrev}, dummyNext, isRoot);
 

--- a/src/buildMathML.js
+++ b/src/buildMathML.js
@@ -5,7 +5,7 @@
  * parser.
  */
 
-import buildCommon from "./buildCommon";
+import {fontMap, makeSpan} from "./buildCommon";
 import {getCharacterMetrics} from "./fontMetrics";
 import ParseError from "./ParseError";
 import symbols, {ligatures} from "./symbols";
@@ -118,9 +118,9 @@ export const getVariant = function(
         text = symbols[mode][text].replace;
     }
 
-    const fontName = buildCommon.fontMap[font].fontName;
+    const fontName = fontMap[font].fontName;
     if (getCharacterMetrics(text, fontName, mode)) {
-        return buildCommon.fontMap[font].variant;
+        return fontMap[font].variant;
     }
 
     return null;
@@ -316,5 +316,5 @@ export default function buildMathML(
     // of span are expected to have more fields in `buildHtml` contexts.
     const wrapperClass = forMathmlOnly ? "katex" : "katex-mathml";
     // $FlowFixMe
-    return buildCommon.makeSpan([wrapperClass], [math]);
+    return makeSpan([wrapperClass], [math]);
 }

--- a/src/buildTree.js
+++ b/src/buildTree.js
@@ -1,7 +1,7 @@
 // @flow
 import buildHTML from "./buildHTML";
 import buildMathML from "./buildMathML";
-import buildCommon from "./buildCommon";
+import {makeSpan} from "./buildCommon";
 import Options from "./Options";
 import Settings from "./Settings";
 import Style from "./Style";
@@ -26,7 +26,7 @@ const displayWrap = function(node: DomSpan, settings: Settings): DomSpan {
         if (settings.fleqn) {
             classes.push("fleqn");
         }
-        node = buildCommon.makeSpan(classes, [node]);
+        node = makeSpan(classes, [node]);
     }
     return node;
 };
@@ -42,12 +42,12 @@ export const buildTree = function(
         return  buildMathML(tree, expression, options, settings.displayMode, true);
     } else if (settings.output === "html") {
         const htmlNode = buildHTML(tree, options);
-        katexNode = buildCommon.makeSpan(["katex"], [htmlNode]);
+        katexNode = makeSpan(["katex"], [htmlNode]);
     } else {
         const mathMLNode = buildMathML(tree, expression, options,
             settings.displayMode, false);
         const htmlNode = buildHTML(tree, options);
-        katexNode = buildCommon.makeSpan(["katex"], [mathMLNode, htmlNode]);
+        katexNode = makeSpan(["katex"], [mathMLNode, htmlNode]);
     }
 
     return displayWrap(katexNode, settings);
@@ -60,7 +60,7 @@ export const buildHTMLTree = function(
 ): DomSpan {
     const options = optionsFromSettings(settings);
     const htmlNode = buildHTML(tree, options);
-    const katexNode = buildCommon.makeSpan(["katex"], [htmlNode]);
+    const katexNode = makeSpan(["katex"], [htmlNode]);
     return displayWrap(katexNode, settings);
 };
 

--- a/src/delimiter.js
+++ b/src/delimiter.js
@@ -26,7 +26,7 @@ import Style from "./Style";
 
 import {PathNode, SvgNode, SymbolNode} from "./domTree";
 import {sqrtPath, innerPath, tallDelim} from "./svgGeometry";
-import buildCommon from "./buildCommon";
+import {makeSpan, makeSymbol, makeSvgSpan, makeVList} from "./buildCommon";
 import {getCharacterMetrics} from "./fontMetrics";
 import symbols from "./symbols";
 import {makeEm} from "./units";
@@ -69,7 +69,7 @@ const styleWrap = function(
 ): DomSpan {
     const newOptions = options.havingBaseStyle(toStyle);
 
-    const span = buildCommon.makeSpan(
+    const span = makeSpan(
         classes.concat(newOptions.sizingClasses(options)),
         [delim], options);
 
@@ -111,7 +111,7 @@ const makeSmallDelim = function(
     mode: Mode,
     classes: string[],
 ): DomSpan {
-    const text = buildCommon.makeSymbol(delim, "Main-Regular", mode, options);
+    const text = makeSymbol(delim, "Main-Regular", mode, options);
     const span = styleWrap(text, style, options, classes);
     if (center) {
         centerSpan(span, options, style);
@@ -128,7 +128,7 @@ const mathrmSize = function(
     mode: Mode,
     options: Options,
 ): SymbolNode {
-    return buildCommon.makeSymbol(value, "Size" + size + "-Regular",
+    return makeSymbol(value, "Size" + size + "-Regular",
         mode, options);
 };
 
@@ -145,7 +145,7 @@ const makeLargeDelim = function(delim,
 ): DomSpan {
     const inner = mathrmSize(delim, size, mode, options);
     const span = styleWrap(
-        buildCommon.makeSpan(["delimsizing", "size" + size], [inner], options),
+        makeSpan(["delimsizing", "size" + size], [inner], options),
         Style.TEXT, options, classes);
     if (center) {
         centerSpan(span, options, Style.TEXT);
@@ -170,9 +170,9 @@ const makeGlyphSpan = function(
         sizeClass = "delim-size4";
     }
 
-    const corner = buildCommon.makeSpan(
+    const corner = makeSpan(
         ["delimsizinginner", sizeClass],
-        [buildCommon.makeSpan([], [buildCommon.makeSymbol(symbol, font, mode)])]);
+        [makeSpan([], [makeSymbol(symbol, font, mode)])]);
 
     // Since this will be passed into `makeVList` in the end, wrap the element
     // in the appropriate tag that VList uses.
@@ -197,7 +197,7 @@ const makeInner = function(
         "viewBox": "0 0 " + 1000 * width + " " + Math.round(1000 * height),
         "preserveAspectRatio": "xMinYMin",
     });
-    const span = buildCommon.makeSvgSpan([], [svgNode], options);
+    const span = makeSvgSpan([], [svgNode], options);
     span.height = height;
     span.style.height = makeEm(height);
     span.style.width = makeEm(width);
@@ -404,7 +404,7 @@ const makeStackedDelim = function(
             "height": height,
             "viewBox": `0 0 ${viewBoxWidth} ${viewBoxHeight}`,
         });
-        const wrapper = buildCommon.makeSvgSpan([], [svg], options);
+        const wrapper = makeSvgSpan([], [svg], options);
         wrapper.height = viewBoxHeight / 1000;
         wrapper.style.width = width;
         wrapper.style.height = height;
@@ -441,14 +441,14 @@ const makeStackedDelim = function(
 
     // Finally, build the vlist
     const newOptions = options.havingBaseStyle(Style.TEXT);
-    const inner = buildCommon.makeVList({
+    const inner = makeVList({
         positionType: "bottom",
         positionData: depth,
         children: stack,
     }, newOptions);
 
     return styleWrap(
-        buildCommon.makeSpan(["delimsizing", "mult"], [inner], newOptions),
+        makeSpan(["delimsizing", "mult"], [inner], newOptions),
         Style.TEXT, options, classes);
 };
 
@@ -475,7 +475,7 @@ const sqrtSvg = function(
         "preserveAspectRatio": "xMinYMin slice",
     });
 
-    return buildCommon.makeSvgSpan(["hide-tail"], [svg], options);
+    return makeSvgSpan(["hide-tail"], [svg], options);
 };
 
 /**

--- a/src/environments/array.js
+++ b/src/environments/array.js
@@ -1,5 +1,5 @@
 // @flow
-import buildCommon from "../buildCommon";
+import {makeFragment, makeLineSpan, makeSpan, makeVList} from "../buildCommon";
 import Style from "../Style";
 import defineEnvironment from "../defineEnvironment";
 import {parseCD} from "./cd";
@@ -393,12 +393,12 @@ const htmlBuilder: HtmlBuilder<"array"> = function(group, options) {
             const tag = group.tags[r];
             let tagSpan;
             if (tag === true) {  // automatic numbering
-                tagSpan = buildCommon.makeSpan(["eqn-num"], [], options);
+                tagSpan = makeSpan(["eqn-num"], [], options);
             } else if (tag === false) {
                 // \nonumber/\notag or starred environment
-                tagSpan = buildCommon.makeSpan([], [], options);
+                tagSpan = makeSpan([], [], options);
             } else {  // manual \tag
-                tagSpan = buildCommon.makeSpan([],
+                tagSpan = makeSpan([],
                     html.buildExpression(tag, options, true), options);
             }
             tagSpan.depth = rw.depth;
@@ -420,7 +420,7 @@ const htmlBuilder: HtmlBuilder<"array"> = function(group, options) {
             // If there is more than one separator in a row, add a space
             // between them.
             if (!firstSeparator) {
-                colSep = buildCommon.makeSpan(["arraycolsep"], []);
+                colSep = makeSpan(["arraycolsep"], []);
                 colSep.style.width =
                     makeEm(options.fontMetrics().doubleRuleSep);
                 cols.push(colSep);
@@ -428,7 +428,7 @@ const htmlBuilder: HtmlBuilder<"array"> = function(group, options) {
 
             if (colDescr.separator === "|" || colDescr.separator === ":") {
                 const lineType = (colDescr.separator === "|") ? "solid" : "dashed";
-                const separator = buildCommon.makeSpan(
+                const separator = makeSpan(
                     ["vertical-separator"], [], options
                 );
                 separator.style.height = makeEm(totalHeight);
@@ -459,7 +459,7 @@ const htmlBuilder: HtmlBuilder<"array"> = function(group, options) {
         if (c > 0 || group.hskipBeforeAndAfter) {
             sepwidth = colDescr.pregap ?? arraycolsep;
             if (sepwidth !== 0) {
-                colSep = buildCommon.makeSpan(["arraycolsep"], []);
+                colSep = makeSpan(["arraycolsep"], []);
                 colSep.style.width = makeEm(sepwidth);
                 cols.push(colSep);
             }
@@ -478,11 +478,11 @@ const htmlBuilder: HtmlBuilder<"array"> = function(group, options) {
             col.push({type: "elem", elem: elem, shift: shift});
         }
 
-        col = buildCommon.makeVList({
+        col = makeVList({
             positionType: "individualShift",
             children: col,
         }, options);
-        col = buildCommon.makeSpan(
+        col = makeSpan(
             ["col-align-" + (colDescr.align || "c")],
             [col]);
         cols.push(col);
@@ -490,18 +490,18 @@ const htmlBuilder: HtmlBuilder<"array"> = function(group, options) {
         if (c < nc - 1 || group.hskipBeforeAndAfter) {
             sepwidth = colDescr.postgap ?? arraycolsep;
             if (sepwidth !== 0) {
-                colSep = buildCommon.makeSpan(["arraycolsep"], []);
+                colSep = makeSpan(["arraycolsep"], []);
                 colSep.style.width = makeEm(sepwidth);
                 cols.push(colSep);
             }
         }
     }
-    body = buildCommon.makeSpan(["mtable"], cols);
+    body = makeSpan(["mtable"], cols);
 
     // Add \hline(s), if any.
     if (hlines.length > 0) {
-        const line = buildCommon.makeLineSpan("hline", options, ruleThickness);
-        const dashes = buildCommon.makeLineSpan("hdashline", options,
+        const line = makeLineSpan("hline", options, ruleThickness);
+        const dashes = makeLineSpan("hdashline", options,
             ruleThickness);
         const vListElems = [{type: "elem", elem: body, shift: 0}];
         while (hlines.length > 0) {
@@ -513,21 +513,21 @@ const htmlBuilder: HtmlBuilder<"array"> = function(group, options) {
                 vListElems.push({type: "elem", elem: line, shift: lineShift});
             }
         }
-        body = buildCommon.makeVList({
+        body = makeVList({
             positionType: "individualShift",
             children: vListElems,
         }, options);
     }
 
     if (tagSpans.length === 0) {
-        return buildCommon.makeSpan(["mord"], [body], options);
+        return makeSpan(["mord"], [body], options);
     } else {
-        let eqnNumCol = buildCommon.makeVList({
+        let eqnNumCol = makeVList({
             positionType: "individualShift",
             children: tagSpans,
         }, options);
-        eqnNumCol = buildCommon.makeSpan(["tag"], [eqnNumCol], options);
-        return buildCommon.makeFragment([body, eqnNumCol]);
+        eqnNumCol = makeSpan(["tag"], [eqnNumCol], options);
+        return makeFragment([body, eqnNumCol]);
     }
 };
 

--- a/src/environments/cd.js
+++ b/src/environments/cd.js
@@ -1,5 +1,5 @@
 // @flow
-import buildCommon from "../buildCommon";
+import {wrapFragment} from "../buildCommon";
 import defineFunction from "../defineFunction";
 import {MathNode} from "../mathMLTree";
 import * as html from "../buildHTML";
@@ -255,7 +255,7 @@ defineFunction({
     },
     htmlBuilder(group, options) {
         const newOptions = options.havingStyle(options.style.sup());
-        const label = buildCommon.wrapFragment(
+        const label = wrapFragment(
             html.buildGroup(group.label, newOptions, options), options);
         label.classes.push("cd-label-" + group.side);
         label.style.bottom = makeEm(0.8 - label.depth);
@@ -300,7 +300,7 @@ defineFunction({
         // Wrap the vertical arrow and its labels.
         // The parent gets position: relative. The child gets position: absolute.
         // So CSS can locate the label correctly.
-        const parent = buildCommon.wrapFragment(
+        const parent = wrapFragment(
             html.buildGroup(group.fragment, options), options
         );
         parent.classes.push("cd-vert-arrow");

--- a/src/functions/accent.js
+++ b/src/functions/accent.js
@@ -1,6 +1,6 @@
 // @flow
 import defineFunction, {normalizeArgument} from "../defineFunction";
-import buildCommon from "../buildCommon";
+import {makeOrd, makeSpan, makeVList, staticSvg, svgData} from "../buildCommon";
 import {getBaseElem, isCharacterBox} from "../utils";
 import {MathNode} from "../mathMLTree";
 import stretchy from "../stretchy";
@@ -95,10 +95,10 @@ export const htmlBuilder: HtmlBuilderSupSub<"accent"> = (grp, options) => {
             // render combining characters when not preceded by a character.
             // So now we use an SVG.
             // If Safari reforms, we should consider reverting to the glyph.
-            accent = buildCommon.staticSvg("vec", options);
-            width = buildCommon.svgData.vec[1];
+            accent = staticSvg("vec", options);
+            width = svgData.vec[1];
         } else {
-            accent = buildCommon.makeOrd({mode: group.mode, text: group.label},
+            accent = makeOrd({mode: group.mode, text: group.label},
                 options, "textord");
             accent = assertSymbolDomNode(accent);
             // Remove the italic correction of the accent, because it only serves to
@@ -110,7 +110,7 @@ export const htmlBuilder: HtmlBuilderSupSub<"accent"> = (grp, options) => {
             }
         }
 
-        accentBody = buildCommon.makeSpan(["accent-body"], [accent]);
+        accentBody = makeSpan(["accent-body"], [accent]);
 
         // "Full" accents expand the width of the resulting symbol to be
         // at least the width of the accent, and overlap directly onto the
@@ -140,7 +140,7 @@ export const htmlBuilder: HtmlBuilderSupSub<"accent"> = (grp, options) => {
             accentBody.style.top = ".2em";
         }
 
-        accentBody = buildCommon.makeVList({
+        accentBody = makeVList({
             positionType: "firstBaseline",
             children: [
                 {type: "elem", elem: body},
@@ -152,7 +152,7 @@ export const htmlBuilder: HtmlBuilderSupSub<"accent"> = (grp, options) => {
     } else {
         accentBody = stretchy.svgSpan(group, options);
 
-        accentBody = buildCommon.makeVList({
+        accentBody = makeVList({
             positionType: "firstBaseline",
             children: [
                 {type: "elem", elem: body},
@@ -172,7 +172,7 @@ export const htmlBuilder: HtmlBuilderSupSub<"accent"> = (grp, options) => {
     }
 
     const accentWrap =
-        buildCommon.makeSpan(["mord", "accent"], [accentBody], options);
+        makeSpan(["mord", "accent"], [accentBody], options);
 
     if (supSubGroup) {
         // Here, we replace the "base" child of the supsub with our newly

--- a/src/functions/accentunder.js
+++ b/src/functions/accentunder.js
@@ -1,7 +1,7 @@
 // @flow
 // Horizontal overlap functions
 import defineFunction from "../defineFunction";
-import buildCommon from "../buildCommon";
+import {makeSpan, makeVList} from "../buildCommon";
 import {MathNode} from "../mathMLTree";
 import stretchy from "../stretchy";
 
@@ -36,7 +36,7 @@ defineFunction({
         const kern = group.label === "\\utilde" ? 0.12 : 0;
 
         // Generate the vlist, with the appropriate kerns
-        const vlist = buildCommon.makeVList({
+        const vlist = makeVList({
             positionType: "top",
             positionData: innerGroup.height,
             children: [
@@ -46,7 +46,7 @@ defineFunction({
             ],
         }, options);
 
-        return buildCommon.makeSpan(["mord", "accentunder"], [vlist], options);
+        return makeSpan(["mord", "accentunder"], [vlist], options);
     },
     mathmlBuilder: (group, options) => {
         const accentNode = stretchy.mathMLnode(group.label);

--- a/src/functions/arrow.js
+++ b/src/functions/arrow.js
@@ -1,6 +1,6 @@
 // @flow
 import defineFunction from "../defineFunction";
-import buildCommon from "../buildCommon";
+import {makeSpan, makeVList, wrapFragment} from "../buildCommon";
 import {MathNode} from "../mathMLTree";
 import stretchy from "../stretchy";
 
@@ -57,7 +57,7 @@ defineFunction({
         // Some groups can return document fragments.  Handle those by wrapping
         // them in a span.
         let newOptions = options.havingStyle(style.sup());
-        const upperGroup = buildCommon.wrapFragment(
+        const upperGroup = wrapFragment(
             html.buildGroup(group.body, newOptions, options), options);
         const arrowPrefix = group.label.slice(0, 2) === "\\x" ? "x" : "cd";
         upperGroup.classes.push(arrowPrefix + "-arrow-pad");
@@ -66,7 +66,7 @@ defineFunction({
         if (group.below) {
             // Build the lower group
             newOptions = options.havingStyle(style.sub());
-            lowerGroup = buildCommon.wrapFragment(
+            lowerGroup = wrapFragment(
                 html.buildGroup(group.below, newOptions, options), options);
             lowerGroup.classes.push(arrowPrefix + "-arrow-pad");
         }
@@ -90,7 +90,7 @@ defineFunction({
             const lowerShift = -options.fontMetrics().axisHeight
                 + lowerGroup.height + 0.5 * arrowBody.height
                 + 0.111;
-            vlist = buildCommon.makeVList({
+            vlist = makeVList({
                 positionType: "individualShift",
                 children: [
                     {type: "elem", elem: upperGroup, shift: upperShift},
@@ -99,7 +99,7 @@ defineFunction({
                 ],
             }, options);
         } else {
-            vlist = buildCommon.makeVList({
+            vlist = makeVList({
                 positionType: "individualShift",
                 children: [
                     {type: "elem", elem: upperGroup, shift: upperShift},
@@ -111,7 +111,7 @@ defineFunction({
         // $FlowFixMe: Replace this with passing "svg-align" into makeVList.
         vlist.children[0].children[0].children[1].classes.push("svg-align");
 
-        return buildCommon.makeSpan(["mrel", "x-arrow"], [vlist], options);
+        return makeSpan(["mrel", "x-arrow"], [vlist], options);
     },
     mathmlBuilder(group, options) {
         const arrowNode = stretchy.mathMLnode(group.label);

--- a/src/functions/color.js
+++ b/src/functions/color.js
@@ -1,6 +1,6 @@
 // @flow
 import defineFunction, {ordargument} from "../defineFunction";
-import buildCommon from "../buildCommon";
+import {makeFragment} from "../buildCommon";
 import {MathNode} from "../mathMLTree";
 import {assertNodeType} from "../parseNode";
 
@@ -20,7 +20,7 @@ const htmlBuilder = (group, options) => {
     // To accomplish this, we wrap the results in a fragment, so the inner
     // elements will be able to directly interact with their neighbors. For
     // example, `\color{red}{2 +} 3` has the same spacing as `2 + 3`
-    return buildCommon.makeFragment(elements);
+    return makeFragment(elements);
 };
 
 const mathmlBuilder = (group, options) => {

--- a/src/functions/cr.js
+++ b/src/functions/cr.js
@@ -2,7 +2,7 @@
 // Row breaks within tabular environments, and line breaks at top level
 
 import defineFunction from "../defineFunction";
-import buildCommon from "../buildCommon";
+import {makeSpan} from "../buildCommon";
 import {MathNode} from "../mathMLTree";
 import {calculateSize, makeEm} from "../units";
 import {assertNodeType} from "../parseNode";
@@ -36,7 +36,7 @@ defineFunction({
     // not within tabular/array environments.
 
     htmlBuilder(group, options) {
-        const span = buildCommon.makeSpan(["mspace"], [], options);
+        const span = makeSpan(["mspace"], [], options);
         if (group.newLine) {
             span.classes.push("newline");
             if (group.size) {

--- a/src/functions/delimsizing.js
+++ b/src/functions/delimsizing.js
@@ -1,5 +1,5 @@
 // @flow
-import buildCommon from "../buildCommon";
+import {makeSpan} from "../buildCommon";
 import defineFunction from "../defineFunction";
 import delimiter from "../delimiter";
 import {MathNode} from "../mathMLTree";
@@ -98,7 +98,7 @@ defineFunction({
         if (group.delim === ".") {
             // Empty delimiters still count as elements, even though they don't
             // show anything.
-            return buildCommon.makeSpan([group.mclass]);
+            return makeSpan([group.mclass]);
         }
 
         // Use delimiter.sizedDelim to generate the delimiter.
@@ -270,7 +270,7 @@ defineFunction({
         // Add it to the end of the expression.
         inner.push(rightDelim);
 
-        return buildCommon.makeSpan(["minner"], inner, options);
+        return makeSpan(["minner"], inner, options);
     },
     mathmlBuilder: (group, options) => {
         assertParsed(group);

--- a/src/functions/enclose.js
+++ b/src/functions/enclose.js
@@ -1,6 +1,6 @@
 // @flow
 import defineFunction from "../defineFunction";
-import buildCommon from "../buildCommon";
+import {makeSpan, makeSvgSpan, makeVList, wrapFragment} from "../buildCommon";
 import {isCharacterBox} from "../utils";
 import {MathNode} from "../mathMLTree";
 import stretchy from "../stretchy";
@@ -17,7 +17,7 @@ const htmlBuilder = (group, options) => {
     // \cancel, \bcancel, \xcancel, \sout, \fbox, \colorbox, \fcolorbox, \phase
     // Some groups can return document fragments.  Handle those by wrapping
     // them in a span.
-    const inner = buildCommon.wrapFragment(
+    const inner = wrapFragment(
         html.buildGroup(group.body, options), options);
 
     const label = group.label.slice(1);
@@ -33,7 +33,7 @@ const htmlBuilder = (group, options) => {
     const isSingleChar = isCharacterBox(group.body);
 
     if (label === "sout") {
-        img = buildCommon.makeSpan(["stretchy", "sout"]);
+        img = makeSpan(["stretchy", "sout"]);
         img.height = options.fontMetrics().defaultRuleThickness / scale;
         imgShift = -0.5 * options.fontMetrics().xHeight;
 
@@ -60,7 +60,7 @@ const htmlBuilder = (group, options) => {
             "preserveAspectRatio": "xMinYMin slice",
         });
         // Wrap it in a span with overflow: hidden.
-        img = buildCommon.makeSvgSpan(["hide-tail"], [svgNode], options);
+        img = makeSvgSpan(["hide-tail"], [svgNode], options);
         img.style.height = makeEm(angleHeight);
         imgShift = inner.depth + lineWeight + clearance;
 
@@ -121,7 +121,7 @@ const htmlBuilder = (group, options) => {
 
     let vlist;
     if (group.backgroundColor) {
-        vlist = buildCommon.makeVList({
+        vlist = makeVList({
             positionType: "individualShift",
             children: [
                 // Put the color background behind inner;
@@ -131,7 +131,7 @@ const htmlBuilder = (group, options) => {
         }, options);
     } else {
         const classes = /cancel|phase/.test(label) ? ["svg-align"] : [];
-        vlist = buildCommon.makeVList({
+        vlist = makeVList({
             positionType: "individualShift",
             children: [
                 // Write the \cancel stroke on top of inner.
@@ -159,9 +159,9 @@ const htmlBuilder = (group, options) => {
 
     if (/cancel/.test(label) && !isSingleChar) {
         // cancel does not create horiz space for its line extension.
-        return buildCommon.makeSpan(["mord", "cancel-lap"], [vlist], options);
+        return makeSpan(["mord", "cancel-lap"], [vlist], options);
     } else {
-        return buildCommon.makeSpan(["mord"], [vlist], options);
+        return makeSpan(["mord"], [vlist], options);
     }
 };
 

--- a/src/functions/genfrac.js
+++ b/src/functions/genfrac.js
@@ -1,6 +1,6 @@
 // @flow
 import defineFunction, {normalizeArgument} from "../defineFunction";
-import buildCommon from "../buildCommon";
+import {makeLineSpan, makeSpan, makeVList} from "../buildCommon";
 import delimiter from "../delimiter";
 import {MathNode, TextNode} from "../mathMLTree";
 import Style from "../Style";
@@ -59,9 +59,9 @@ const htmlBuilder = (group, options) => {
     if (group.hasBarLine) {
         if (group.barSize) {
             ruleWidth = calculateSize(group.barSize, options);
-            rule = buildCommon.makeLineSpan("frac-line", options, ruleWidth);
+            rule = makeLineSpan("frac-line", options, ruleWidth);
         } else {
-            rule = buildCommon.makeLineSpan("frac-line", options);
+            rule = makeLineSpan("frac-line", options);
         }
         ruleWidth = rule.height;
         ruleSpacing = rule.height;
@@ -104,7 +104,7 @@ const htmlBuilder = (group, options) => {
             denomShift += 0.5 * (clearance - candidateClearance);
         }
 
-        frac = buildCommon.makeVList({
+        frac = makeVList({
             positionType: "individualShift",
             children: [
                 {type: "elem", elem: denomm, shift: denomShift},
@@ -131,7 +131,7 @@ const htmlBuilder = (group, options) => {
 
         const midShift = -(axisHeight - 0.5 * ruleWidth);
 
-        frac = buildCommon.makeVList({
+        frac = makeVList({
             positionType: "individualShift",
             children: [
                 {type: "elem", elem: denomm, shift: denomShift},
@@ -168,7 +168,7 @@ const htmlBuilder = (group, options) => {
     }
 
     if (group.continued) {
-        rightDelim = buildCommon.makeSpan([]); // zero width for \cfrac
+        rightDelim = makeSpan([]); // zero width for \cfrac
     } else if (group.rightDelim == null) {
         rightDelim = html.makeNullDelimiter(options, ["mclose"]);
     } else {
@@ -177,9 +177,9 @@ const htmlBuilder = (group, options) => {
             options.havingStyle(style), group.mode, ["mclose"]);
     }
 
-    return buildCommon.makeSpan(
+    return makeSpan(
         ["mord"].concat(newOptions.sizingClasses(options)),
-        [leftDelim, buildCommon.makeSpan(["mfrac"], [frac]), rightDelim],
+        [leftDelim, makeSpan(["mfrac"], [frac]), rightDelim],
         options);
 };
 

--- a/src/functions/hbox.js
+++ b/src/functions/hbox.js
@@ -1,6 +1,6 @@
 // @flow
 import defineFunction, {ordargument} from "../defineFunction";
-import buildCommon from "../buildCommon";
+import {makeFragment} from "../buildCommon";
 import {MathNode} from "../mathMLTree";
 
 import * as html from "../buildHTML";
@@ -29,7 +29,7 @@ defineFunction({
     },
     htmlBuilder(group, options) {
         const elements = html.buildExpression(group.body, options, false);
-        return buildCommon.makeFragment(elements);
+        return makeFragment(elements);
     },
     mathmlBuilder(group, options) {
         return new MathNode(

--- a/src/functions/horizBrace.js
+++ b/src/functions/horizBrace.js
@@ -1,6 +1,6 @@
 // @flow
 import defineFunction from "../defineFunction";
-import buildCommon from "../buildCommon";
+import {makeSpan, makeVList} from "../buildCommon";
 import {MathNode} from "../mathMLTree";
 import stretchy from "../stretchy";
 import Style from "../Style";
@@ -43,7 +43,7 @@ export const htmlBuilder: HtmlBuilderSupSub<"horizBrace"> = (grp, options) => {
     // This first vlist contains the content and the brace:   equation
     let vlist;
     if (group.isOver) {
-        vlist = buildCommon.makeVList({
+        vlist = makeVList({
             positionType: "firstBaseline",
             children: [
                 {type: "elem", elem: body},
@@ -54,7 +54,7 @@ export const htmlBuilder: HtmlBuilderSupSub<"horizBrace"> = (grp, options) => {
         // $FlowFixMe: Replace this with passing "svg-align" into makeVList.
         vlist.children[0].children[0].children[1].classes.push("svg-align");
     } else {
-        vlist = buildCommon.makeVList({
+        vlist = makeVList({
             positionType: "bottom",
             positionData: body.depth + 0.1 + braceBody.height,
             children: [
@@ -77,12 +77,12 @@ export const htmlBuilder: HtmlBuilderSupSub<"horizBrace"> = (grp, options) => {
         //   ┏━━━━━━━━┓   or    ┏━━━┓     not    ┏━━━━━━━━━┓
         //    equation           eqn                 eqn
 
-        const vSpan = buildCommon.makeSpan(
+        const vSpan = makeSpan(
             ["mord", (group.isOver ? "mover" : "munder")],
             [vlist], options);
 
         if (group.isOver) {
-            vlist = buildCommon.makeVList({
+            vlist = makeVList({
                 positionType: "firstBaseline",
                 children: [
                     {type: "elem", elem: vSpan},
@@ -91,7 +91,7 @@ export const htmlBuilder: HtmlBuilderSupSub<"horizBrace"> = (grp, options) => {
                 ],
             }, options);
         } else {
-            vlist = buildCommon.makeVList({
+            vlist = makeVList({
                 positionType: "bottom",
                 positionData: vSpan.depth + 0.2 + supSubGroup.height +
                     supSubGroup.depth,
@@ -104,7 +104,7 @@ export const htmlBuilder: HtmlBuilderSupSub<"horizBrace"> = (grp, options) => {
         }
     }
 
-    return buildCommon.makeSpan(
+    return makeSpan(
         ["mord", (group.isOver ? "mover" : "munder")], [vlist], options);
 };
 

--- a/src/functions/href.js
+++ b/src/functions/href.js
@@ -1,6 +1,6 @@
 // @flow
 import defineFunction, {ordargument} from "../defineFunction";
-import buildCommon from "../buildCommon";
+import {makeAnchor} from "../buildCommon";
 import {assertNodeType} from "../parseNode";
 import {MathNode} from "../mathMLTree";
 
@@ -35,7 +35,7 @@ defineFunction({
     },
     htmlBuilder: (group, options) => {
         const elements = html.buildExpression(group.body, options, false);
-        return buildCommon.makeAnchor(group.href, [], elements, options);
+        return makeAnchor(group.href, [], elements, options);
     },
     mathmlBuilder: (group, options) => {
         let math = mml.buildExpressionRow(group.body, options);

--- a/src/functions/html.js
+++ b/src/functions/html.js
@@ -1,6 +1,6 @@
 // @flow
 import defineFunction, {ordargument} from "../defineFunction";
-import buildCommon from "../buildCommon";
+import {makeSpan} from "../buildCommon";
 import {assertNodeType} from "../parseNode";
 import ParseError from "../ParseError";
 
@@ -91,7 +91,7 @@ defineFunction({
             classes.push(...group.attributes.class.trim().split(/\s+/));
         }
 
-        const span = buildCommon.makeSpan(classes, elements, options);
+        const span = makeSpan(classes, elements, options);
         for (const attr in group.attributes) {
             if (attr !== "class" && group.attributes.hasOwnProperty(attr)) {
                 span.setAttribute(attr, group.attributes[attr]);

--- a/src/functions/htmlmathml.js
+++ b/src/functions/htmlmathml.js
@@ -1,6 +1,6 @@
 // @flow
 import defineFunction, {ordargument} from "../defineFunction";
-import buildCommon from "../buildCommon";
+import {makeFragment} from "../buildCommon";
 
 import * as html from "../buildHTML";
 import * as mml from "../buildMathML";
@@ -26,7 +26,7 @@ defineFunction({
             options,
             false
         );
-        return buildCommon.makeFragment(elements);
+        return makeFragment(elements);
     },
     mathmlBuilder: (group, options) => {
         return mml.buildExpressionRow(group.mathml, options);

--- a/src/functions/kern.js
+++ b/src/functions/kern.js
@@ -2,7 +2,7 @@
 // Horizontal spacing commands
 
 import defineFunction from "../defineFunction";
-import buildCommon from "../buildCommon";
+import {makeGlue} from "../buildCommon";
 import {SpaceNode} from "../mathMLTree";
 import {calculateSize} from "../units";
 import {assertNodeType} from "../parseNode";
@@ -47,7 +47,7 @@ defineFunction({
         };
     },
     htmlBuilder(group, options) {
-        return buildCommon.makeGlue(group.dimension, options);
+        return makeGlue(group.dimension, options);
     },
     mathmlBuilder(group, options) {
         const dimension = calculateSize(group.dimension, options);

--- a/src/functions/lap.js
+++ b/src/functions/lap.js
@@ -1,7 +1,7 @@
 // @flow
 // Horizontal overlap functions
 import defineFunction from "../defineFunction";
-import buildCommon from "../buildCommon";
+import {makeSpan} from "../buildCommon";
 import {MathNode} from "../mathMLTree";
 import {makeEm} from "../units";
 
@@ -29,16 +29,16 @@ defineFunction({
         let inner;
         if (group.alignment === "clap") {
             // ref: https://www.math.lsu.edu/~aperlis/publications/mathclap/
-            inner = buildCommon.makeSpan(
+            inner = makeSpan(
                 [], [html.buildGroup(group.body, options)]);
             // wrap, since CSS will center a .clap > .inner > span
-            inner = buildCommon.makeSpan(["inner"], [inner], options);
+            inner = makeSpan(["inner"], [inner], options);
         } else {
-            inner = buildCommon.makeSpan(
+            inner = makeSpan(
                 ["inner"], [html.buildGroup(group.body, options)]);
         }
-        const fix = buildCommon.makeSpan(["fix"], []);
-        let node = buildCommon.makeSpan(
+        const fix = makeSpan(["fix"], []);
+        let node = makeSpan(
             [group.alignment], [inner, fix], options);
 
         // At this point, we have correctly set horizontal alignment of the
@@ -46,7 +46,7 @@ defineFunction({
         // Next, use a strut to set the height of the HTML bounding box.
         // Otherwise, a tall argument may be misplaced.
         // This code resolved issue #1153
-        const strut = buildCommon.makeSpan(["strut"]);
+        const strut = makeSpan(["strut"]);
         strut.style.height = makeEm(node.height + node.depth);
         if (node.depth) {
             strut.style.verticalAlign = makeEm(-node.depth);
@@ -55,8 +55,8 @@ defineFunction({
 
         // Next, prevent vertical misplacement when next to something tall.
         // This code resolves issue #1234
-        node = buildCommon.makeSpan(["thinbox"], [node], options);
-        return buildCommon.makeSpan(["mord", "vbox"], [node], options);
+        node = makeSpan(["thinbox"], [node], options);
+        return makeSpan(["mord", "vbox"], [node], options);
     },
     mathmlBuilder: (group, options) => {
         // mathllap, mathrlap, mathclap

--- a/src/functions/mathchoice.js
+++ b/src/functions/mathchoice.js
@@ -1,6 +1,6 @@
 // @flow
 import defineFunction, {ordargument} from "../defineFunction";
-import buildCommon from "../buildCommon";
+import {makeFragment} from "../buildCommon";
 import Style from "../Style";
 
 import * as html from "../buildHTML";
@@ -42,7 +42,7 @@ defineFunction({
             options,
             false
         );
-        return buildCommon.makeFragment(elements);
+        return makeFragment(elements);
     },
     mathmlBuilder: (group, options) => {
         const body = chooseMathStyle(group, options);

--- a/src/functions/mclass.js
+++ b/src/functions/mclass.js
@@ -1,6 +1,6 @@
 // @flow
 import defineFunction, {ordargument} from "../defineFunction";
-import buildCommon from "../buildCommon";
+import {makeSpan} from "../buildCommon";
 import {isCharacterBox} from "../utils";
 import {MathNode} from "../mathMLTree";
 import type {AnyParseNode} from "../parseNode";
@@ -9,8 +9,6 @@ import * as html from "../buildHTML";
 import * as mml from "../buildMathML";
 
 import type {ParseNode} from "../parseNode";
-
-const makeSpan = buildCommon.makeSpan;
 
 function htmlBuilder(group: ParseNode<"mclass">, options) {
     const elements = html.buildExpression(group.body, options, true);

--- a/src/functions/op.js
+++ b/src/functions/op.js
@@ -1,7 +1,7 @@
 // @flow
 // Limits, symbols
 import defineFunction, {ordargument} from "../defineFunction";
-import buildCommon from "../buildCommon";
+import {mathsym, makeSpan, makeSymbol, makeVList, staticSvg} from "../buildCommon";
 import {SymbolNode} from "../domTree";
 import {MathNode, newDocumentFragment, TextNode} from "../mathMLTree";
 import Style from "../Style";
@@ -64,7 +64,7 @@ export const htmlBuilder: HtmlBuilderSupSub<"op"> = (grp, options) => {
             group.name = stash === "oiint" ? "\\iint" : "\\iiint";
         }
 
-        base = buildCommon.makeSymbol(
+        base = makeSymbol(
             group.name, fontName, "math", options,
             ["mop", "op-symbol", large ? "large-op" : "small-op"]);
 
@@ -72,9 +72,9 @@ export const htmlBuilder: HtmlBuilderSupSub<"op"> = (grp, options) => {
             // We're in \oiint or \oiiint. Overlay the oval.
             // TODO: When font glyphs are available, delete this code.
             const italic = base.italic;
-            const oval = buildCommon.staticSvg(stash + "Size"
+            const oval = staticSvg(stash + "Size"
                 + (large ? "2" : "1"), options);
-            base = buildCommon.makeVList({
+            base = makeVList({
                 positionType: "individualShift",
                 children: [
                     {type: "elem", elem: base, shift: 0},
@@ -93,16 +93,16 @@ export const htmlBuilder: HtmlBuilderSupSub<"op"> = (grp, options) => {
             base = inner[0];
             base.classes[0] = "mop"; // replace old mclass
         } else {
-            base = buildCommon.makeSpan(["mop"], inner, options);
+            base = makeSpan(["mop"], inner, options);
         }
     } else {
         // Otherwise, this is a text operator. Build the text from the
         // operator's name.
         const output = [];
         for (let i = 1; i < group.name.length; i++) {
-            output.push(buildCommon.mathsym(group.name[i], group.mode, options));
+            output.push(mathsym(group.name[i], group.mode, options));
         }
-        base = buildCommon.makeSpan(["mop"], output, options);
+        base = makeSpan(["mop"], output, options);
     }
 
     // If content of op is a single symbol, shift it vertically.

--- a/src/functions/operatorname.js
+++ b/src/functions/operatorname.js
@@ -1,7 +1,7 @@
 // @flow
 import defineFunction, {ordargument} from "../defineFunction";
 import defineMacro from "../defineMacro";
-import buildCommon from "../buildCommon";
+import {makeSpan} from "../buildCommon";
 import {MathNode, newDocumentFragment, SpaceNode, TextNode} from "../mathMLTree";
 import {SymbolNode} from "../domTree";
 import {assembleSupSub} from "./utils/assembleSupSub";
@@ -63,9 +63,9 @@ export const htmlBuilder: HtmlBuilderSupSub<"operatorname"> = (grp, options) => 
                     .replace(/\u2217/, "*");
             }
         }
-        base = buildCommon.makeSpan(["mop"], expression, options);
+        base = makeSpan(["mop"], expression, options);
     } else {
-        base = buildCommon.makeSpan(["mop"], [], options);
+        base = makeSpan(["mop"], [], options);
     }
 
     if (hasLimits) {

--- a/src/functions/ordgroup.js
+++ b/src/functions/ordgroup.js
@@ -1,6 +1,6 @@
 // @flow
 import {defineFunctionBuilders} from "../defineFunction";
-import buildCommon from "../buildCommon";
+import {makeFragment, makeSpan} from "../buildCommon";
 
 import * as html from "../buildHTML";
 import * as mml from "../buildMathML";
@@ -9,10 +9,10 @@ defineFunctionBuilders({
     type: "ordgroup",
     htmlBuilder(group, options) {
         if (group.semisimple) {
-            return buildCommon.makeFragment(
+            return makeFragment(
                 html.buildExpression(group.body, options, false));
         }
-        return buildCommon.makeSpan(
+        return makeSpan(
             ["mord"], html.buildExpression(group.body, options, true), options);
     },
     mathmlBuilder(group, options) {

--- a/src/functions/overline.js
+++ b/src/functions/overline.js
@@ -1,6 +1,6 @@
 // @flow
 import defineFunction from "../defineFunction";
-import buildCommon from "../buildCommon";
+import {makeLineSpan, makeSpan, makeVList} from "../buildCommon";
 import {MathNode, TextNode} from "../mathMLTree";
 
 import * as html from "../buildHTML";
@@ -28,11 +28,11 @@ defineFunction({
             options.havingCrampedStyle());
 
         // Create the line above the body
-        const line = buildCommon.makeLineSpan("overline-line", options);
+        const line = makeLineSpan("overline-line", options);
 
         // Generate the vlist, with the appropriate kerns
         const defaultRuleThickness = options.fontMetrics().defaultRuleThickness;
-        const vlist = buildCommon.makeVList({
+        const vlist = makeVList({
             positionType: "firstBaseline",
             children: [
                 {type: "elem", elem: innerGroup},
@@ -42,7 +42,7 @@ defineFunction({
             ],
         }, options);
 
-        return buildCommon.makeSpan(["mord", "overline"], [vlist], options);
+        return makeSpan(["mord", "overline"], [vlist], options);
     },
     mathmlBuilder(group, options) {
         const operator = new MathNode(

--- a/src/functions/phantom.js
+++ b/src/functions/phantom.js
@@ -1,6 +1,6 @@
 // @flow
 import defineFunction, {ordargument} from "../defineFunction";
-import buildCommon from "../buildCommon";
+import {makeFragment, makeSpan, makeVList} from "../buildCommon";
 import {MathNode} from "../mathMLTree";
 
 import * as html from "../buildHTML";
@@ -30,7 +30,7 @@ defineFunction({
 
         // \phantom isn't supposed to affect the elements it contains.
         // See "color" for more details.
-        return buildCommon.makeFragment(elements);
+        return makeFragment(elements);
     },
     mathmlBuilder: (group, options) => {
         const inner = mml.buildExpression(group.body, options);
@@ -54,7 +54,7 @@ defineFunction({
         };
     },
     htmlBuilder: (group, options) => {
-        let node = buildCommon.makeSpan(
+        let node = makeSpan(
             [], [html.buildGroup(group.body, options.withPhantom())]);
         node.height = 0;
         node.depth = 0;
@@ -66,13 +66,13 @@ defineFunction({
         }
 
         // See smash for comment re: use of makeVList
-        node = buildCommon.makeVList({
+        node = makeVList({
             positionType: "firstBaseline",
             children: [{type: "elem", elem: node}],
         }, options);
 
         // For spacing, TeX treats \smash as a math group (same spacing as ord).
-        return buildCommon.makeSpan(["mord"], [node], options);
+        return makeSpan(["mord"], [node], options);
     },
     mathmlBuilder: (group, options) => {
         const inner = mml.buildExpression(ordargument(group.body), options);
@@ -100,11 +100,11 @@ defineFunction({
         };
     },
     htmlBuilder: (group, options) => {
-        const inner = buildCommon.makeSpan(
+        const inner = makeSpan(
             ["inner"],
             [html.buildGroup(group.body, options.withPhantom())]);
-        const fix = buildCommon.makeSpan(["fix"], []);
-        return buildCommon.makeSpan(
+        const fix = makeSpan(["fix"], []);
+        return makeSpan(
             ["mord", "rlap"], [inner, fix], options);
     },
     mathmlBuilder: (group, options) => {

--- a/src/functions/pmb.js
+++ b/src/functions/pmb.js
@@ -1,6 +1,6 @@
 // @flow
 import defineFunction, {ordargument} from "../defineFunction";
-import buildCommon from "../buildCommon";
+import {makeSpan} from "../buildCommon";
 import {MathNode} from "../mathMLTree";
 import * as html from "../buildHTML";
 import * as mml from "../buildMathML";
@@ -30,7 +30,7 @@ defineFunction({
     },
     htmlBuilder(group: ParseNode<"pmb">, options) {
         const elements = html.buildExpression(group.body, options, true);
-        const node = buildCommon.makeSpan([group.mclass], elements, options);
+        const node = makeSpan([group.mclass], elements, options);
         node.style.textShadow = "0.02em 0.01em 0.04px";
         return node;
     },

--- a/src/functions/raisebox.js
+++ b/src/functions/raisebox.js
@@ -1,6 +1,6 @@
 // @flow
 import defineFunction from "../defineFunction";
-import buildCommon from "../buildCommon";
+import {makeVList} from "../buildCommon";
 import {MathNode} from "../mathMLTree";
 import {assertNodeType} from "../parseNode";
 import {calculateSize} from "../units";
@@ -30,7 +30,7 @@ defineFunction({
     htmlBuilder(group, options) {
         const body = html.buildGroup(group.body, options);
         const dy = calculateSize(group.dy, options);
-        return buildCommon.makeVList({
+        return makeVList({
             positionType: "shift",
             positionData: -dy,
             children: [{type: "elem", elem: body}],

--- a/src/functions/rule.js
+++ b/src/functions/rule.js
@@ -1,5 +1,5 @@
 // @flow
-import buildCommon from "../buildCommon";
+import {makeSpan} from "../buildCommon";
 import defineFunction from "../defineFunction";
 import {MathNode} from "../mathMLTree";
 import {assertNodeType} from "../parseNode";
@@ -29,7 +29,7 @@ defineFunction({
     },
     htmlBuilder(group, options) {
         // Make an empty span for the rule
-        const rule = buildCommon.makeSpan(["mord", "rule"], [], options);
+        const rule = makeSpan(["mord", "rule"], [], options);
 
         // Calculate the shift, width, and height of the rule, and account for units
         const width = calculateSize(group.width, options);

--- a/src/functions/sizing.js
+++ b/src/functions/sizing.js
@@ -1,5 +1,5 @@
 // @flow
-import buildCommon from "../buildCommon";
+import {makeFragment} from "../buildCommon";
 import defineFunction from "../defineFunction";
 import {MathNode} from "../mathMLTree";
 import {makeEm} from "../units";
@@ -38,7 +38,7 @@ export function sizingGroup(
         inner[i].depth *= multiplier;
     }
 
-    return buildCommon.makeFragment(inner);
+    return makeFragment(inner);
 }
 
 const sizeFuncs = [

--- a/src/functions/smash.js
+++ b/src/functions/smash.js
@@ -1,7 +1,7 @@
 // @flow
 // smash, with optional [tb], as in AMS
 import defineFunction from "../defineFunction";
-import buildCommon from "../buildCommon";
+import {makeSpan, makeVList} from "../buildCommon";
 import {MathNode} from "../mathMLTree";
 import {assertNodeType} from "../parseNode";
 
@@ -54,7 +54,7 @@ defineFunction({
         };
     },
     htmlBuilder: (group, options) => {
-        const node = buildCommon.makeSpan(
+        const node = makeSpan(
             [], [html.buildGroup(group.body, options)]);
 
         if (!group.smashHeight && !group.smashDepth) {
@@ -85,13 +85,13 @@ defineFunction({
         // makeVList applies "display: table-cell", which prevents the browser
         // from acting on that line height. So we'll call makeVList now.
 
-        const smashedNode = buildCommon.makeVList({
+        const smashedNode = makeVList({
             positionType: "firstBaseline",
             children: [{type: "elem", elem: node}],
         }, options);
 
         // For spacing, TeX treats \hphantom as a math group (same spacing as ord).
-        return buildCommon.makeSpan(["mord"], [smashedNode], options);
+        return makeSpan(["mord"], [smashedNode], options);
     },
     mathmlBuilder: (group, options) => {
         const node = new MathNode(

--- a/src/functions/sqrt.js
+++ b/src/functions/sqrt.js
@@ -1,6 +1,6 @@
 // @flow
 import defineFunction from "../defineFunction";
-import buildCommon from "../buildCommon";
+import {makeSpan, makeVList, wrapFragment} from "../buildCommon";
 import {MathNode} from "../mathMLTree";
 import delimiter from "../delimiter";
 import Style from "../Style";
@@ -39,7 +39,7 @@ defineFunction({
 
         // Some groups can return document fragments.  Handle those by wrapping
         // them in a span.
-        inner = buildCommon.wrapFragment(inner, options);
+        inner = wrapFragment(inner, options);
 
         // Calculate the minimum size for the \surd delimiter
         const metrics = options.fontMetrics();
@@ -74,7 +74,7 @@ defineFunction({
         inner.style.paddingLeft = makeEm(advanceWidth);
 
         // Overlay the image and the argument.
-        const body = buildCommon.makeVList({
+        const body = makeVList({
             positionType: "firstBaseline",
             children: [
                 {type: "elem", elem: inner, wrapperClasses: ["svg-align"]},
@@ -85,7 +85,7 @@ defineFunction({
         }, options);
 
         if (!group.index) {
-            return buildCommon.makeSpan(["mord", "sqrt"], [body], options);
+            return makeSpan(["mord", "sqrt"], [body], options);
         } else {
             // Handle the optional root index
 
@@ -98,16 +98,16 @@ defineFunction({
             const toShift = 0.6 * (body.height - body.depth);
 
             // Build a VList with the superscript shifted up correctly
-            const rootVList = buildCommon.makeVList({
+            const rootVList = makeVList({
                 positionType: "shift",
                 positionData: -toShift,
                 children: [{type: "elem", elem: rootm}],
             }, options);
             // Add a class surrounding it so we can add on the appropriate
             // kerning
-            const rootVListWrap = buildCommon.makeSpan(["root"], [rootVList]);
+            const rootVListWrap = makeSpan(["root"], [rootVList]);
 
-            return buildCommon.makeSpan(["mord", "sqrt"],
+            return makeSpan(["mord", "sqrt"],
                 [rootVListWrap, body], options);
         }
     },

--- a/src/functions/supsub.js
+++ b/src/functions/supsub.js
@@ -1,6 +1,6 @@
 // @flow
 import {defineFunctionBuilders} from "../defineFunction";
-import buildCommon from "../buildCommon";
+import {makeSpan, makeVList} from "../buildCommon";
 import {SymbolNode} from "../domTree";
 import {isCharacterBox} from "../utils";
 import {MathNode} from "../mathMLTree";
@@ -153,7 +153,7 @@ defineFunctionBuilders({
                 {type: "elem", elem: supm, shift: -supShift, marginRight},
             ];
 
-            supsub = buildCommon.makeVList({
+            supsub = makeVList({
                 positionType: "individualShift",
                 children: vlistElem,
             }, options);
@@ -166,7 +166,7 @@ defineFunctionBuilders({
             const vlistElem =
                 [{type: "elem", elem: subm, marginLeft, marginRight}];
 
-            supsub = buildCommon.makeVList({
+            supsub = makeVList({
                 positionType: "shift",
                 positionData: subShift,
                 children: vlistElem,
@@ -176,7 +176,7 @@ defineFunctionBuilders({
             supShift = Math.max(supShift, minSupShift,
                 supm.depth + 0.25 * metrics.xHeight);
 
-            supsub = buildCommon.makeVList({
+            supsub = makeVList({
                 positionType: "shift",
                 positionData: -supShift,
                 children: [{type: "elem", elem: supm, marginRight}],
@@ -187,8 +187,8 @@ defineFunctionBuilders({
 
         // Wrap the supsub vlist in a span.msupsub to reset text-align.
         const mclass = html.getTypeOfDomTree(base, "right") || "mord";
-        return buildCommon.makeSpan([mclass],
-            [base, buildCommon.makeSpan(["msupsub"], [supsub])],
+        return makeSpan([mclass],
+            [base, makeSpan(["msupsub"], [supsub])],
             options);
     },
     mathmlBuilder(group, options) {

--- a/src/functions/symbolsOp.js
+++ b/src/functions/symbolsOp.js
@@ -1,6 +1,6 @@
 // @flow
 import {defineFunctionBuilders} from "../defineFunction";
-import buildCommon from "../buildCommon";
+import {mathsym} from "../buildCommon";
 import {MathNode} from "../mathMLTree";
 
 import * as mml from "../buildMathML";
@@ -10,7 +10,7 @@ import * as mml from "../buildMathML";
 defineFunctionBuilders({
     type: "atom",
     htmlBuilder(group, options) {
-        return buildCommon.mathsym(
+        return mathsym(
             group.text, group.mode, options, ["m" + group.family]);
     },
     mathmlBuilder(group, options) {

--- a/src/functions/symbolsOrd.js
+++ b/src/functions/symbolsOrd.js
@@ -1,6 +1,6 @@
 // @flow
 import {defineFunctionBuilders} from "../defineFunction";
-import buildCommon from "../buildCommon";
+import {makeOrd} from "../buildCommon";
 import {MathNode} from "../mathMLTree";
 
 import * as mml from "../buildMathML";
@@ -19,7 +19,7 @@ const defaultVariant: {[string]: string} = {
 defineFunctionBuilders({
     type: "mathord",
     htmlBuilder(group, options) {
-        return buildCommon.makeOrd(group, options, "mathord");
+        return makeOrd(group, options, "mathord");
     },
     mathmlBuilder(group: ParseNode<"mathord">, options) {
         const node = new MathNode(
@@ -37,7 +37,7 @@ defineFunctionBuilders({
 defineFunctionBuilders({
     type: "textord",
     htmlBuilder(group, options) {
-        return buildCommon.makeOrd(group, options, "textord");
+        return makeOrd(group, options, "textord");
     },
     mathmlBuilder(group: ParseNode<"textord">, options) {
         const text = mml.makeText(group.text, group.mode, options);

--- a/src/functions/symbolsSpacing.js
+++ b/src/functions/symbolsSpacing.js
@@ -1,6 +1,6 @@
 // @flow
 import {defineFunctionBuilders} from "../defineFunction";
-import buildCommon from "../buildCommon";
+import {mathsym, makeOrd, makeSpan} from "../buildCommon";
 import {MathNode, TextNode} from "../mathMLTree";
 import ParseError from "../ParseError";
 
@@ -38,17 +38,17 @@ defineFunctionBuilders({
             // things has an entry in the symbols table, so these will be turned
             // into appropriate outputs.
             if (group.mode === "text") {
-                const ord = buildCommon.makeOrd(group, options, "textord");
+                const ord = makeOrd(group, options, "textord");
                 ord.classes.push(className);
                 return ord;
             } else {
-                return buildCommon.makeSpan(["mspace", className],
-                    [buildCommon.mathsym(group.text, group.mode, options)],
+                return makeSpan(["mspace", className],
+                    [mathsym(group.text, group.mode, options)],
                     options);
             }
         } else if (cssSpace.hasOwnProperty(group.text)) {
             // Spaces based on just a CSS class.
-            return buildCommon.makeSpan(
+            return makeSpan(
                 ["mspace", cssSpace[group.text]],
                 [], options);
         } else {

--- a/src/functions/text.js
+++ b/src/functions/text.js
@@ -1,6 +1,6 @@
 // @flow
 import defineFunction, {ordargument} from "../defineFunction";
-import buildCommon from "../buildCommon";
+import {makeSpan} from "../buildCommon";
 
 import * as html from "../buildHTML";
 import * as mml from "../buildMathML";
@@ -67,7 +67,7 @@ defineFunction({
     htmlBuilder(group, options) {
         const newOptions = optionsWithFont(group, options);
         const inner = html.buildExpression(group.body, newOptions, true);
-        return buildCommon.makeSpan(["mord", "text"], inner, newOptions);
+        return makeSpan(["mord", "text"], inner, newOptions);
     },
     mathmlBuilder(group, options) {
         const newOptions = optionsWithFont(group, options);

--- a/src/functions/underline.js
+++ b/src/functions/underline.js
@@ -1,6 +1,6 @@
 // @flow
 import defineFunction from "../defineFunction";
-import buildCommon from "../buildCommon";
+import {makeLineSpan, makeSpan, makeVList} from "../buildCommon";
 import {MathNode, TextNode} from "../mathMLTree";
 
 import * as html from "../buildHTML";
@@ -26,11 +26,11 @@ defineFunction({
         const innerGroup = html.buildGroup(group.body, options);
 
         // Create the line to go below the body
-        const line = buildCommon.makeLineSpan("underline-line", options);
+        const line = makeLineSpan("underline-line", options);
 
         // Generate the vlist, with the appropriate kerns
         const defaultRuleThickness = options.fontMetrics().defaultRuleThickness;
-        const vlist = buildCommon.makeVList({
+        const vlist = makeVList({
             positionType: "top",
             positionData: innerGroup.height,
             children: [
@@ -41,7 +41,7 @@ defineFunction({
             ],
         }, options);
 
-        return buildCommon.makeSpan(["mord", "underline"], [vlist], options);
+        return makeSpan(["mord", "underline"], [vlist], options);
     },
     mathmlBuilder(group, options) {
         const operator = new MathNode(

--- a/src/functions/utils/assembleSupSub.js
+++ b/src/functions/utils/assembleSupSub.js
@@ -1,5 +1,5 @@
 // @flow
-import buildCommon from "../../buildCommon";
+import {makeSpan, makeVList} from "../../buildCommon";
 import * as html from "../../buildHTML";
 import {isCharacterBox} from "../../utils";
 import type {StyleInterface} from "../../Style";
@@ -19,7 +19,7 @@ export const assembleSupSub = (
     slant: number,
     baseShift: number,
 ): DomSpan => {
-    base = buildCommon.makeSpan([], [base]);
+    base = makeSpan([], [base]);
     const subIsSingleCharacter = subGroup &&  isCharacterBox(subGroup);
     let sub;
     let sup;
@@ -58,7 +58,7 @@ export const assembleSupSub = (
             sub.kern +
             base.depth + baseShift;
 
-        finalGroup = buildCommon.makeVList({
+        finalGroup = makeVList({
             positionType: "bottom",
             positionData: bottom,
             children: [
@@ -78,7 +78,7 @@ export const assembleSupSub = (
         // that we are supposed to shift the limits by 1/2 of the slant,
         // but since we are centering the limits adding a full slant of
         // margin will shift by 1/2 that.
-        finalGroup = buildCommon.makeVList({
+        finalGroup = makeVList({
             positionType: "top",
             positionData: top,
             children: [
@@ -91,7 +91,7 @@ export const assembleSupSub = (
     } else if (sup) {
         const bottom = base.depth + baseShift;
 
-        finalGroup = buildCommon.makeVList({
+        finalGroup = makeVList({
             positionType: "bottom",
             positionData: bottom,
             children: [
@@ -112,9 +112,9 @@ export const assembleSupSub = (
     if (sub && slant !== 0 && !subIsSingleCharacter) {
         // A negative margin-left was applied to the lower limit.
         // Avoid an overlap by placing a spacer on the left on the group.
-        const spacer = buildCommon.makeSpan(["mspace"], [], options);
+        const spacer = makeSpan(["mspace"], [], options);
         spacer.style.marginRight = makeEm(slant);
         parts.unshift(spacer);
     }
-    return buildCommon.makeSpan(["mop", "op-limits"], parts, options);
+    return makeSpan(["mop", "op-limits"], parts, options);
 };

--- a/src/functions/vcenter.js
+++ b/src/functions/vcenter.js
@@ -1,6 +1,6 @@
 // @flow
 import defineFunction from "../defineFunction";
-import buildCommon from "../buildCommon";
+import {makeVList} from "../buildCommon";
 import {MathNode} from "../mathMLTree";
 
 import * as html from "../buildHTML";
@@ -27,7 +27,7 @@ defineFunction({
         const body = html.buildGroup(group.body, options);
         const axisHeight = options.fontMetrics().axisHeight;
         const dy = 0.5 * ((body.height - axisHeight) - (body.depth + axisHeight));
-        return buildCommon.makeVList({
+        return makeVList({
             positionType: "shift",
             positionData: dy,
             children: [{type: "elem", elem: body}],

--- a/src/functions/verb.js
+++ b/src/functions/verb.js
@@ -1,6 +1,6 @@
 // @flow
 import defineFunction from "../defineFunction";
-import buildCommon from "../buildCommon";
+import {makeSpan, makeSymbol, tryCombineChars} from "../buildCommon";
 import {MathNode, TextNode} from "../mathMLTree";
 import ParseError from "../ParseError";
 
@@ -31,12 +31,12 @@ defineFunction({
             if (c === '~') {
                 c = '\\textasciitilde';
             }
-            body.push(buildCommon.makeSymbol(c, "Typewriter-Regular",
+            body.push(makeSymbol(c, "Typewriter-Regular",
                 group.mode, newOptions, ["mord", "texttt"]));
         }
-        return buildCommon.makeSpan(
+        return makeSpan(
             ["mord", "text"].concat(newOptions.sizingClasses(options)),
-            buildCommon.tryCombineChars(body),
+            tryCombineChars(body),
             newOptions,
         );
     },

--- a/src/stretchy.js
+++ b/src/stretchy.js
@@ -6,7 +6,7 @@
  */
 
 import {LineNode, PathNode, SvgNode} from "./domTree";
-import buildCommon from "./buildCommon";
+import {makeSpan, makeSvgSpan} from "./buildCommon";
 import {MathNode, TextNode} from "./mathMLTree";
 import {makeEm} from "./units";
 
@@ -237,7 +237,7 @@ const svgSpan = function(
                 "preserveAspectRatio": "none",
             });
             return {
-                span: buildCommon.makeSvgSpan([], [svgNode], options),
+                span: makeSvgSpan([], [svgNode], options),
                 minWidth: 0,
                 height,
             };
@@ -278,7 +278,7 @@ const svgSpan = function(
                     "preserveAspectRatio": aligns[i] + " slice",
                 });
 
-                const span = buildCommon.makeSvgSpan(
+                const span = makeSvgSpan(
                     [widthClasses[i]], [svgNode], options);
                 if (numSvgChildren === 1) {
                     return {span, minWidth, height};
@@ -289,7 +289,7 @@ const svgSpan = function(
             }
 
             return {
-                span: buildCommon.makeSpan(["stretchy"], spans, options),
+                span: makeSpan(["stretchy"], spans, options),
                 minWidth,
                 height,
             };
@@ -320,7 +320,7 @@ const encloseSpan = function(
     const totalHeight = inner.height + inner.depth + topPad + bottomPad;
 
     if (/fbox|color|angl/.test(label)) {
-        img = buildCommon.makeSpan(["stretchy", label], [], options);
+        img = makeSpan(["stretchy", label], [], options);
 
         if (label === "fbox") {
             const color = options.color && options.getColor();
@@ -360,7 +360,7 @@ const encloseSpan = function(
             "height": makeEm(totalHeight),
         });
 
-        img = buildCommon.makeSvgSpan([], [svgNode], options);
+        img = makeSvgSpan([], [svgNode], options);
     }
 
     img.height = totalHeight;


### PR DESCRIPTION
<!-- PR title should follow Angular Commit Message Conventions (https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines) -->

**What is the previous behavior before this PR?**
Default export was used in `src/buildCommon.js`

**What is the new behavior after this PR?**
Named exports used `src/buildCommon.js`

Bundle size reduction:

- katex.js size is 2.2 Kb smaller.
- katex.min.js size is 1.8 Kb smaller.

<!-- If this PR contains a breaking change, please uncomment following line -->
<!-- BREAKING CHANGE: describe its impact and migration methods -->

<!-- If this PR fixes or closes issues, please uncomment following line and change the issue number -->
<!-- Fixes #1, Closes #2 -->
Derived from https://github.com/KaTeX/KaTeX/pull/4064
