### PR TITLE
feat: \qedsymbol and \openbox

### DIFF
--- a/docs/support_table.md
+++ b/docs/support_table.md
@@ -803,6 +803,7 @@ use `\ce` instead|
 |\Omicron|$\Omicron$||
 |\omicron|$\omicron$||
 |\ominus|$\ominus$||
+|\openbox|$\openbox$||
 |\operatorname|$\operatorname{asin} x$|`\operatorname{asin} x`|
 |\operatorname\*|$\operatorname*{asin}\limits_y x$|`\operatorname*{asin}\limits_y x`|
 |\operatornamewithlimits|$\operatornamewithlimits{asin}\limits_y x$|`\operatornamewithlimits{asin}\limits_y x`|
@@ -879,6 +880,7 @@ use `\ce` instead|
 |Symbol/Function |  Rendered   | Source or Comment|
 |:---------------|:------------|:-----------------|
 |\Q|<span style="color:firebrick;">Not supported</span>|See `\Bbb{Q}`|
+|\qedsymbol|$\qedsymbol$||
 |\qquad|$a\qquad\qquad{b}$|`a\qquad\qquad{b}`|
 |\quad|$a\quad\quad{b}$|`a\quad\quad{b}`|
 |\R|$\R$||

--- a/docs/supported.md
+++ b/docs/supported.md
@@ -656,30 +656,31 @@ In cases where KaTeX fonts do not have a bold glyph, `\pmb` can simulate one. Fo
 |$\text{\textasciicircum}$ `\text{\textasciicircum}`|$\mathellipsis$ `\mathellipsis`|$\ddagger$ `\ddagger`
 |$`$ <code>`</code>|$\text{\textellipsis}$ `\text{\textellipsis}`|$\text{\textdaggerdbl}$ `\text{\textdaggerdbl}`
 |$\text{\textquoteleft}$ `\text{\textquoteleft}`|$\Box$ `\Box`|$\Dagger$ `\Dagger`
