### PR TITLE
fix: forward variables to fonts module

### DIFF
--- a/src/styles/katex-swap.scss
+++ b/src/styles/katex-swap.scss
@@ -1,7 +1,4 @@
-@use 'fonts.scss' with (
-  $font-display: swap,
-);
-
 @use 'katex' with (
+  $font-display: swap,
   $version: $version,
 );

--- a/src/styles/katex.scss
+++ b/src/styles/katex.scss
@@ -1,6 +1,15 @@
 /* stylelint-disable font-family-no-missing-generic-family-keyword */
 @use "sass:list";
 @use "sass:math";
+
+@forward "fonts.scss" with (
+    $font-folder: "../../fonts" !default,
+    $use-woff2: true !default,
+    $use-woff: true !default,
+    $use-ttf: true !default,
+    $font-display: block !default
+);
+
 @use "fonts.scss";
 
 // The mu unit is defined as 1/18 em


### PR DESCRIPTION
<!-- PR title should follow Angular Commit Message Conventions (https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines) -->

**What is the previous behavior before this PR?**
After changing `import` to `@use` in https://github.com/KaTeX/KaTeX/pull/4114 variables weren't passed to `fonts.scss` properly using [@forward](https://sass-lang.com/documentation/at-rules/forward/#configuring-modules). Despite there's no changes in css artifact this impacted how SCSS users interact with exposed variables.

**What is the new behavior after this PR?**
This should be working now.

<!-- If this PR contains a breaking change, please uncomment following line -->
<!-- BREAKING CHANGE: describe its impact and migration methods -->

<!-- If this PR fixes or closes issues, please uncomment following line and change the issue number -->
<!-- Fixes #1, Closes #2 -->
Fixes https://github.com/KaTeX/KaTeX/issues/4144
