### PR TITLE
fix: emoji with color variation selector

### DIFF
--- a/src/macros.ts
+++ b/src/macros.ts
@@ -335,7 +335,6 @@ defineMacro("\u231E", "\\llcorner");
 defineMacro("\u231F", "\\lrcorner");
 defineMacro("\u00A9", "\\copyright");
 defineMacro("\u00AE", "\\textregistered");
-defineMacro("\uFE0F", "\\textregistered");
 
 // The KaTeX fonts have corners at codepoints that don't match Unicode.
 // For MathML purposes, use the Unicode code point.

--- a/test/katex-spec.ts
+++ b/test/katex-spec.ts
@@ -4127,7 +4127,17 @@ describe("Unicode", function() {
 
     it("should parse symbols", function() {
         expect("£¥ℂℍℑℎℓℕ℘ℙℚℜℝℤℲℵðℶℷℸ⅁∀∁∂∃∇∞∠∡∢♠♡♢♣♭♮♯✓°¬‼⋮\u00B7\u00A9").toBuild(strictSettings);
-        expect("\\text{£¥ℂℍℎ\u00A9\u00AE\uFE0F}").toBuild(strictSettings);
+        expect("\\text{£¥ℂℍℎ\u00A9\u00AE}").toBuild(strictSettings);
+    });
+
+    it("should not treat emoji variation selectors as registered signs", function() {
+        const parsed = getParsed("🏳️‍🌈", nonstrictSettings);
+        expect(parsed).toHaveLength(4);
+        expect(parsed[1]).toMatchObject({
+            type: "textord",
+            mode: "text",
+            text: "\uFE0F",
+        });
     });
 
     it("should build Greek capital letters", function() {


### PR DESCRIPTION
<!-- PR title should follow Angular Commit Message Conventions (https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines) -->

**What is the previous behavior before this PR?**
U+FE0F ([VARIATION SELECTOR](https://en.wikipedia.org/wiki/Variation_Selectors_(Unicode_block))-16) was treated like `\textregistered`, causing weird behavior reported in #3842.

It looks like I introduced this in #1454, specifically https://github.com/KaTeX/KaTeX/pull/1454/changes/1c801e5b5fe8fa1bdb2667dbb96ed9f823760014 . I think the reason was a page like https://emojiterra.com/registered/ which mentions U+00AE U+FE0F is a registered trademark emoji ®️, and I interpreted the sequence as two individual characters. In fact, ®️ used to render as two registered trademarks in a row, which is incorrect.

**What is the new behavior after this PR?**
U+FE0F remains as is, enabling color selection in emoji like 🏳️‍🌈.

®️ also renders (somewhat) correctly as a single `\textregistered`, though the "color emoji" part becomes nonfunctional and there's a warning about missing character metrics for U+FE0F.

<!-- If this PR contains a breaking change, please uncomment following line -->
<!-- BREAKING CHANGE: describe its impact and migration methods -->

<!-- If this PR fixes or closes issues, please uncomment following line and change the issue number -->
<!-- Fixes #1, Closes #2 -->
Fixes #3842