-|$\lq$ `\lq`|$\square$ `\square`|$\angle$ `\angle`
-|$\text{\textquoteright}$ `\text{\textquoteright}`|$\blacksquare$ `\blacksquare`|$\measuredangle$ `\measuredangle`
-|$\rq$ `\rq`|$\triangle$ `\triangle`|$\sphericalangle$ `\sphericalangle`
-|$\text{\textquotedblleft}$ `\text{\textquotedblleft}`|$\triangledown$ `\triangledown`|$\top$ `\top`
-|$"$ `"`|$\triangleleft$ `\triangleleft`|$\bot$ `\bot`
-|$\text{\textquotedblright}$ `\text{\textquotedblright}`|$\triangleright$ `\triangleright`|$\$$ `\$`
-|$\colon$ `\colon`|$\bigtriangledown$ `\bigtriangledown`|$\text{\textdollar}$ `\text{\textdollar}`
-|$\backprime$ `\backprime`|$\bigtriangleup$ `\bigtriangleup`|$\pounds$ `\pounds`
-|$\prime$ `\prime`|$\blacktriangle$ `\blacktriangle`|$\mathsterling$ `\mathsterling`
-|$\text{\textless}$ `\text{\textless}`|$\blacktriangledown$ `\blacktriangledown`|$\text{\textsterling}$ `\text{\textsterling}`
-|$\text{\textgreater}$ `\text{\textgreater}`|$\blacktriangleleft$ `\blacktriangleleft`|$\yen$ `\yen`
-|$\text{\textbar}$ `\text{\textbar}`|$\blacktriangleright$ `\blacktriangleright`|$\surd$ `\surd`
-|$\text{\textbardbl}$ `\text{\textbardbl}`|$\diamond$ `\diamond`|$\degree$ `\degree`
-|$\text{\textbraceleft}$ `\text{\textbraceleft}`|$\Diamond$ `\Diamond`|$\text{\textdegree}$ `\text{\textdegree}`
-|$\text{\textbraceright}$ `\text{\textbraceright}`|$\lozenge$ `\lozenge`|$\mho$ `\mho`
-|$\text{\textbackslash}$ `\text{\textbackslash}`|$\blacklozenge$ `\blacklozenge`|$\diagdown$ `\diagdown`
-|$\text{\P}$ `\text{\P}` or `\P`|$\star$ `\star`|$\diagup$ `\diagup`
-|$\text{\S}$ `\text{\S}` or `\S`|$\bigstar$ `\bigstar`|$\flat$ `\flat`
-|$\text{\sect}$ `\text{\sect}`|$\clubsuit$ `\clubsuit`|$\natural$ `\natural`
-|$\copyright$ `\copyright`|$\clubs$ `\clubs`|$\sharp$ `\sharp`
-|$\circledR$ `\circledR`|$\diamondsuit$ `\diamondsuit`|$\heartsuit$ `\heartsuit`
-|$\text{\textregistered}$ `\text{\textregistered}`|$\diamonds$ `\diamonds`|$\hearts$ `\hearts`
-|$\circledS$ `\circledS`|$\spadesuit$ `\spadesuit`|$\spades$ `\spades`
-|$\text{\textcircled a}$ `\text{\textcircled a}`|$\maltese$ `\maltese`|$\minuso$ `\minuso`|
+|$\lq$ `\lq`|$\openbox$ `\openbox`|$\angle$ `\angle`
+|$\text{\textquoteright}$ `\text{\textquoteright}`|$\qedsymbol$ `\qedsymbol`|$\measuredangle$ `\measuredangle`
+|$\rq$ `\rq`|$\square$ `\square`|$\sphericalangle$ `\sphericalangle`
+|$\text{\textquotedblleft}$ `\text{\textquotedblleft}`|$\blacksquare$ `\blacksquare`|$\top$ `\top`
+|$"$ `"`|$\triangle$ `\triangle`|$\bot$ `\bot`
+|$\text{\textquotedblright}$ `\text{\textquotedblright}`|$\triangledown$ `\triangledown`|$\$$ `\$`
+|$\colon$ `\colon`|$\triangleleft$ `\triangleleft`|$\text{\textdollar}$ `\text{\textdollar}`
+|$\backprime$ `\backprime`|$\triangleright$ `\triangleright`|$\pounds$ `\pounds`
+|$\prime$ `\prime`|$\bigtriangledown$ `\bigtriangledown`|$\mathsterling$ `\mathsterling`
+|$\text{\textless}$ `\text{\textless}`|$\bigtriangleup$ `\bigtriangleup`|$\text{\textsterling}$ `\text{\textsterling}`
+|$\text{\textgreater}$ `\text{\textgreater}`|$\blacktriangle$ `\blacktriangle`|$\yen$ `\yen`
+|$\text{\textbar}$ `\text{\textbar}`|$\blacktriangledown$ `\blacktriangledown`|$\surd$ `\surd`
+|$\text{\textbardbl}$ `\text{\textbardbl}`|$\blacktriangleleft$ `\blacktriangleleft`|$\degree$ `\degree`
+|$\text{\textbraceleft}$ `\text{\textbraceleft}`|$\blacktriangleright$ `\blacktriangleright`|$\text{\textdegree}$ `\text{\textdegree}`
+|$\text{\textbraceright}$ `\text{\textbraceright}`|$\diamond$ `\diamond`|$\mho$ `\mho`
+|$\text{\textbackslash}$ `\text{\textbackslash}`|$\Diamond$ `\Diamond`|$\diagdown$ `\diagdown`
+|$\text{\P}$ `\text{\P}` or `\P`|$\lozenge$ `\lozenge`|$\diagup$ `\diagup`
+|$\text{\S}$ `\text{\S}` or `\S`|$\blacklozenge$ `\blacklozenge`|$\flat$ `\flat`
+|$\text{\sect}$ `\text{\sect}`|$\star$ `\star`|$\natural$ `\natural`
+|$\copyright$ `\copyright`|$\bigstar$ `\bigstar`|$\sharp$ `\sharp`
+|$\circledR$ `\circledR`|$\clubsuit$ `\clubsuit`|$\heartsuit$ `\heartsuit`
+|$\text{\textregistered}$ `\text{\textregistered}`|$\clubs$ `\clubs`|$\hearts$ `\hearts`
+|$\circledS$ `\circledS`|$\diamondsuit$ `\diamondsuit`|$\spadesuit$ `\spadesuit`
+|$\text{\textcircled a}$ `\text{\textcircled a}`|$\diamonds$ `\diamonds`|$\spades$ `\spades`|
+|$\maltese$ `\maltese`|$\minuso$ `\minuso`||
 
 Direct Input: § ¶ $ £ ¥ ∇ ∞ · ∠ ∡ ∢ ♠ ♡ ♢ ♣ ♭ ♮ ♯ ✓ …  ⋮  ⋯  ⋱  !$ ‼ ⦵
 

