### PR TITLE
chore: texcmp docker update

### DIFF
--- a/dockers/texcmp/Dockerfile
+++ b/dockers/texcmp/Dockerfile
@@ -1,10 +1,11 @@
-FROM ubuntu:17.10
+FROM ubuntu:18.04
 
 MAINTAINER Martin von Gagern <gagern@ma.tum.de>
 
 ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 /usr/bin/dumb-init
 
 # Disable regular updates, keep security updates, avoid intermediate layers
+# Grant ImageMagick rights to read and write PDFs
 RUN sed -i 's/^\(deb.*updates\)/#\1/' /etc/apt/sources.list \
  && apt-get update \
  && apt-get upgrade -y \
@@ -19,6 +20,7 @@ RUN sed -i 's/^\(deb.*updates\)/#\1/' /etc/apt/sources.list \
         texlive-fonts-recommended \
         texlive-latex-base \
         texlive-latex-extra \
+ && sed -i 's/<policy domain="coder" rights="none" pattern="PDF" \/>/<policy domain="coder" rights="read|write" pattern="PDF" \/>/g' /etc/ImageMagick-6/policy.xml \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* \
  && chmod +x /usr/bin/dumb-init


### PR DESCRIPTION
I needed to run texcmp during #4137, and found it was no longer working.

**What is the previous behavior before this PR?**
Attempt to build texcmp's docker (via `texcmp.sh`) fails because Ubuntu 17.10 is unsupported:

```
0.817 E: The repository 'http://archive.ubuntu.com/ubuntu artful Release' does not have a Release file.
0.817 E: The repository 'http://archive.ubuntu.com/ubuntu artful-backports Release' does not have a Release file.
0.817 E: The repository 'http://security.ubuntu.com/ubuntu artful-security Release' does not have a Release file.
```

**What is the new behavior after this PR?**
Minimal update to next Ubuntu LTS, 18.04. This required adding a rule for ImageMagick to have permission to read PDF files, or else it would throw this error:

```
Error executing convert -density 559.65888 -units PixelsPerInch -flatten -depth 8 /tmp/texcmp/FractionTest.pdf /KaTeX/test/screenshotter/tex/FractionTest-pdflatex.png
convert-im6.q16: not authorized `/tmp/texcmp/FractionTest.pdf' @ error/constitute.c/ReadImage/412.
convert-im6.q16: no images defined `/KaTeX/test/screenshotter/tex/FractionTest-pdflatex.png' @ error/convert.c/ConvertImageCommand/3258.
```