--- a/src/macros.ts
+++ b/src/macros.ts
@@ -776,6 +776,22 @@ defineMacro("\\varprojlim", "\\DOTSB\\operatorname*{\\underleftarrow{lim}}");
 
 //////////////////////////////////////////////////////////////////////
 // amsthm.sty
+
+// \newcommand{\openbox}{\leavevmode\hbox to.77778em{%
+//   \hfil\vrule\vbox to.675em{\hrule width.6em\vfil\hrule}\vrule\hfil}}
+// defines 0.77778em total width, 0.6em inner width, 0.675em total height.
+// 0.4pt (default) rule thickness.
+// Side padding (0.77778em - 0.6em - 2 * 0.4pt) / 2 = 0.04889em.
+// The top rule is raised by 0.675em - 0.4pt = 0.635em at 10pt.
+// For MathML, use a simple white square instead of exposing the rule stack.
+defineMacro("\\openbox", "\\html@mathml{" +
+    "\\kern0.04889em" +
+    "\\rule{0.4pt}{0.675em}" +
+    "\\rlap{\\raisebox{0.635em}{\\rule{0.6em}{0.4pt}}}" +
+    "\\rule{0.6em}{0.4pt}" +
+    "\\rule{0.4pt}{0.675em}" +
+    "\\kern0.04889em" +
+    "}{\\char`□}");
 defineMacro("\\qedsymbol", "\\openbox");
 
 //////////////////////////////////////////////////////////////////////

--- a/src/macros.ts
+++ b/src/macros.ts
@@ -775,6 +775,10 @@ defineMacro("\\varinjlim", "\\DOTSB\\operatorname*{\\underrightarrow{lim}}");
 defineMacro("\\varprojlim", "\\DOTSB\\operatorname*{\\underleftarrow{lim}}");
 
 //////////////////////////////////////////////////////////////////////
+// amsthm.sty
+defineMacro("\\qedsymbol", "\\openbox");
+
+//////////////////////////////////////////////////////////////////////
 // MathML alternates for KaTeX glyphs in the Unicode private area
 defineMacro("\\gvertneqq", "\\html@mathml{\\@gvertneqq}{\u2269}");
 defineMacro("\\lvertneqq", "\\html@mathml{\\@lvertneqq}{\u2268}");

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -296,6 +296,9 @@ defineSymbol(math, ams, textord, "\u2571", "\\diagup");
 defineSymbol(math, ams, textord, "\u2572", "\\diagdown");
 defineSymbol(math, ams, textord, "\u25a1", "\\square");
 defineSymbol(math, ams, textord, "\u25a1", "\\Box");
+// amsthm defines \openbox via box drawing; we approximate it with \square.
+defineSymbol(math, ams, textord, "\u25a1", "\\openbox");
+defineSymbol(text, ams, textord, "\u25a1", "\\openbox");
 defineSymbol(math, ams, textord, "\u25ca", "\\Diamond");
 // unicode-math maps U+A5 to \mathyen. We map to AMS function \yen
 defineSymbol(math, ams, textord, "\u00a5", "\\yen", true);

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -296,9 +296,6 @@ defineSymbol(math, ams, textord, "\u2571", "\\diagup");
 defineSymbol(math, ams, textord, "\u2572", "\\diagdown");
 defineSymbol(math, ams, textord, "\u25a1", "\\square");
 defineSymbol(math, ams, textord, "\u25a1", "\\Box");
-// amsthm defines \openbox via box drawing; we approximate it with \square.
-defineSymbol(math, ams, textord, "\u25a1", "\\openbox");
-defineSymbol(text, ams, textord, "\u25a1", "\\openbox");
 defineSymbol(math, ams, textord, "\u25ca", "\\Diamond");
 // unicode-math maps U+A5 to \mathyen. We map to AMS function \yen
 defineSymbol(math, ams, textord, "\u00a5", "\\yen", true);

--- a/test/katex-spec.ts
+++ b/test/katex-spec.ts
@@ -3559,6 +3559,18 @@ describe("A macro expander", function() {
         expect`X \impliedby Y`.toBuild();
     });
 
+    it("should expand \\openbox like amsthm", function() {
+        expect`\openbox`.toBuildLike`\square`;
+        expect`\openbox`.toBuild();
+        expect`\text{\openbox}`.toBuild();
+    });
+
+    it("should expand \\qedsymbol like amsthm", function() {
+        expect`\qedsymbol`.toParseLike`\openbox`;
+        expect`\qedsymbol`.toBuild();
+        expect`\text{\qedsymbol}`.toBuild();
+    });
+
     it("should allow aliasing characters", function() {
         expect`x’=c`.toParseLike("x'=c", new Settings({macros: {
             "’": "'",

--- a/test/katex-spec.ts
+++ b/test/katex-spec.ts
@@ -3560,15 +3560,18 @@ describe("A macro expander", function() {
     });
 
     it("should expand \\openbox like amsthm", function() {
-        expect`\openbox`.toBuildLike`\square`;
         expect`\openbox`.toBuild();
         expect`\text{\openbox}`.toBuild();
+        expect(katex.renderToString("\\openbox")).toContain("rule");
+        expect(katex.renderToString("\\openbox")).toContain("□");
     });
 
     it("should expand \\qedsymbol like amsthm", function() {
         expect`\qedsymbol`.toParseLike`\openbox`;
         expect`\qedsymbol`.toBuild();
         expect`\text{\qedsymbol}`.toBuild();
+        expect(katex.renderToString("\\qedsymbol")).toContain("rule");
+        expect(katex.renderToString("\\qedsymbol")).toContain("□");
     });
 
     it("should allow aliasing characters", function() {


### PR DESCRIPTION
<!-- PR title should follow Angular Commit Message Conventions (https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines) -->

**What is the previous behavior before this PR?**
`\qedsymbol` and `\openbox` from amsthm were not supported

**Interlude**
Originally I planned to implement `\qedsymbol` and `\openbox` as aliases for the `\square` symbol, but (like LaTeX), working in both text and math mode (unlike `\square`).

Here's a comparison of how LaTeX renders `\openbox` versus `\square`:

red `\openbox` over green `\square`
<img width="1695" height="1709" alt="image" src="https://github.com/user-attachments/assets/1211b58d-9d52-46f4-be15-b224f15efe9a" />

red `\openbox` under green `\square`
<img width="1709" height="1699" alt="image" src="https://github.com/user-attachments/assets/d5cdf3cd-9149-4bb2-b442-6f6353c7a86e" />

Zoomed in a ton like this, there are some slight dimension differences, and perhaps more notably, `\square` has rounded corners.

**What is the new behavior after this PR?**
Instead I tried to write `\openbox` using macros, close to how amsthm does it. Here's how it looks with the PR:

```latex
\openbox \text{ vs. } \square
```

<img width="739" height="182" alt="image" src="https://github.com/user-attachments/assets/16a422a5-f3f1-43db-a966-bbc786efe7bc" />

Here's what texcmp renders:

<img width="54" height="53" alt="Openbox" src="https://github.com/user-attachments/assets/6c953287-6db0-44d1-9eb4-1c30d84e5b3b" />

I *think* this is just rasterization error.

<!-- If this PR contains a breaking change, please uncomment following line -->
<!-- BREAKING CHANGE: describe its impact and migration methods -->

<!-- If this PR fixes or closes issues, please uncomment following line and change the issue number -->
<!-- Fixes #1, Closes #2 -->

Fixes #3843
