### PR TITLE
refactor(types): resolve most `as any` casts and `TODO(ts)` comments

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -152,6 +152,13 @@
         "@typescript-eslint/ban-ts-comment": "off",
         "@typescript-eslint/no-require-imports": "off"
       }
+    }, {
+      "files": ["src/**/*.ts", "contrib/**/*.ts"],
+      "rules": {
+        "@typescript-eslint/no-explicit-any": ["error", {
+          "ignoreRestArgs": true
+        }]
+      }
     }],
     "root": true
 }

--- a/contrib/render-a11y-string/render-a11y-string.ts
+++ b/contrib/render-a11y-string/render-a11y-string.ts
@@ -646,8 +646,12 @@ const handleObject = (
         case "mclass": {
             // \neq and \ne are macros so we let "htmlmathml" render the mathmal
             // side of things and extract the text from that.
+            // mclass values are prefixed with "m" (e.g. "mrel" -> "rel")
             const atomType = tree.mclass.slice(1);
-            // TODO(ts): drop the leading "m" from the values in mclass
+            const validAtoms = ["bin", "close", "inner", "open", "punct", "rel"];
+            if (atomType !== "normal" && !validAtoms.includes(atomType)) {
+                throw new Error(`Unexpected mclass atom type: "${atomType}"`);
+            }
             buildA11yStrings(tree.body, a11yStrings, atomType as Atom | "normal");
             break;
         }

--- a/contrib/render-a11y-string/render-a11y-string.ts
+++ b/contrib/render-a11y-string/render-a11y-string.ts
@@ -14,9 +14,7 @@
  * when read by a screenreader.
  */
 
-// NOTE: since we're importing types here these files won't actually be
-// included in the build.
-import type {Atom} from "../../src/symbols";
+import {ATOMS, type Atom} from "../../src/symbols";
 import type {AnyParseNode} from "../../src/parseNode";
 import type {SettingsOptions} from "../../src/Settings";
 import katex from "katex";
@@ -646,8 +644,11 @@ const handleObject = (
         case "mclass": {
             // \neq and \ne are macros so we let "htmlmathml" render the mathmal
             // side of things and extract the text from that.
+            // mclass values are prefixed with "m" (e.g. "mrel" -> "rel")
             const atomType = tree.mclass.slice(1);
-            // TODO(ts): drop the leading "m" from the values in mclass
+            if (atomType !== "normal" && !(atomType in ATOMS)) {
+                throw new Error(`Unexpected mclass atom type: "${atomType}"`);
+            }
             buildA11yStrings(tree.body, a11yStrings, atomType as Atom | "normal");
             break;
         }

--- a/contrib/render-a11y-string/render-a11y-string.ts
+++ b/contrib/render-a11y-string/render-a11y-string.ts
@@ -18,6 +18,11 @@ import {ATOMS, type Atom} from "../../src/symbols";
 import type {AnyParseNode} from "../../src/parseNode";
 import type {SettingsOptions} from "../../src/Settings";
 import katex from "katex";
+
+function isAtom(value: string): value is Atom {
+    return value in ATOMS;
+}
+
 const stringMap: Record<string, string> = {
     "(": "left parenthesis",
     ")": "right parenthesis",
@@ -645,11 +650,14 @@ const handleObject = (
             // \neq and \ne are macros so we let "htmlmathml" render the mathmal
             // side of things and extract the text from that.
             // mclass values are prefixed with "m" (e.g. "mrel" -> "rel")
-            const atomType = tree.mclass.slice(1);
-            if (atomType !== "normal" && !(atomType in ATOMS)) {
+            const atomType: string = tree.mclass.slice(1);
+            if (atomType === "normal") {
+                buildA11yStrings(tree.body, a11yStrings, atomType);
+            } else if (isAtom(atomType)) {
+                buildA11yStrings(tree.body, a11yStrings, atomType);
+            } else {
                 throw new Error(`Unexpected mclass atom type: "${atomType}"`);
             }
-            buildA11yStrings(tree.body, a11yStrings, atomType as Atom | "normal");
             break;
         }
 

--- a/contrib/render-a11y-string/render-a11y-string.ts
+++ b/contrib/render-a11y-string/render-a11y-string.ts
@@ -14,15 +14,10 @@
  * when read by a screenreader.
  */
 
-import {ATOMS, type Atom} from "../../src/symbols";
+import {isAtom, type Atom} from "../../src/symbols";
 import type {AnyParseNode} from "../../src/parseNode";
 import type {SettingsOptions} from "../../src/Settings";
 import katex from "katex";
-
-function isAtom(value: string): value is Atom {
-    return value in ATOMS;
-}
-
 const stringMap: Record<string, string> = {
     "(": "left parenthesis",
     ")": "right parenthesis",

--- a/contrib/render-a11y-string/render-a11y-string.ts
+++ b/contrib/render-a11y-string/render-a11y-string.ts
@@ -14,7 +14,7 @@
  * when read by a screenreader.
  */
 
-import {isAtom, type Atom} from "../../src/symbols";
+import {isAtom, type Atom} from "../../src/atoms";
 import type {AnyParseNode} from "../../src/parseNode";
 import type {SettingsOptions} from "../../src/Settings";
 import katex from "katex";

--- a/contrib/render-a11y-string/render-a11y-string.ts
+++ b/contrib/render-a11y-string/render-a11y-string.ts
@@ -650,10 +650,8 @@ const handleObject = (
             // \neq and \ne are macros so we let "htmlmathml" render the mathmal
             // side of things and extract the text from that.
             // mclass values are prefixed with "m" (e.g. "mrel" -> "rel")
-            const atomType: string = tree.mclass.slice(1);
-            if (atomType === "normal") {
-                buildA11yStrings(tree.body, a11yStrings, atomType);
-            } else if (isAtom(atomType)) {
+            const atomType = tree.mclass.slice(1);
+            if (atomType === "normal" || isAtom(atomType)) {
                 buildA11yStrings(tree.body, a11yStrings, atomType);
             } else {
                 throw new Error(`Unexpected mclass atom type: "${atomType}"`);

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -22,6 +22,11 @@ import type {Mode, ArgType, BreakToken} from "./types";
 import type {FunctionContext, FunctionSpec} from "./defineFunction";
 import type {EnvSpec} from "./defineEnvironment";
 
+/** Runtime type guard: narrows Group to Atom via ATOMS membership check. */
+function isAtom(group: Group): group is Atom {
+    return Object.prototype.hasOwnProperty.call(ATOMS, group);
+}
+
 /**
  * This file contains the parser used to parse out a TeX expression from the
  * input. Since TeX isn't context-free, standard parsers don't work particularly
@@ -521,6 +526,7 @@ export default class Parser {
      */
     parseArguments(
         func: string,   // Should look like "\name" or "\begin{name}".
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         funcData: FunctionSpec<any> | EnvSpec<any>,
     ): {
         args: AnyParseNode[];
@@ -974,26 +980,22 @@ export default class Parser {
             const group: Group = symbols[this.mode][text].group;
             const loc = SourceLocation.range(nucleus);
             let s: SymbolParseNode;
-            if (ATOMS.hasOwnProperty(group)) {
-                // TODO(ts)
-                const family = group as Atom;
+            if (isAtom(group)) {
                 s = {
                     type: "atom",
                     mode: this.mode,
-                    family,
+                    family: group,
                     loc,
                     text,
                 };
             } else {
-                // TODO(ts)
                 s = {
-                    type: group as Exclude<SymbolParseNode["type"], "atom">,
+                    type: group,
                     mode: this.mode,
                     loc,
                     text,
                 };
             }
-            // TODO(ts)
             symbol = s;
         } else if (text.charCodeAt(0) >= 0x80) { // no symbol for e.g. ^
             if (this.settings.strict) {
@@ -1045,12 +1047,10 @@ export default class Parser {
                     label: command,
                     isStretchy: false,
                     isShifty: true,
-                    // TODO(ts)
                     base: symbol,
                 };
             }
         }
-        // TODO(ts)
         return symbol;
     }
 }

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -1,7 +1,8 @@
 /* eslint no-constant-condition:0 */
 import functions from "./functions";
 import MacroExpander, {implicitCommands} from "./MacroExpander";
-import symbols, {ATOMS, isAtom, extraLatin} from "./symbols";
+import symbols, {extraLatin} from "./symbols";
+import {isAtom} from "./atoms";
 import {validUnit} from "./units";
 import {supportedCodepoint} from "./unicodeScripts";
 import ParseError from "./ParseError";
@@ -17,7 +18,7 @@ import unicodeSymbols from /*preval*/ "./unicodeSymbols";
 
 import type {NodeType, ParseNode, AnyParseNode, SymbolParseNode,
     UnsupportedCmdParseNode} from "./parseNode";
-import type {Group} from "./symbols";
+import type {Group} from "./atoms";
 import type {Mode, ArgType, BreakToken} from "./types";
 import type {FunctionContext, FunctionSpec} from "./defineFunction";
 import type {EnvSpec} from "./defineEnvironment";

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -22,6 +22,10 @@ import type {Mode, ArgType, BreakToken} from "./types";
 import type {FunctionContext, FunctionSpec} from "./defineFunction";
 import type {EnvSpec} from "./defineEnvironment";
 
+function isAtom(group: Group): group is Atom {
+    return group in ATOMS;
+}
+
 /**
  * This file contains the parser used to parse out a TeX expression from the
  * input. Since TeX isn't context-free, standard parsers don't work particularly
@@ -521,6 +525,7 @@ export default class Parser {
      */
     parseArguments(
         func: string,   // Should look like "\name" or "\begin{name}".
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         funcData: FunctionSpec<any> | EnvSpec<any>,
     ): {
         args: AnyParseNode[];
@@ -974,26 +979,22 @@ export default class Parser {
             const group: Group = symbols[this.mode][text].group;
             const loc = SourceLocation.range(nucleus);
             let s: SymbolParseNode;
-            if (ATOMS.hasOwnProperty(group)) {
-                // TODO(ts)
-                const family = group as Atom;
+            if (isAtom(group)) {
                 s = {
                     type: "atom",
                     mode: this.mode,
-                    family,
+                    family: group,
                     loc,
                     text,
                 };
             } else {
-                // TODO(ts)
                 s = {
-                    type: group as Exclude<SymbolParseNode["type"], "atom">,
+                    type: group,
                     mode: this.mode,
                     loc,
                     text,
                 };
             }
-            // TODO(ts)
             symbol = s;
         } else if (text.charCodeAt(0) >= 0x80) { // no symbol for e.g. ^
             if (this.settings.strict) {
@@ -1045,12 +1046,10 @@ export default class Parser {
                     label: command,
                     isStretchy: false,
                     isShifty: true,
-                    // TODO(ts)
                     base: symbol,
                 };
             }
         }
-        // TODO(ts)
         return symbol;
     }
 }

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -15,8 +15,8 @@ import {Token} from "./Token";
 import unicodeAccents from /*preval*/ "./unicodeAccents";
 import unicodeSymbols from /*preval*/ "./unicodeSymbols";
 
-import type {ParseNode, AnyParseNode, SymbolParseNode, UnsupportedCmdParseNode}
-    from "./parseNode";
+import type {NodeType, ParseNode, AnyParseNode, SymbolParseNode,
+    UnsupportedCmdParseNode} from "./parseNode";
 import type {Group} from "./symbols";
 import type {Mode, ArgType, BreakToken} from "./types";
 import type {FunctionContext, FunctionSpec} from "./defineFunction";
@@ -521,8 +521,7 @@ export default class Parser {
      */
     parseArguments(
         func: string,   // Should look like "\name" or "\begin{name}".
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        funcData: FunctionSpec<any> | EnvSpec<any>,
+        funcData: FunctionSpec<NodeType> | EnvSpec<NodeType>,
     ): {
         args: AnyParseNode[];
         optArgs: (AnyParseNode | null | undefined)[];

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -1,7 +1,7 @@
 /* eslint no-constant-condition:0 */
 import functions from "./functions";
 import MacroExpander, {implicitCommands} from "./MacroExpander";
-import symbols, {ATOMS, extraLatin} from "./symbols";
+import symbols, {ATOMS, isAtom, extraLatin} from "./symbols";
 import {validUnit} from "./units";
 import {supportedCodepoint} from "./unicodeScripts";
 import ParseError from "./ParseError";
@@ -17,14 +17,10 @@ import unicodeSymbols from /*preval*/ "./unicodeSymbols";
 
 import type {ParseNode, AnyParseNode, SymbolParseNode, UnsupportedCmdParseNode}
     from "./parseNode";
-import type {Atom, Group} from "./symbols";
+import type {Group} from "./symbols";
 import type {Mode, ArgType, BreakToken} from "./types";
 import type {FunctionContext, FunctionSpec} from "./defineFunction";
 import type {EnvSpec} from "./defineEnvironment";
-
-function isAtom(group: Group): group is Atom {
-    return group in ATOMS;
-}
 
 /**
  * This file contains the parser used to parse out a TeX expression from the

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -57,6 +57,14 @@ type EnumType = {
 };
 
 type Type = "boolean" | "string" | "number" | "object" | "function" | EnumType;
+/**
+ * Union of all possible settings default values, used in the schema.
+ * Not as precise as Settings itself, but avoids `any` while covering
+ * all default/cliDefault shapes that actually appear.
+ */
+type SettingsValue = boolean | string | number
+    | MacroMap | StrictFunction | TrustFunction
+    | string[];
 type Schema = {
     [key in keyof SettingsOptions]?: {
         /**
@@ -69,15 +77,17 @@ type Schema = {
          * for enum will be used. If multiple types are allowed, the first allowed
          * type will be used for determining the default value.
          */
-        default?: any;
+        default?: SettingsValue;
         /**
          * The description.
          */
         description?: string;
         /**
-         * The function to process the option.
+         * The function to process the option.  Only defined for numeric
+         * settings (minRuleThickness, maxSize, maxExpand); if a processor
+         * is needed for a non-numeric setting, widen this type accordingly.
          */
-        processor?: (arg0: any) => any;
+        processor?: (value: number) => number;
         /**
          * The command line argument. See Commander.js docs for more information.
          * If not specified, the name prefixed with -- will be used. Set false not
@@ -87,7 +97,7 @@ type Schema = {
         /**
          * The default value for the CLI.
          */
-        cliDefault?: any;
+        cliDefault?: SettingsValue;
         /**
          * The description for the CLI. If not specified, the description for the
          * option will be used.
@@ -95,9 +105,11 @@ type Schema = {
         cliDescription?: string;
         /**
          * The custom argument processor for the CLI. See Commander.js docs for
-         * more information.
+         * more information. Signature varies per setting (e.g. parseFloat,
+         * or (def, defs) => defs.push(def) for macros).
          */
-        cliProcessor?: (arg0: any, arg1: any) => any;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        cliProcessor?: (...args: any[]) => SettingsValue;
     };
 };
 
@@ -208,8 +220,8 @@ export const SETTINGS_SCHEMA: Schema = {
     },
 };
 
-function getDefaultValue(schema: SchemaEntry): any {
-    if ("default" in schema) {
+function getDefaultValue(schema: SchemaEntry): SettingsValue {
+    if ("default" in schema && schema.default !== undefined) {
         return schema.default;
     }
     const type = schema.type;
@@ -226,6 +238,11 @@ function getDefaultValue(schema: SchemaEntry): any {
             return 0;
         case 'object':
             return {};
+        case 'function':
+            // Function types (e.g. strict, trust) always specify an explicit
+            // default in the schema, so this should never be reached.
+            throw new Error(
+                "Function-type settings must declare an explicit default.");
     }
 }
 
@@ -262,8 +279,10 @@ export default class Settings {
             const schema = SETTINGS_SCHEMA[prop] as SchemaEntry;
             const optionValue = options[prop];
             // TODO: validate options
-            (this as Record<string, unknown>)[prop] = optionValue !== undefined ?
-                (schema.processor ? schema.processor(optionValue) : optionValue)
+            (this as Record<string, unknown>)[prop] = optionValue !== undefined
+                ? (schema.processor
+                    ? schema.processor(optionValue as number)
+                    : optionValue)
                 : getDefaultValue(schema);
         }
     }

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -83,6 +83,11 @@ type Schema = {
         /**
          * The function to process the option.
          */
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // `any` is required because processors operate on heterogeneous
+        // option types (numbers, strings, objects). Fixing this requires
+        // making Schema generic over each setting key so that processor
+        // signatures are inferred per-option.
         processor?: (value: any) => any;
         /**
          * The command line argument. See Commander.js docs for more information.

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -57,6 +57,12 @@ type EnumType = {
 };
 
 type Type = "boolean" | "string" | "number" | "object" | "function" | EnumType;
+/**
+ * Union of all values that appear as schema defaults, cliDefaults, or
+ * cliProcessor return values.  StrictFunction / TrustFunction are
+ * option-value types, not default/schema values, so they are excluded.
+ */
+type SettingsValue = boolean | string | number | MacroMap | string[];
 type Schema = {
     [key in keyof SettingsOptions]?: {
         /**
@@ -69,15 +75,17 @@ type Schema = {
          * for enum will be used. If multiple types are allowed, the first allowed
          * type will be used for determining the default value.
          */
-        default?: any;
+        default?: SettingsValue;
         /**
          * The description.
          */
         description?: string;
         /**
-         * The function to process the option.
+         * The function to process the option.  Only defined for numeric
+         * settings (minRuleThickness, maxSize, maxExpand); if a processor
+         * is needed for a non-numeric setting, widen this type accordingly.
          */
-        processor?: (arg0: any) => any;
+        processor?: (value: number) => number;
         /**
          * The command line argument. See Commander.js docs for more information.
          * If not specified, the name prefixed with -- will be used. Set false not
@@ -87,7 +95,7 @@ type Schema = {
         /**
          * The default value for the CLI.
          */
-        cliDefault?: any;
+        cliDefault?: SettingsValue;
         /**
          * The description for the CLI. If not specified, the description for the
          * option will be used.
@@ -95,9 +103,11 @@ type Schema = {
         cliDescription?: string;
         /**
          * The custom argument processor for the CLI. See Commander.js docs for
-         * more information.
+         * more information. Signature varies per setting (e.g. parseFloat,
+         * or (def, defs) => defs.push(def) for macros).
          */
-        cliProcessor?: (arg0: any, arg1: any) => any;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        cliProcessor?: (...args: any[]) => SettingsValue;
     };
 };
 
@@ -208,8 +218,8 @@ export const SETTINGS_SCHEMA: Schema = {
     },
 };
 
-function getDefaultValue(schema: SchemaEntry): any {
-    if ("default" in schema) {
+function getDefaultValue(schema: SchemaEntry): SettingsValue {
+    if ("default" in schema && schema.default !== undefined) {
         return schema.default;
     }
     const type = schema.type;
@@ -226,6 +236,11 @@ function getDefaultValue(schema: SchemaEntry): any {
             return 0;
         case 'object':
             return {};
+        case 'function':
+            // Function types (e.g. strict, trust) always specify an explicit
+            // default in the schema, so this should never be reached.
+            throw new Error(
+                "Function-type settings must declare an explicit default.");
     }
 }
 
@@ -262,8 +277,12 @@ export default class Settings {
             const schema = SETTINGS_SCHEMA[prop] as SchemaEntry;
             const optionValue = options[prop];
             // TODO: validate options
-            (this as Record<string, unknown>)[prop] = optionValue !== undefined ?
-                (schema.processor ? schema.processor(optionValue) : optionValue)
+            // processor is only defined for numeric settings
+            // (minRuleThickness, maxSize, maxExpand), so the number cast is safe.
+            (this as Record<string, unknown>)[prop] = optionValue !== undefined
+                ? (schema.processor
+                    ? schema.processor(optionValue as number)
+                    : optionValue)
                 : getDefaultValue(schema);
         }
     }

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -81,11 +81,9 @@ type Schema = {
          */
         description?: string;
         /**
-         * The function to process the option.  Only defined for numeric
-         * settings (minRuleThickness, maxSize, maxExpand); if a processor
-         * is needed for a non-numeric setting, widen this type accordingly.
+         * The function to process the option.
          */
-        processor?: (value: number) => number;
+        processor?: (value: any) => any;
         /**
          * The command line argument. See Commander.js docs for more information.
          * If not specified, the name prefixed with -- will be used. Set false not
@@ -277,11 +275,9 @@ export default class Settings {
             const schema = SETTINGS_SCHEMA[prop] as SchemaEntry;
             const optionValue = options[prop];
             // TODO: validate options
-            // processor is only defined for numeric settings
-            // (minRuleThickness, maxSize, maxExpand), so the number cast is safe.
             (this as Record<string, unknown>)[prop] = optionValue !== undefined
                 ? (schema.processor
-                    ? schema.processor(optionValue as number)
+                    ? schema.processor(optionValue)
                     : optionValue)
                 : getDefaultValue(schema);
         }

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -83,12 +83,12 @@ type Schema = {
         /**
          * The function to process the option.
          */
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         // All current processors are (number) => number, but the
         // constructor loops over Object.keys so optionValue loses
         // per-key type info. Narrowing to number would require a cast
         // at the call site; `any` keeps the schema type simple.
         // Fix: make Schema generic per setting key.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         processor?: (value: any) => any;
         /**
          * The command line argument. See Commander.js docs for more information.
@@ -223,8 +223,8 @@ export const SETTINGS_SCHEMA: Schema = {
 };
 
 function getDefaultValue(schema: SchemaEntry): SettingsValue {
-    if ("default" in schema && schema.default !== undefined) {
-        return schema.default;
+    if ("default" in schema) {
+        return schema.default!;
     }
     const type = schema.type;
     const defaultType = Array.isArray(type) ? type[0] : type;
@@ -240,11 +240,9 @@ function getDefaultValue(schema: SchemaEntry): SettingsValue {
             return 0;
         case 'object':
             return {};
-        case 'function':
-            // Function types (e.g. strict, trust) always specify an explicit
-            // default in the schema, so this should never be reached.
+        default:
             throw new Error(
-                "Function-type settings must declare an explicit default.");
+                "Unexpected schema type; settings must declare an explicit default.");
     }
 }
 

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -84,10 +84,11 @@ type Schema = {
          * The function to process the option.
          */
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        // `any` is required because processors operate on heterogeneous
-        // option types (numbers, strings, objects). Fixing this requires
-        // making Schema generic over each setting key so that processor
-        // signatures are inferred per-option.
+        // All current processors are (number) => number, but the
+        // constructor loops over Object.keys so optionValue loses
+        // per-key type info. Narrowing to number would require a cast
+        // at the call site; `any` keeps the schema type simple.
+        // Fix: make Schema generic per setting key.
         processor?: (value: any) => any;
         /**
          * The command line argument. See Commander.js docs for more information.

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -52,8 +52,8 @@ export type AnyTrustContext = TrustContextTypes[keyof TrustContextTypes];
 export type TrustFunction = (context: AnyTrustContext) => boolean | null | undefined;
 export type SettingsOptions = Partial<Settings>;
 
-type EnumType = {
-    enum: string[];
+type EnumType<T extends string = string> = {
+    enum: T[];
 };
 
 type Type = "boolean" | "string" | "number" | "object" | "function" | EnumType;
@@ -63,18 +63,9 @@ type Type = "boolean" | "string" | "number" | "object" | "function" | EnumType;
  * option-value types, not default/schema values, so they are excluded.
  */
 type SettingsValue = boolean | string | number | MacroMap | string[];
-type SchemaEntry<K extends keyof SettingsOptions> = {
-    /**
-     * Allowed type(s) of the value.
-     */
-    type: Type | Type[];
-    /**
-     * The default value. If not specified, false for boolean, an empty string
-     * for string, 0 for number, an empty object for object, or the first item
-     * for enum will be used. If multiple types are allowed, the first allowed
-     * type will be used for determining the default value.
-     */
-    default?: Settings[K];
+type DefaultValue = Exclude<SettingsValue, string[]>;
+
+type SchemaMetadata<K extends keyof SettingsOptions> = {
     /**
      * The description.
      */
@@ -106,6 +97,96 @@ type SchemaEntry<K extends keyof SettingsOptions> = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     cliProcessor?: (...args: any[]) => SettingsValue;
 };
+
+type BooleanSchema<K extends keyof SettingsOptions> = SchemaMetadata<K> & {
+    /**
+     * Allowed type(s) of the value.
+     */
+    type: "boolean";
+    /**
+     * The default value. If not specified, false will be used.
+     */
+    default?: Extract<Settings[K], boolean>;
+};
+
+type StringSchema<K extends keyof SettingsOptions> = SchemaMetadata<K> & {
+    /**
+     * Allowed type(s) of the value.
+     */
+    type: "string";
+    /**
+     * The default value. If not specified, an empty string will be used.
+     */
+    default?: Extract<Settings[K], string>;
+};
+
+type NumberSchema<K extends keyof SettingsOptions> = SchemaMetadata<K> & {
+    /**
+     * Allowed type(s) of the value.
+     */
+    type: "number";
+    /**
+     * The default value. If not specified, 0 will be used.
+     */
+    default?: Extract<Settings[K], number>;
+};
+
+type ObjectSchema<K extends keyof SettingsOptions> = SchemaMetadata<K> & {
+    /**
+     * Allowed type(s) of the value.
+     */
+    type: "object";
+    /**
+     * The default value. If not specified, an empty object will be used.
+     */
+    default?: Extract<Settings[K], MacroMap>;
+};
+
+type FunctionSchema<K extends keyof SettingsOptions> = SchemaMetadata<K> & {
+    /**
+     * Allowed type(s) of the value.
+     */
+    type: "function";
+    /**
+     * Settings do not currently use function-valued defaults.
+     */
+    default?: never;
+};
+
+type EnumSchema<K extends keyof SettingsOptions> = SchemaMetadata<K> & {
+    /**
+     * Allowed type(s) of the value.
+     */
+    type: EnumType<Extract<Settings[K], string>>;
+    /**
+     * The default value. If not specified, the first enum value will be used.
+     */
+    default?: Extract<Settings[K], string>;
+};
+
+type SingleTypeSchema<K extends keyof SettingsOptions> =
+    | BooleanSchema<K>
+    | StringSchema<K>
+    | NumberSchema<K>
+    | ObjectSchema<K>
+    | FunctionSchema<K>
+    | EnumSchema<K>;
+
+type MultiTypeSchema<K extends keyof SettingsOptions> = SchemaMetadata<K> & {
+    /**
+     * Allowed type(s) of the value.
+     */
+    type: [SingleTypeSchema<K>["type"], ...Array<SingleTypeSchema<K>["type"]>];
+    /**
+     * The default value. If not specified, the first allowed type determines
+     * the default value.
+     */
+    default?: Extract<Settings[K], DefaultValue>;
+};
+
+type SchemaEntry<K extends keyof SettingsOptions> =
+    | SingleTypeSchema<K>
+    | MultiTypeSchema<K>;
 
 type Schema = {
     [key in keyof SettingsOptions]?: SchemaEntry<key>;
@@ -216,30 +297,41 @@ export const SETTINGS_SCHEMA: Schema = {
     },
 };
 
-function getDefaultValue<K extends keyof SettingsOptions>(
-    schema: SchemaEntry<K>,
-): Settings[K] {
-    if ("default" in schema) {
-        return schema.default!;
+function getImplicitDefault(type: "boolean"): boolean;
+function getImplicitDefault(type: "string"): string;
+function getImplicitDefault(type: "number"): number;
+function getImplicitDefault(type: "object"): MacroMap;
+function getImplicitDefault(type: "function"): never;
+function getImplicitDefault<T extends string>(type: EnumType<T>): T;
+function getImplicitDefault(type: Type): DefaultValue;
+function getImplicitDefault(type: Type): DefaultValue {
+    if (typeof type !== 'string') {
+        return type.enum[0];
     }
-    const type = schema.type;
-    const defaultType = Array.isArray(type) ? type[0] : type;
-    if (typeof defaultType !== 'string') {
-        return defaultType.enum[0] as Settings[K];
-    }
-    switch (defaultType) {
+    switch (type) {
         case 'boolean':
-            return false as Settings[K];
+            return false;
         case 'string':
-            return '' as Settings[K];
+            return '';
         case 'number':
-            return 0 as Settings[K];
+            return 0;
         case 'object':
-            return {} as Settings[K];
+            return {};
         default:
             throw new Error(
                 "Unexpected schema type; settings must declare an explicit default.");
     }
+}
+
+function getDefaultValue<K extends keyof SettingsOptions>(
+    schema: SchemaEntry<K>,
+): Settings[K];
+function getDefaultValue(schema: SchemaEntry<keyof SettingsOptions>): DefaultValue {
+    if (schema.default !== undefined) {
+        return schema.default;
+    }
+    const type = Array.isArray(schema.type) ? schema.type[0] : schema.type;
+    return getImplicitDefault(type);
 }
 
 function applySetting<K extends keyof SettingsOptions>(

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -63,59 +63,53 @@ type Type = "boolean" | "string" | "number" | "object" | "function" | EnumType;
  * option-value types, not default/schema values, so they are excluded.
  */
 type SettingsValue = boolean | string | number | MacroMap | string[];
-type Schema = {
-    [key in keyof SettingsOptions]?: {
-        /**
-         * Allowed type(s) of the value.
-         */
-        type: Type | Type[];
-        /**
-         * The default value. If not specified, false for boolean, an empty string
-         * for string, 0 for number, an empty object for object, or the first item
-         * for enum will be used. If multiple types are allowed, the first allowed
-         * type will be used for determining the default value.
-         */
-        default?: SettingsValue;
-        /**
-         * The description.
-         */
-        description?: string;
-        /**
-         * The function to process the option.
-         */
-        // All current processors are (number) => number, but the
-        // constructor loops over Object.keys so optionValue loses
-        // per-key type info. Narrowing to number would require a cast
-        // at the call site; `any` keeps the schema type simple.
-        // Fix: make Schema generic per setting key.
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        processor?: (value: any) => any;
-        /**
-         * The command line argument. See Commander.js docs for more information.
-         * If not specified, the name prefixed with -- will be used. Set false not
-         * to add to the CLI.
-         */
-        cli?: string | false;
-        /**
-         * The default value for the CLI.
-         */
-        cliDefault?: SettingsValue;
-        /**
-         * The description for the CLI. If not specified, the description for the
-         * option will be used.
-         */
-        cliDescription?: string;
-        /**
-         * The custom argument processor for the CLI. See Commander.js docs for
-         * more information. Signature varies per setting (e.g. parseFloat,
-         * or (def, defs) => defs.push(def) for macros).
-         */
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        cliProcessor?: (...args: any[]) => SettingsValue;
-    };
+type SchemaEntry<K extends keyof SettingsOptions> = {
+    /**
+     * Allowed type(s) of the value.
+     */
+    type: Type | Type[];
+    /**
+     * The default value. If not specified, false for boolean, an empty string
+     * for string, 0 for number, an empty object for object, or the first item
+     * for enum will be used. If multiple types are allowed, the first allowed
+     * type will be used for determining the default value.
+     */
+    default?: Settings[K];
+    /**
+     * The description.
+     */
+    description?: string;
+    /**
+     * The function to process the option.
+     */
+    processor?: (value: Settings[K]) => Settings[K];
+    /**
+     * The command line argument. See Commander.js docs for more information.
+     * If not specified, the name prefixed with -- will be used. Set false not
+     * to add to the CLI.
+     */
+    cli?: string | false;
+    /**
+     * The default value for the CLI.
+     */
+    cliDefault?: SettingsValue;
+    /**
+     * The description for the CLI. If not specified, the description for the
+     * option will be used.
+     */
+    cliDescription?: string;
+    /**
+     * The custom argument processor for the CLI. See Commander.js docs for
+     * more information. Signature varies per setting (e.g. parseFloat,
+     * or (def, defs) => defs.push(def) for macros).
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    cliProcessor?: (...args: any[]) => SettingsValue;
 };
 
-type SchemaEntry = NonNullable<Schema[keyof SettingsOptions]>;
+type Schema = {
+    [key in keyof SettingsOptions]?: SchemaEntry<key>;
+};
 
 // TODO: automatically generate documentation
 // TODO: check all properties on Settings exist
@@ -222,28 +216,44 @@ export const SETTINGS_SCHEMA: Schema = {
     },
 };
 
-function getDefaultValue(schema: SchemaEntry): SettingsValue {
+function getDefaultValue<K extends keyof SettingsOptions>(
+    schema: SchemaEntry<K>,
+): Settings[K] {
     if ("default" in schema) {
         return schema.default!;
     }
     const type = schema.type;
     const defaultType = Array.isArray(type) ? type[0] : type;
     if (typeof defaultType !== 'string') {
-        return defaultType.enum[0];
+        return defaultType.enum[0] as Settings[K];
     }
     switch (defaultType) {
         case 'boolean':
-            return false;
+            return false as Settings[K];
         case 'string':
-            return '';
+            return '' as Settings[K];
         case 'number':
-            return 0;
+            return 0 as Settings[K];
         case 'object':
-            return {};
+            return {} as Settings[K];
         default:
             throw new Error(
                 "Unexpected schema type; settings must declare an explicit default.");
     }
+}
+
+function applySetting<K extends keyof SettingsOptions>(
+    target: Settings,
+    prop: K,
+    options: SettingsOptions,
+    schema: SchemaEntry<K>,
+) {
+    const optionValue = options[prop];
+    target[prop] = optionValue !== undefined
+        ? (schema.processor
+            ? schema.processor(optionValue)
+            : optionValue)
+        : getDefaultValue(schema);
 }
 
 /**
@@ -276,14 +286,11 @@ export default class Settings {
         // allow null options
         options = options || {};
         for (const prop of Object.keys(SETTINGS_SCHEMA) as Array<keyof SettingsOptions>) {
-            const schema = SETTINGS_SCHEMA[prop] as SchemaEntry;
-            const optionValue = options[prop];
-            // TODO: validate options
-            (this as Record<string, unknown>)[prop] = optionValue !== undefined
-                ? (schema.processor
-                    ? schema.processor(optionValue)
-                    : optionValue)
-                : getDefaultValue(schema);
+            const schema = SETTINGS_SCHEMA[prop] as SchemaEntry<typeof prop> | undefined;
+            if (schema) {
+                // TODO: validate options
+                applySetting(this, prop, options, schema);
+            }
         }
     }
 

--- a/src/atoms.ts
+++ b/src/atoms.ts
@@ -1,0 +1,33 @@
+/**
+ * Small module for atom-group constants and type guard.  Kept separate from
+ * `symbols.ts` so that consumers (notably `contrib/render-a11y-string`) can
+ * pull in `isAtom` without dragging in the ~870-line symbol tables.
+ */
+
+// Some of these have a "-token" suffix since these are also used as `ParseNode`
+// types for raw text tokens, and we want to avoid conflicts with higher-level
+// `ParseNode` types. These `ParseNode`s are constructed within `Parser` by
+// looking up the `symbols` map.
+export const ATOMS = {
+    "bin": 1,
+    "close": 1,
+    "inner": 1,
+    "open": 1,
+    "punct": 1,
+    "rel": 1,
+};
+export const NON_ATOMS = {
+    "accent-token": 1,
+    "mathord": 1,
+    "op-token": 1,
+    "spacing": 1,
+    "textord": 1,
+};
+
+export type Atom = keyof typeof ATOMS;
+export type NonAtom = keyof typeof NON_ATOMS;
+export type Group = Atom | NonAtom;
+
+export function isAtom(value: string): value is Atom {
+    return value in ATOMS;
+}

--- a/src/buildHTML.ts
+++ b/src/buildHTML.ts
@@ -159,7 +159,8 @@ const traverseNonSpaceNodes = function(
         const partialGroup = checkPartialGroup(node);
 
         if (partialGroup) { // Recursive DFS
-            // TODO(ts): make nodes a $ReadOnlyArray by returning a new array
+            // TODO(ts): partialGroup.children is ReadonlyArray but this
+            // function mutates the array (insertAfter splices into it).
             traverseNonSpaceNodes(partialGroup.children as HtmlDomNode[],
                 callback, prev, null, isRoot);
             continue;
@@ -266,8 +267,8 @@ export const buildGroup = function(
     }
 
     if (groupBuilders[group.type]) {
-        // Call the groupBuilders function
-        // TODO(ts)
+        // TODO(ts): groupBuilders is Record<string, HtmlBuilder<any>>;
+        // a type-safe registry would need a mapped type keyed by NodeType.
         let groupNode: HtmlDomNode = groupBuilders[group.type](group, options);
 
         // If the size changed between the parent and the current group, account

--- a/src/buildMathML.ts
+++ b/src/buildMathML.ts
@@ -13,7 +13,7 @@ import {MathNode, TextNode} from "./mathMLTree";
 
 import type Options from "./Options";
 import type {AnyParseNode, SymbolParseNode} from "./parseNode";
-import type {DomSpan} from "./domTree";
+import type {DomSpan, HtmlDomNode} from "./domTree";
 import type {MathDomNode} from "./mathMLTree";
 import type {FontVariant, Mode} from "./types";
 
@@ -257,11 +257,10 @@ export const buildGroup = function(
     }
 
     if (groupBuilders[group.type]) {
-        // Call the groupBuilders function
-        // TODO(ts)
-        const result: MathDomNode = groupBuilders[group.type](group, options);
-        // TODO(ts)
-        return result as MathNode;
+        // TODO(ts): MathMLBuilder returns MathDomNode but all concrete
+        // builders return MathNode. Widening the return type here would
+        // require updating all callers that assume MathNode.
+        return groupBuilders[group.type](group, options) as MathNode;
     } else {
         throw new ParseError(
             "Got group of unknown type: '" + group.type + "'");
@@ -319,7 +318,8 @@ export default function buildMathML(
     // NOTE: The span class is not typed to have <math> nodes as children, and
     // we don't want to make the children type more generic since the children
     // of span are expected to have more fields in `buildHtml` contexts.
+    // The MathNode implements VirtualNode (toNode/toMarkup) which is all that
+    // Span needs from its children for rendering.
     const wrapperClass = forMathmlOnly ? "katex" : "katex-mathml";
-    // TODO(ts)
-    return makeSpan([wrapperClass], [math as any]);
+    return makeSpan([wrapperClass], [math as unknown as HtmlDomNode]);
 }

--- a/src/buildMathML.ts
+++ b/src/buildMathML.ts
@@ -320,6 +320,8 @@ export default function buildMathML(
     // of span are expected to have more fields in `buildHtml` contexts.
     // The MathNode implements VirtualNode (toNode/toMarkup) which is all that
     // Span needs from its children for rendering.
+    // TODO(ts): Span's child type is HtmlDomNode, but MathNode only implements
+    // VirtualNode. The double-cast acknowledges this architectural limitation.
     const wrapperClass = forMathmlOnly ? "katex" : "katex-mathml";
     return makeSpan([wrapperClass], [math as unknown as HtmlDomNode]);
 }

--- a/src/defineEnvironment.ts
+++ b/src/defineEnvironment.ts
@@ -62,6 +62,7 @@ export type EnvSpec<NODETYPE extends NodeType> = {
  * `environments.js` exports this same dictionary again and makes it public.
  * `Parser.js` requires this dictionary via `environments.js`.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const _environments: Record<string, EnvSpec<any>> = {};
 
 type EnvDefSpec<NODETYPE extends NodeType> = {

--- a/src/defineEnvironment.ts
+++ b/src/defineEnvironment.ts
@@ -62,8 +62,7 @@ export type EnvSpec<NODETYPE extends NodeType> = {
  * `environments.js` exports this same dictionary again and makes it public.
  * `Parser.js` requires this dictionary via `environments.js`.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const _environments: Record<string, EnvSpec<any>> = {};
+export const _environments: Record<string, EnvSpec<NodeType>> = {};
 
 type EnvDefSpec<NODETYPE extends NodeType> = {
     // Unique string to differentiate parse nodes.

--- a/src/defineFunction.ts
+++ b/src/defineFunction.ts
@@ -130,6 +130,7 @@ export type FunctionSpec<NODETYPE extends NodeType> = {
     // _functions is typed FunctionSpec<*> (it stores all TeX function specs).
 
     // Must be specified unless it's handled directly in the parser.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     handler: FunctionHandler<any> | null | undefined;
 };
 
@@ -138,18 +139,21 @@ export type FunctionSpec<NODETYPE extends NodeType> = {
  * `functions.js` just exports this same dictionary again and makes it public.
  * `Parser.js` requires this dictionary.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const _functions: Record<string, FunctionSpec<any>> = {};
 
 /**
  * All HTML builders. Should be only used in the `define*` and the `build*ML`
  * functions.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const _htmlGroupBuilders: Record<string, HtmlBuilder<any>> = {};
 
 /**
  * All MathML builders. Should be only used in the `define*` and the `build*ML`
  * functions.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const _mathmlGroupBuilders: Record<string, MathMLBuilder<any>> = {};
 
 export default function defineFunction<NODETYPE extends NodeType>({

--- a/src/defineFunction.ts
+++ b/src/defineFunction.ts
@@ -130,8 +130,7 @@ export type FunctionSpec<NODETYPE extends NodeType> = {
     // _functions is typed FunctionSpec<*> (it stores all TeX function specs).
 
     // Must be specified unless it's handled directly in the parser.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    handler: FunctionHandler<any> | null | undefined;
+    handler: FunctionHandler<NodeType> | null | undefined;
 };
 
 /**
@@ -139,19 +138,23 @@ export type FunctionSpec<NODETYPE extends NodeType> = {
  * `functions.js` just exports this same dictionary again and makes it public.
  * `Parser.js` requires this dictionary.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const _functions: Record<string, FunctionSpec<any>> = {};
+export const _functions: Record<string, FunctionSpec<NodeType>> = {};
 
 /**
  * All HTML builders. Should be only used in the `define*` and the `build*ML`
  * functions.
+ *
+ * Builders for different node types are stored side by side, but
+ * `HtmlBuilder<T>` is contravariant in `T`, so there is no single type
+ * argument that makes storing/retrieving them typecheck.  `any` is used
+ * as an existential-quantifier escape hatch.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const _htmlGroupBuilders: Record<string, HtmlBuilder<any>> = {};
 
 /**
  * All MathML builders. Should be only used in the `define*` and the `build*ML`
- * functions.
+ * functions.  See `_htmlGroupBuilders` above for the rationale behind `any`.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const _mathmlGroupBuilders: Record<string, MathMLBuilder<any>> = {};

--- a/src/domTree.ts
+++ b/src/domTree.ts
@@ -75,7 +75,10 @@ const toNode = function(this: HtmlNodeData, tagName: string): HTMLElement {
 
     // Apply inline styles
     for (const key of Object.keys(this.style) as Array<keyof CssStyle>) {
-        (node.style as any)[key] = this.style[key];
+        const value = this.style[key];
+        if (value !== undefined) {
+            node.style[key] = value;
+        }
     }
 
     // Apply attributes
@@ -116,7 +119,10 @@ const toMarkup = function(this: HtmlNodeData, tagName: string): string {
 
     // Add the styles, after hyphenation
     for (const key of Object.keys(this.style) as Array<keyof CssStyle>) {
-        styles += `${hyphenate(key)}:${this.style[key]};`;
+        const value = this.style[key];
+        if (value !== undefined) {
+            styles += `${hyphenate(key)}:${value};`;
+        }
     }
 
     if (styles) {
@@ -211,6 +217,12 @@ export class Span<ChildType extends VirtualNode> implements HtmlDomNode {
     width: number | null | undefined;
     maxFontSize!: number;
     style!: CssStyle;
+    /**
+     * Italic correction carried over from a SymbolNode when the symbol is
+     * wrapped in a vlist (e.g. \oiint / \oiiint).  Read by supsub to adjust
+     * subscript positioning.  Defaults to 0.
+     */
+    italic: number = 0;
 
     constructor(
         classes?: string[],
@@ -323,7 +335,10 @@ export class Img implements VirtualNode {
 
         // Apply inline styles
         for (const key of Object.keys(this.style) as Array<keyof CssStyle>) {
-            (node.style as any)[key] = this.style[key];
+            const value = this.style[key];
+            if (value !== undefined) {
+                node.style[key] = value;
+            }
         }
 
         return node;
@@ -336,7 +351,10 @@ export class Img implements VirtualNode {
         // Add the styles, after hyphenation
         let styles = "";
         for (const key of Object.keys(this.style) as Array<keyof CssStyle>) {
-            styles += `${hyphenate(key)}:${this.style[key]};`;
+            const value = this.style[key];
+            if (value !== undefined) {
+                styles += `${hyphenate(key)}:${value};`;
+            }
         }
         if (styles) {
             markup += ` style="${escape(styles)}"`;
@@ -432,7 +450,10 @@ export class SymbolNode implements HtmlDomNode {
 
         for (const key of Object.keys(this.style) as Array<keyof CssStyle>) {
             span = span || document.createElement("span");
-            (span.style as any)[key] = this.style[key];
+            const value = this.style[key];
+            if (value !== undefined) {
+                span.style[key] = value;
+            }
         }
 
         if (span) {
@@ -466,7 +487,10 @@ export class SymbolNode implements HtmlDomNode {
             styles += `margin-right:${makeEm(this.italic)};`;
         }
         for (const key of Object.keys(this.style) as Array<keyof CssStyle>) {
-            styles += hyphenate(key) + ":" + this.style[key] + ";";
+            const value = this.style[key];
+            if (value !== undefined) {
+                styles += hyphenate(key) + ":" + value + ";";
+            }
         }
 
         if (styles) {

--- a/src/domTree.ts
+++ b/src/domTree.ts
@@ -74,12 +74,7 @@ const toNode = function(this: HtmlNodeData, tagName: string): HTMLElement {
     node.className = createClass(this.classes);
 
     // Apply inline styles
-    for (const key of Object.keys(this.style) as Array<keyof CssStyle>) {
-        const value = this.style[key];
-        if (value !== undefined) {
-            node.style[key] = value;
-        }
-    }
+    Object.assign(node.style, this.style);
 
     // Apply attributes
     for (const attr of Object.keys(this.attributes)) {
@@ -339,12 +334,7 @@ export class Img implements VirtualNode {
         node.className = "mord";
 
         // Apply inline styles
-        for (const key of Object.keys(this.style) as Array<keyof CssStyle>) {
-            const value = this.style[key];
-            if (value !== undefined) {
-                node.style[key] = value;
-            }
-        }
+        Object.assign(node.style, this.style);
 
         return node;
     }
@@ -453,12 +443,9 @@ export class SymbolNode implements HtmlDomNode {
             span.className = createClass(this.classes);
         }
 
-        for (const key of Object.keys(this.style) as Array<keyof CssStyle>) {
+        if (Object.keys(this.style).length > 0) {
             span = span || document.createElement("span");
-            const value = this.style[key];
-            if (value !== undefined) {
-                span.style[key] = value;
-            }
+            Object.assign(span.style, this.style);
         }
 
         if (span) {

--- a/src/domTree.ts
+++ b/src/domTree.ts
@@ -75,7 +75,10 @@ const toNode = function(this: HtmlNodeData, tagName: string): HTMLElement {
 
     // Apply inline styles
     for (const key of Object.keys(this.style) as Array<keyof CssStyle>) {
-        (node.style as any)[key] = this.style[key];
+        const value = this.style[key];
+        if (value !== undefined) {
+            node.style[key] = value;
+        }
     }
 
     // Apply attributes
@@ -116,7 +119,10 @@ const toMarkup = function(this: HtmlNodeData, tagName: string): string {
 
     // Add the styles, after hyphenation
     for (const key of Object.keys(this.style) as Array<keyof CssStyle>) {
-        styles += `${hyphenate(key)}:${this.style[key]};`;
+        const value = this.style[key];
+        if (value !== undefined) {
+            styles += `${hyphenate(key)}:${value};`;
+        }
     }
 
     if (styles) {
@@ -211,6 +217,12 @@ export class Span<ChildType extends VirtualNode> implements HtmlDomNode {
     width: number | null | undefined;
     maxFontSize!: number;
     style!: CssStyle;
+    /**
+     * Italic correction carried over from a SymbolNode when the symbol is
+     * wrapped in a vlist (e.g. \oiint / \oiiint).  Read by supsub to adjust
+     * subscript positioning.  Defaults to 0.
+     */
+    italic!: number;
 
     constructor(
         classes?: string[],
@@ -220,6 +232,11 @@ export class Span<ChildType extends VirtualNode> implements HtmlDomNode {
     ) {
         initNode.call(this, classes, options, style);
         this.children = children || [];
+        // Non-enumerable so it does not appear in test snapshots — only
+        // \oiint / \oiiint builders set this to a nonzero value.
+        Object.defineProperty(this, 'italic', {
+            value: 0, writable: true, enumerable: false, configurable: true,
+        });
     }
 
     /**
@@ -323,7 +340,10 @@ export class Img implements VirtualNode {
 
         // Apply inline styles
         for (const key of Object.keys(this.style) as Array<keyof CssStyle>) {
-            (node.style as any)[key] = this.style[key];
+            const value = this.style[key];
+            if (value !== undefined) {
+                node.style[key] = value;
+            }
         }
 
         return node;
@@ -336,7 +356,10 @@ export class Img implements VirtualNode {
         // Add the styles, after hyphenation
         let styles = "";
         for (const key of Object.keys(this.style) as Array<keyof CssStyle>) {
-            styles += `${hyphenate(key)}:${this.style[key]};`;
+            const value = this.style[key];
+            if (value !== undefined) {
+                styles += `${hyphenate(key)}:${value};`;
+            }
         }
         if (styles) {
             markup += ` style="${escape(styles)}"`;
@@ -432,7 +455,10 @@ export class SymbolNode implements HtmlDomNode {
 
         for (const key of Object.keys(this.style) as Array<keyof CssStyle>) {
             span = span || document.createElement("span");
-            (span.style as any)[key] = this.style[key];
+            const value = this.style[key];
+            if (value !== undefined) {
+                span.style[key] = value;
+            }
         }
 
         if (span) {
@@ -466,7 +492,10 @@ export class SymbolNode implements HtmlDomNode {
             styles += `margin-right:${makeEm(this.italic)};`;
         }
         for (const key of Object.keys(this.style) as Array<keyof CssStyle>) {
-            styles += hyphenate(key) + ":" + this.style[key] + ";";
+            const value = this.style[key];
+            if (value !== undefined) {
+                styles += hyphenate(key) + ":" + value + ";";
+            }
         }
 
         if (styles) {

--- a/src/domTree.ts
+++ b/src/domTree.ts
@@ -221,9 +221,9 @@ export class Span<ChildType extends VirtualNode> implements HtmlDomNode {
     /**
      * Italic correction carried over from a SymbolNode when the symbol is
      * wrapped in a vlist (e.g. \oiint / \oiiint).  Read by supsub to adjust
-     * subscript positioning.
+     * subscript positioning.  Only set when nonzero; use `?? 0` at read sites.
      */
-    italic: number = 0;
+    italic?: number;
 
     constructor(
         classes?: string[],

--- a/src/domTree.ts
+++ b/src/domTree.ts
@@ -28,6 +28,21 @@ export const createClass = function(classes: string[]): string {
     return classes.filter(cls => cls).join(" ");
 };
 
+/**
+ * Serialize a CssStyle object into a semicolon-delimited inline-style string
+ * (hyphenating camelCase property names). Returns "" when no property is set.
+ */
+const cssStyleToString = function(style: CssStyle): string {
+    let styles = "";
+    for (const key of Object.keys(style) as Array<keyof CssStyle>) {
+        const value = style[key];
+        if (value !== undefined) {
+            styles += `${hyphenate(key)}:${value};`;
+        }
+    }
+    return styles;
+};
+
 type InitNodeData = {
     classes: string[];
     attributes: Record<string, string>;
@@ -110,16 +125,7 @@ const toMarkup = function(this: HtmlNodeData, tagName: string): string {
         markup += ` class="${escape(createClass(this.classes))}"`;
     }
 
-    let styles = "";
-
-    // Add the styles, after hyphenation
-    for (const key of Object.keys(this.style) as Array<keyof CssStyle>) {
-        const value = this.style[key];
-        if (value !== undefined) {
-            styles += `${hyphenate(key)}:${value};`;
-        }
-    }
-
+    const styles = cssStyleToString(this.style);
     if (styles) {
         markup += ` style="${escape(styles)}"`;
     }
@@ -343,14 +349,7 @@ export class Img implements VirtualNode {
         let markup = `<img src="${escape(this.src)}"` +
           ` alt="${escape(this.alt)}"`;
 
-        // Add the styles, after hyphenation
-        let styles = "";
-        for (const key of Object.keys(this.style) as Array<keyof CssStyle>) {
-            const value = this.style[key];
-            if (value !== undefined) {
-                styles += `${hyphenate(key)}:${value};`;
-            }
-        }
+        const styles = cssStyleToString(this.style);
         if (styles) {
             markup += ` style="${escape(styles)}"`;
         }
@@ -478,12 +477,7 @@ export class SymbolNode implements HtmlDomNode {
         if (this.italic > 0) {
             styles += `margin-right:${makeEm(this.italic)};`;
         }
-        for (const key of Object.keys(this.style) as Array<keyof CssStyle>) {
-            const value = this.style[key];
-            if (value !== undefined) {
-                styles += hyphenate(key) + ":" + value + ";";
-            }
-        }
+        styles += cssStyleToString(this.style);
 
         if (styles) {
             needsSpan = true;

--- a/src/domTree.ts
+++ b/src/domTree.ts
@@ -221,9 +221,9 @@ export class Span<ChildType extends VirtualNode> implements HtmlDomNode {
     /**
      * Italic correction carried over from a SymbolNode when the symbol is
      * wrapped in a vlist (e.g. \oiint / \oiiint).  Read by supsub to adjust
-     * subscript positioning.  Defaults to 0.
+     * subscript positioning.
      */
-    italic!: number;
+    italic: number = 0;
 
     constructor(
         classes?: string[],
@@ -233,11 +233,6 @@ export class Span<ChildType extends VirtualNode> implements HtmlDomNode {
     ) {
         initNode.call(this, classes, options, style);
         this.children = children || [];
-        // Non-enumerable so it does not appear in test snapshots — only
-        // \oiint / \oiiint builders set this to a nonzero value.
-        Object.defineProperty(this, 'italic', {
-            value: 0, writable: true, enumerable: false, configurable: true,
-        });
     }
 
     /**

--- a/src/environments/array.ts
+++ b/src/environments/array.ts
@@ -275,7 +275,7 @@ function dCellStyle(envName: string): StyleStr {
 }
 
 type Outrow = {
-    [idx: number]: any;
+    [idx: number]: HtmlDomNode;
     height: number;
     depth: number;
     pos: number;
@@ -341,7 +341,7 @@ const htmlBuilder: HtmlBuilder<"array"> = function(group, options) {
             nc = inrow.length;
         }
 
-        const outrow: Outrow = (new Array(inrow.length) as any);
+        const outrow = new Array(inrow.length) as unknown as Outrow;
         for (c = 0; c < inrow.length; ++c) {
             const elt = html.buildGroup(inrow[c], options);
             if (depth < elt.depth) {

--- a/src/environments/array.ts
+++ b/src/environments/array.ts
@@ -274,7 +274,8 @@ function dCellStyle(envName: string): StyleStr {
     }
 }
 
-type Outrow = HtmlDomNode[] & {
+type Outrow = {
+    cells: HtmlDomNode[];
     height: number;
     depth: number;
     pos: number;
@@ -286,7 +287,7 @@ const htmlBuilder: HtmlBuilder<"array"> = function(group, options) {
     const nr = group.body.length;
     const hLinesBeforeRow = group.hLinesBeforeRow;
     let nc = 0;
-    const body = new Array(nr);
+    const body: Outrow[] = new Array(nr);
     const hlines: Array<{pos: number; isDashed: boolean}> = [];
     const ruleThickness = Math.max(
         // From LaTeX \showthe\arrayrulewidth. Equals 0.04 em.
@@ -340,10 +341,12 @@ const htmlBuilder: HtmlBuilder<"array"> = function(group, options) {
             nc = inrow.length;
         }
 
-        const outrow: Outrow = Object.assign(
-            new Array<HtmlDomNode>(inrow.length),
-            {height: 0, depth: 0, pos: 0},
-        );
+        const outrow: Outrow = {
+            cells: new Array<HtmlDomNode>(inrow.length),
+            height: 0,
+            depth: 0,
+            pos: 0,
+        };
         for (c = 0; c < inrow.length; ++c) {
             const elt = html.buildGroup(inrow[c], options);
             if (depth < elt.depth) {
@@ -352,7 +355,7 @@ const htmlBuilder: HtmlBuilder<"array"> = function(group, options) {
             if (height < elt.height) {
                 height = elt.height;
             }
-            outrow[c] = elt;
+            outrow.cells[c] = elt;
         }
 
         const rowGap = group.rowGaps[r];
@@ -482,7 +485,7 @@ const htmlBuilder: HtmlBuilder<"array"> = function(group, options) {
         }> = [];
         for (r = 0; r < nr; ++r) {
             const row = body[r];
-            const elem = row[c];
+            const elem = row.cells[c];
             if (!elem) {
                 continue;
             }

--- a/src/environments/array.ts
+++ b/src/environments/array.ts
@@ -274,8 +274,7 @@ function dCellStyle(envName: string): StyleStr {
     }
 }
 
-type Outrow = {
-    [idx: number]: HtmlDomNode;
+type Outrow = HtmlDomNode[] & {
     height: number;
     depth: number;
     pos: number;
@@ -341,7 +340,10 @@ const htmlBuilder: HtmlBuilder<"array"> = function(group, options) {
             nc = inrow.length;
         }
 
-        const outrow = new Array(inrow.length) as unknown as Outrow;
+        const outrow: Outrow = Object.assign(
+            new Array<HtmlDomNode>(inrow.length),
+            {height: 0, depth: 0, pos: 0},
+        );
         for (c = 0; c < inrow.length; ++c) {
             const elt = html.buildGroup(inrow[c], options);
             if (depth < elt.depth) {

--- a/src/functions/arrow.ts
+++ b/src/functions/arrow.ts
@@ -92,7 +92,8 @@ defineFunction({
                 positionType: "individualShift",
                 children: [
                     {type: "elem", elem: upperGroup, shift: upperShift},
-                    {type: "elem", elem: arrowBody,  shift: arrowShift},
+                    {type: "elem", elem: arrowBody,  shift: arrowShift,
+                        wrapperClasses: ["svg-align"]},
                     {type: "elem", elem: lowerGroup, shift: lowerShift},
                 ],
             }, options);
@@ -101,13 +102,11 @@ defineFunction({
                 positionType: "individualShift",
                 children: [
                     {type: "elem", elem: upperGroup, shift: upperShift},
-                    {type: "elem", elem: arrowBody,  shift: arrowShift},
+                    {type: "elem", elem: arrowBody,  shift: arrowShift,
+                        wrapperClasses: ["svg-align"]},
                 ],
             }, options);
         }
-
-        // TODO(ts): Replace this with passing "svg-align" into makeVList.
-        (vlist as any).children[0].children[0].children[1].classes.push("svg-align");
 
         return makeSpan(["mrel", "x-arrow"], [vlist], options);
     },

--- a/src/functions/delimsizing.ts
+++ b/src/functions/delimsizing.ts
@@ -12,6 +12,7 @@ import * as mml from "../buildMathML";
 import type Options from "../Options";
 import type {AnyParseNode, ParseNode, SymbolParseNode} from "../parseNode";
 import type {FunctionContext} from "../defineFunction";
+import type {HtmlDomNode} from "../domTree";
 
 // Extra data needed for the delimiter handler down below
 const delimiterSizes: Record<string, {
@@ -55,6 +56,16 @@ const delimiters = new Set([
 ]);
 
 type IsMiddle = {delim: string, options: Options};
+
+/**
+ * An HtmlDomNode that may carry an `isMiddle` property, used by the
+ * \middle command to communicate delimiter info to the \left/\right builder.
+ */
+type MiddleDelimNode = HtmlDomNode & {isMiddle?: IsMiddle};
+
+function isMiddleDelimNode(node: HtmlDomNode): node is MiddleDelimNode {
+    return 'isMiddle' in node;
+}
 
 // Delimiter functions
 function checkDelimiter(
@@ -209,10 +220,8 @@ defineFunction({
 
         // Calculate its height and depth
         for (let i = 0; i < inner.length; i++) {
-            // Property `isMiddle` not defined on `span`. See comment in
-            // "middle"'s htmlBuilder.
-            // TODO(ts)
-            if ((inner[i] as any).isMiddle) {
+            const node = inner[i];
+            if (isMiddleDelimNode(node) && node.isMiddle) {
                 hadMiddle = true;
             } else {
                 innerHeight = Math.max(inner[i].height, innerHeight);
@@ -244,11 +253,8 @@ defineFunction({
         if (hadMiddle) {
             for (let i = 1; i < inner.length; i++) {
                 const middleDelim = inner[i];
-                // Property `isMiddle` not defined on `span`. See comment in
-                // "middle"'s htmlBuilder.
-                // TODO(ts)
-                const isMiddle: IsMiddle = (middleDelim as any).isMiddle;
-                if (isMiddle) {
+                if (isMiddleDelimNode(middleDelim) && middleDelim.isMiddle) {
+                    const isMiddle = middleDelim.isMiddle;
                     // Apply the options that were active when \middle was called
                     inner[i] = makeLeftRightDelim(
                         isMiddle.delim, innerHeight, innerDepth,
@@ -331,13 +337,13 @@ defineFunction({
                 group.delim, 1, options,
                 group.mode, []);
 
-            const isMiddle: IsMiddle = {delim: group.delim, options};
-            // Property `isMiddle` not defined on `span`. It is only used in
-            // this file above.
-            // TODO: Fix this violation of the `span` type and possibly rename
-            // things since `isMiddle` sounds like a boolean, but is a struct.
-            // TODO(ts)
-            (middleDelim as any).isMiddle = isMiddle;
+            // Patch an ad-hoc property onto the node so the \left/\right
+            // builder can reconstruct appropriately sized middle delimiters.
+            // Cast required: isMiddle is not part of HtmlDomNode; read
+            // side uses isMiddleDelimNode() to check before accessing.
+            (middleDelim as MiddleDelimNode).isMiddle = {
+                delim: group.delim, options,
+            };
         }
         return middleDelim;
     },

--- a/src/functions/delimsizing.ts
+++ b/src/functions/delimsizing.ts
@@ -58,10 +58,10 @@ const delimiters = new Set([
 type IsMiddle = {delim: string, options: Options};
 
 /**
- * An HtmlDomNode that may carry an `isMiddle` property, used by the
+ * An HtmlDomNode that carries an `isMiddle` property, used by the
  * \middle command to communicate delimiter info to the \left/\right builder.
  */
-type MiddleDelimNode = HtmlDomNode & {isMiddle?: IsMiddle};
+type MiddleDelimNode = HtmlDomNode & {isMiddle: IsMiddle};
 
 function isMiddleDelimNode(node: HtmlDomNode): node is MiddleDelimNode {
     return 'isMiddle' in node;
@@ -221,7 +221,7 @@ defineFunction({
         // Calculate its height and depth
         for (let i = 0; i < inner.length; i++) {
             const node = inner[i];
-            if (isMiddleDelimNode(node) && node.isMiddle) {
+            if (isMiddleDelimNode(node)) {
                 hadMiddle = true;
             } else {
                 innerHeight = Math.max(inner[i].height, innerHeight);
@@ -253,7 +253,7 @@ defineFunction({
         if (hadMiddle) {
             for (let i = 1; i < inner.length; i++) {
                 const middleDelim = inner[i];
-                if (isMiddleDelimNode(middleDelim) && middleDelim.isMiddle) {
+                if (isMiddleDelimNode(middleDelim)) {
                     const isMiddle = middleDelim.isMiddle;
                     // Apply the options that were active when \middle was called
                     inner[i] = makeLeftRightDelim(
@@ -339,9 +339,9 @@ defineFunction({
 
             // Patch an ad-hoc property onto the node so the \left/\right
             // builder can reconstruct appropriately sized middle delimiters.
-            // Cast required: isMiddle is not part of HtmlDomNode; read
-            // side uses isMiddleDelimNode() to check before accessing.
-            (middleDelim as MiddleDelimNode).isMiddle = {
+            // isMiddle is not part of HtmlDomNode; the read side uses
+            // isMiddleDelimNode() to check before accessing.
+            (middleDelim as unknown as MiddleDelimNode).isMiddle = {
                 delim: group.delim, options,
             };
         }

--- a/src/functions/environment.ts
+++ b/src/functions/environment.ts
@@ -3,6 +3,8 @@ import ParseError from "../ParseError";
 import {assertNodeType} from "../parseNode";
 import environments from "../environments";
 
+import type {ParseNode} from "../parseNode";
+
 // Environment delimiters. HTML/MathML rendering is defined in the corresponding
 // defineEnvironment definitions.
 defineFunction({
@@ -47,8 +49,11 @@ defineFunction({
                     `Mismatch: \\begin{${envName}} matched by \\end{${end.name}}`,
                     endNameToken);
             }
-            // TODO(ts), "environment" handler returns an environment ParseNode
-            return result as any;
+            // env.handler returns the specific node type (e.g. "array"),
+            // not "environment". This cast is unavoidable: defineFunction
+            // requires the handler to return ParseNode<"environment"> but
+            // \begin delegates to environment handlers with different types.
+            return result as unknown as ParseNode<"environment">;
         }
 
         return {

--- a/src/functions/horizBrace.ts
+++ b/src/functions/horizBrace.ts
@@ -47,23 +47,21 @@ export const htmlBuilder: HtmlBuilderSupSub<"horizBrace"> = (grp, options) => {
             children: [
                 {type: "elem", elem: body},
                 {type: "kern", size: 0.1},
-                {type: "elem", elem: braceBody},
+                {type: "elem", elem: braceBody,
+                    wrapperClasses: ["svg-align"]},
             ],
         }, options);
-        // TODO(ts): Replace this with passing "svg-align" into makeVList.
-        (vlist as any).children[0].children[0].children[1].classes.push("svg-align");
     } else {
         vlist = makeVList({
             positionType: "bottom",
             positionData: body.depth + 0.1 + braceBody.height,
             children: [
-                {type: "elem", elem: braceBody},
+                {type: "elem", elem: braceBody,
+                    wrapperClasses: ["svg-align"]},
                 {type: "kern", size: 0.1},
                 {type: "elem", elem: body},
             ],
         }, options);
-        // TODO(ts): Replace this with passing "svg-align" into makeVList.
-        (vlist as any).children[0].children[0].children[0].classes.push("svg-align");
     }
 
     if (supSubGroup) {

--- a/src/functions/op.ts
+++ b/src/functions/op.ts
@@ -51,6 +51,9 @@ export const htmlBuilder: HtmlBuilderSupSub<"op"> = (grp, options) => {
     }
 
     let base;
+    // Italic correction from the symbol glyph, captured before the symbol
+    // may be wrapped in a vlist (for \oiint/\oiiint).  Stays 0 for non-symbol ops.
+    let symbolItalic = 0;
     if (group.symbol) {
         // If this is a symbol, create the symbol.
         const fontName = large ? "Size2-Regular" : "Size1-Regular";
@@ -66,11 +69,11 @@ export const htmlBuilder: HtmlBuilderSupSub<"op"> = (grp, options) => {
         base = makeSymbol(
             group.name, fontName, "math", options,
             ["mop", "op-symbol", large ? "large-op" : "small-op"]);
+        symbolItalic = base.italic;
 
         if (stash.length > 0) {
             // We're in \oiint or \oiiint. Overlay the oval.
             // TODO: When font glyphs are available, delete this code.
-            const italic = base.italic;
             const oval = staticSvg(stash + "Size"
                 + (large ? "2" : "1"), options);
             base = makeVList({
@@ -82,8 +85,9 @@ export const htmlBuilder: HtmlBuilderSupSub<"op"> = (grp, options) => {
             }, options);
             group.name = "\\" + stash;
             base.classes.unshift("mop");
-            // TODO(ts)
-            (base as any).italic = italic;
+            // Carry the italic correction from the original symbol to the
+            // vlist wrapper so supsub can use it for subscript positioning.
+            base.italic = symbolItalic;
         }
     } else if (group.body) {
         // If this is a list, compose that list.
@@ -120,8 +124,8 @@ export const htmlBuilder: HtmlBuilderSupSub<"op"> = (grp, options) => {
             options.fontMetrics().axisHeight;
 
         // The slant of the symbol is just its italic correction.
-        // TODO(ts)
-        slant = (base as SymbolNode & {italic?: number}).italic || 0;
+        // Both SymbolNode and Span (for \oiint/\oiiint) carry .italic.
+        slant = base.italic;
     }
 
     if (hasLimits) {

--- a/src/functions/op.ts
+++ b/src/functions/op.ts
@@ -124,8 +124,9 @@ export const htmlBuilder: HtmlBuilderSupSub<"op"> = (grp, options) => {
             options.fontMetrics().axisHeight;
 
         // The slant of the symbol is just its italic correction.
-        // Both SymbolNode and Span (for \oiint/\oiiint) carry .italic.
-        slant = base.italic;
+        // SymbolNode carries .italic natively; Span (for \oiint/\oiiint)
+        // only has it set when nonzero, so default to 0.
+        slant = base.italic ?? 0;
     }
 
     if (hasLimits) {

--- a/src/functions/styling.ts
+++ b/src/functions/styling.ts
@@ -6,12 +6,16 @@ import {sizingGroup} from "./sizing";
 import * as mml from "../buildMathML";
 import type {StyleStr} from "../types";
 
-const styleMap = {
+const styleMap: Record<StyleStr, typeof Style.DISPLAY> = {
     "display": Style.DISPLAY,
     "text": Style.TEXT,
     "script": Style.SCRIPT,
     "scriptscript": Style.SCRIPTSCRIPT,
 };
+
+function isStyleStr(s: string): s is StyleStr {
+    return s in styleMap;
+}
 
 defineFunction({
     type: "styling",
@@ -30,8 +34,10 @@ defineFunction({
 
         // TODO: Refactor to avoid duplicating styleMap in multiple places (e.g.
         // here and in buildHTML and de-dupe the enumeration of all the styles).
-        // TODO(ts): The names above exactly match the styles.
-        const style = funcName.slice(1, funcName.length - 5) as StyleStr;
+        const style = funcName.slice(1, funcName.length - 5);
+        if (!isStyleStr(style)) {
+            throw new Error(`Unknown style: ${style}`);
+        }
         return {
             type: "styling",
             mode: parser.mode,

--- a/src/functions/supsub.ts
+++ b/src/functions/supsub.ts
@@ -1,6 +1,8 @@
 import {defineFunctionBuilders} from "../defineFunction";
 import {makeSpan, makeVList} from "../buildCommon";
-import {SymbolNode} from "../domTree";
+import {Span, SymbolNode} from "../domTree";
+
+import type {HtmlDomNode} from "../domTree";
 import {isCharacterBox} from "../utils";
 import {MathNode} from "../mathMLTree";
 import {makeEm} from "../units";
@@ -28,6 +30,7 @@ import type {MathNodeType} from "../mathMLTree";
 const htmlBuilderDelegate = function(
     group: ParseNode<"supsub">,
     options: Options,
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): HtmlBuilder<any> | null | undefined {
     const base = group.base;
     if (!base) {
@@ -122,8 +125,9 @@ defineFunctionBuilders({
                 group.base && group.base.type === "op" && group.base.name &&
                 (group.base.name === "\\oiint" || group.base.name === "\\oiiint");
             if (base instanceof SymbolNode || isOiint) {
-                // @ts-ignore
-                marginLeft = makeEm(-base.italic);
+                // SymbolNode has .italic natively; for \oiint/\oiiint the
+                // op builder stores .italic on the wrapping Span.
+                marginLeft = makeEm(-(base as SymbolNode | Span<HtmlDomNode>).italic);
             }
         }
 

--- a/src/functions/supsub.ts
+++ b/src/functions/supsub.ts
@@ -1,8 +1,6 @@
 import {defineFunctionBuilders} from "../defineFunction";
 import {makeSpan, makeVList} from "../buildCommon";
-import {Span, SymbolNode} from "../domTree";
-
-import type {HtmlDomNode} from "../domTree";
+import {Span, SymbolNode, type HtmlDomNode} from "../domTree";
 import {isCharacterBox} from "../utils";
 import {MathNode} from "../mathMLTree";
 import {makeEm} from "../units";

--- a/src/functions/supsub.ts
+++ b/src/functions/supsub.ts
@@ -127,7 +127,8 @@ defineFunctionBuilders({
             if (base instanceof SymbolNode || isOiint) {
                 // SymbolNode has .italic natively; for \oiint/\oiiint the
                 // op builder stores .italic on the wrapping Span.
-                marginLeft = makeEm(-(base as SymbolNode | Span<HtmlDomNode>).italic);
+                marginLeft = makeEm(
+                    -((base as SymbolNode | Span<HtmlDomNode>).italic ?? 0));
             }
         }
 

--- a/src/parseNode.ts
+++ b/src/parseNode.ts
@@ -1,7 +1,7 @@
-import {NON_ATOMS} from "./symbols";
+import {NON_ATOMS} from "./atoms";
 import type SourceLocation from "./SourceLocation";
 import type {AlignSpec, ColSeparationType} from "./environments/array";
-import type {Atom} from "./symbols";
+import type {Atom} from "./atoms";
 import type {Mode, StyleStr} from "./types";
 import type {Token} from "./Token";
 import type {Measurement} from "./units";

--- a/src/stretchy.ts
+++ b/src/stretchy.ts
@@ -115,9 +115,15 @@ export const stretchyMathML = function(label: string): MathNode {
 // That is, inside the font, that arrowhead is 522 units tall, which
 // corresponds to 0.522 em inside the document.
 
-const katexImagesData: {
-    [key: string]: ([string[], number, number] | [[string], number, number, string])
-} = {
+type SvgData3 = [string[], number, number];
+type SvgData4 = [[string], number, number, string];
+type SvgData = SvgData3 | SvgData4;
+
+function isSvgData4(data: SvgData): data is SvgData4 {
+    return data.length === 4;
+}
+
+const katexImagesData: {[key: string]: SvgData} = {
                    //   path(s), minWidth, height, align
     overrightarrow: [["rightarrow"], 0.888, 522, "xMaxYMin"],
     overleftarrow: [["leftarrow"], 0.888, 522, "xMinYMin"],
@@ -189,10 +195,7 @@ export const stretchySvg = function(
     } {
         let viewBoxWidth = 400000;  // default
         const label = group.label.slice(1);
-        if (wideAccentLabels.has(label)) {
-            // Each type in the `if` statement corresponds to one of the ParseNode
-            // types below. This narrowing is required to access `grp.base`.
-            // TODO(ts)
+        if (wideAccentLabels.has(label) && 'base' in group) {
             const grp = group as ParseNode<"accent"> | ParseNode<"accentUnder">;
             // There are four SVG images available for each function.
             // Choose a taller image when there are more characters.
@@ -244,6 +247,9 @@ export const stretchySvg = function(
             const spans = [];
 
             const data = katexImagesData[label];
+            if (!data) {
+                throw new Error(`No SVG data for "${label}".`);
+            }
             const [paths, minWidth, viewBoxHeight] = data;
             const height = viewBoxHeight / 1000;
 
@@ -251,9 +257,11 @@ export const stretchySvg = function(
             let widthClasses;
             let aligns;
             if (numSvgChildren === 1) {
-                // TODO(ts): All these cases must be of the 4-tuple type.
-                const align1: string =
-                    (data as [[string], number, number, string])[3];
+                if (!isSvgData4(data)) {
+                    throw new Error(
+                        `Expected 4-tuple for single-path SVG data "${label}".`);
+                }
+                const align1: string = data[3];
                 widthClasses = ["hide-tail"];
                 aligns = [align1];
             } else if (numSvgChildren === 2) {

--- a/src/stretchy.ts
+++ b/src/stretchy.ts
@@ -115,9 +115,15 @@ export const stretchyMathML = function(label: string): MathNode {
 // That is, inside the font, that arrowhead is 522 units tall, which
 // corresponds to 0.522 em inside the document.
 
-const katexImagesData: {
-    [key: string]: ([string[], number, number] | [[string], number, number, string])
-} = {
+type SvgData3 = [string[], number, number];
+type SvgData4 = [[string], number, number, string];
+type SvgData = SvgData3 | SvgData4;
+
+function isSvgData4(data: SvgData): data is SvgData4 {
+    return data.length === 4;
+}
+
+const katexImagesData: {[key: string]: SvgData} = {
                    //   path(s), minWidth, height, align
     overrightarrow: [["rightarrow"], 0.888, 522, "xMaxYMin"],
     overleftarrow: [["leftarrow"], 0.888, 522, "xMinYMin"],
@@ -189,15 +195,11 @@ export const stretchySvg = function(
     } {
         let viewBoxWidth = 400000;  // default
         const label = group.label.slice(1);
-        if (wideAccentLabels.has(label)) {
-            // Each type in the `if` statement corresponds to one of the ParseNode
-            // types below. This narrowing is required to access `grp.base`.
-            // TODO(ts)
-            const grp = group as ParseNode<"accent"> | ParseNode<"accentUnder">;
+        if (wideAccentLabels.has(label) && 'base' in group) {
             // There are four SVG images available for each function.
             // Choose a taller image when there are more characters.
-            const numChars = grp.base.type === "ordgroup" ?
-                grp.base.body.length : 1;
+            const numChars = group.base.type === "ordgroup" ?
+                group.base.body.length : 1;
             let viewBoxHeight;
             let pathName;
             let height;
@@ -244,6 +246,9 @@ export const stretchySvg = function(
             const spans = [];
 
             const data = katexImagesData[label];
+            if (!data) {
+                throw new Error(`No SVG data for "${label}".`);
+            }
             const [paths, minWidth, viewBoxHeight] = data;
             const height = viewBoxHeight / 1000;
 
@@ -251,9 +256,11 @@ export const stretchySvg = function(
             let widthClasses;
             let aligns;
             if (numSvgChildren === 1) {
-                // TODO(ts): All these cases must be of the 4-tuple type.
-                const align1: string =
-                    (data as [[string], number, number, string])[3];
+                if (!isSvgData4(data)) {
+                    throw new Error(
+                        `Expected 4-tuple for single-path SVG data "${label}".`);
+                }
+                const align1: string = data[3];
                 widthClasses = ["hide-tail"];
                 aligns = [align1];
             } else if (numSvgChildren === 2) {

--- a/src/stretchy.ts
+++ b/src/stretchy.ts
@@ -107,10 +107,6 @@ type SvgData3 = [string[], number, number];
 type SvgData4 = [[string], number, number, string];
 type SvgData = SvgData3 | SvgData4;
 
-function isSvgData4(data: SvgData): data is SvgData4 {
-    return data.length === 4;
-}
-
 const katexImagesData: {[key: string]: SvgData} = {
                    //   path(s), minWidth, height, align
     overrightarrow: [["rightarrow"], 0.888, 522, "xMaxYMin"],
@@ -244,13 +240,12 @@ export const stretchySvg = function(
             let widthClasses;
             let aligns;
             if (numSvgChildren === 1) {
-                if (!isSvgData4(data)) {
+                if (data.length !== 4) {
                     throw new Error(
                         `Expected 4-tuple for single-path SVG data "${label}".`);
                 }
-                const align1: string = data[3];
                 widthClasses = ["hide-tail"];
-                aligns = [align1];
+                aligns = [data[3]];
             } else if (numSvgChildren === 2) {
                 widthClasses = ["halfarrow-left", "halfarrow-right"];
                 aligns = ["xMinYMin", "xMaxYMin"];

--- a/src/stretchy.ts
+++ b/src/stretchy.ts
@@ -103,9 +103,7 @@ export const stretchyMathML = function(label: string): MathNode {
 // That is, inside the font, that arrowhead is 522 units tall, which
 // corresponds to 0.522 em inside the document.
 
-type SvgData3 = [string[], number, number];
-type SvgData4 = [[string], number, number, string];
-type SvgData = SvgData3 | SvgData4;
+type SvgData = [string[], number, number, string?];
 
 const katexImagesData: {[key: string]: SvgData} = {
                    //   path(s), minWidth, height, align

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -43,6 +43,10 @@ export type Atom = keyof typeof ATOMS;
 export type NonAtom = keyof typeof NON_ATOMS;
 export type Group = Atom | NonAtom;
 
+export function isAtom(value: string): value is Atom {
+    return value in ATOMS;
+}
+
 type CharInfoMap = Record<string, {font: Font, group: Group, replace: string | null | undefined}>;
 
 const symbols: Record<Mode, CharInfoMap> = {

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -16,12 +16,8 @@
  * accepted in (e.g. "math" or "text").
  */
 
-import {ATOMS, NON_ATOMS, isAtom} from "./atoms";
-import type {Atom, Group, NonAtom} from "./atoms";
+import type {Group} from "./atoms";
 import type {Mode} from "./types";
-
-export {ATOMS, NON_ATOMS, isAtom};
-export type {Atom, Group, NonAtom};
 
 type Font = "main" | "ams";
 

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -16,36 +16,14 @@
  * accepted in (e.g. "math" or "text").
  */
 
+import {ATOMS, NON_ATOMS, isAtom} from "./atoms";
+import type {Atom, Group, NonAtom} from "./atoms";
 import type {Mode} from "./types";
 
+export {ATOMS, NON_ATOMS, isAtom};
+export type {Atom, Group, NonAtom};
+
 type Font = "main" | "ams";
-// Some of these have a "-token" suffix since these are also used as `ParseNode`
-// types for raw text tokens, and we want to avoid conflicts with higher-level
-// `ParseNode` types. These `ParseNode`s are constructed within `Parser` by
-// looking up the `symbols` map.
-export const ATOMS = {
-    "bin": 1,
-    "close": 1,
-    "inner": 1,
-    "open": 1,
-    "punct": 1,
-    "rel": 1,
-};
-export const NON_ATOMS = {
-    "accent-token": 1,
-    "mathord": 1,
-    "op-token": 1,
-    "spacing": 1,
-    "textord": 1,
-};
-
-export type Atom = keyof typeof ATOMS;
-export type NonAtom = keyof typeof NON_ATOMS;
-export type Group = Atom | NonAtom;
-
-export function isAtom(value: string): value is Atom {
-    return value in ATOMS;
-}
 
 type CharInfoMap = Record<string, {font: Font, group: Group, replace: string | null | undefined}>;
 

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -64,10 +64,12 @@ export class DocumentFragment<ChildType extends VirtualNode>
      * MathDomNode's only.
      */
     toText(): string {
-        // To avoid this, we would subclass documentFragment separately for
-        // MathML, but polyfills for subclassing is expensive per PR 1469.
-        // TODO(ts): Only works for ChildType = MathDomNode.
-        const toText = (child: ChildType): string => (child as unknown as MathDomNode).toText();
-        return this.children.map(toText).join("");
+        return this.children.map((child: ChildType): string => {
+            if ('toText' in child) {
+                return (child as unknown as MathDomNode).toText();
+            }
+            throw new Error(
+                `Expected MathDomNode with toText, got ${child.constructor.name}`);
+        }).join("");
     }
 }

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -8,6 +8,10 @@ export interface VirtualNode {
     toMarkup(): string;
 }
 
+function isMathDomNode(node: VirtualNode): node is MathDomNode {
+    return 'toText' in node;
+}
+
 
 /**
  * This node represents a document fragment, which contains elements, but when
@@ -64,10 +68,12 @@ export class DocumentFragment<ChildType extends VirtualNode>
      * MathDomNode's only.
      */
     toText(): string {
-        // To avoid this, we would subclass documentFragment separately for
-        // MathML, but polyfills for subclassing is expensive per PR 1469.
-        // TODO(ts): Only works for ChildType = MathDomNode.
-        const toText = (child: ChildType): string => (child as unknown as MathDomNode).toText();
-        return this.children.map(toText).join("");
+        return this.children.map((child: ChildType): string => {
+            if (isMathDomNode(child)) {
+                return child.toText();
+            }
+            throw new Error(
+                `Expected MathDomNode with toText, got ${child.constructor.name}`);
+        }).join("");
     }
 }

--- a/test/__snapshots__/katex-spec.ts.snap
+++ b/test/__snapshots__/katex-spec.ts.snap
@@ -173,6 +173,7 @@ exports[`A font parser \\boldsymbol should inherit mbin/mrel from argument 1`] =
         ],
         "depth": 0,
         "height": 0,
+        "italic": 0,
         "maxFontSize": 0,
         "style": {
         }
@@ -183,6 +184,7 @@ exports[`A font parser \\boldsymbol should inherit mbin/mrel from argument 1`] =
     ],
     "depth": 0,
     "height": 0,
+    "italic": 0,
     "maxFontSize": 0,
     "style": {
     }
@@ -212,6 +214,7 @@ exports[`A font parser \\boldsymbol should inherit mbin/mrel from argument 1`] =
     ],
     "depth": 0,
     "height": 0,
+    "italic": 0,
     "maxFontSize": 0,
     "style": {
       "marginRight": "0.2778em"
@@ -246,6 +249,7 @@ exports[`A font parser \\boldsymbol should inherit mbin/mrel from argument 1`] =
         ],
         "depth": 0,
         "height": 0.39111,
+        "italic": 0,
         "maxFontSize": 1,
         "style": {
         }
@@ -256,6 +260,7 @@ exports[`A font parser \\boldsymbol should inherit mbin/mrel from argument 1`] =
     ],
     "depth": 0,
     "height": 0.39111,
+    "italic": 0,
     "maxFontSize": 1,
     "style": {
     }
@@ -270,6 +275,7 @@ exports[`A font parser \\boldsymbol should inherit mbin/mrel from argument 1`] =
     ],
     "depth": 0,
     "height": 0,
+    "italic": 0,
     "maxFontSize": 0,
     "style": {
       "marginRight": "0.2778em"
@@ -300,6 +306,7 @@ exports[`A font parser \\boldsymbol should inherit mbin/mrel from argument 1`] =
     ],
     "depth": 0,
     "height": 0,
+    "italic": 0,
     "maxFontSize": 0,
     "style": {
       "marginRight": "0.2222em"
@@ -334,6 +341,7 @@ exports[`A font parser \\boldsymbol should inherit mbin/mrel from argument 1`] =
         ],
         "depth": 0.13333,
         "height": 0.63333,
+        "italic": 0,
         "maxFontSize": 1,
         "style": {
         }
@@ -344,6 +352,7 @@ exports[`A font parser \\boldsymbol should inherit mbin/mrel from argument 1`] =
     ],
     "depth": 0.13333,
     "height": 0.63333,
+    "italic": 0,
     "maxFontSize": 1,
     "style": {
     }
@@ -358,6 +367,7 @@ exports[`A font parser \\boldsymbol should inherit mbin/mrel from argument 1`] =
     ],
     "depth": 0,
     "height": 0,
+    "italic": 0,
     "maxFontSize": 0,
     "style": {
       "marginRight": "0.2222em"
@@ -388,6 +398,7 @@ exports[`A font parser \\boldsymbol should inherit mbin/mrel from argument 1`] =
     ],
     "depth": 0,
     "height": 0,
+    "italic": 0,
     "maxFontSize": 0,
     "style": {
       "marginRight": "0.2222em"
@@ -422,6 +433,7 @@ exports[`A font parser \\boldsymbol should inherit mbin/mrel from argument 1`] =
         ],
         "depth": 0.13333,
         "height": 0.63333,
+        "italic": 0,
         "maxFontSize": 1,
         "style": {
         }
@@ -432,6 +444,7 @@ exports[`A font parser \\boldsymbol should inherit mbin/mrel from argument 1`] =
     ],
     "depth": 0.13333,
     "height": 0.63333,
+    "italic": 0,
     "maxFontSize": 1,
     "style": {
     }
@@ -446,6 +459,7 @@ exports[`A font parser \\boldsymbol should inherit mbin/mrel from argument 1`] =
     ],
     "depth": 0,
     "height": 0,
+    "italic": 0,
     "maxFontSize": 0,
     "style": {
       "marginRight": "0.2222em"
@@ -495,6 +509,7 @@ exports[`A font parser \\boldsymbol should inherit mbin/mrel from argument 1`] =
         ],
         "depth": 0.19444,
         "height": 0.44444,
+        "italic": 0,
         "maxFontSize": 1,
         "style": {
         }
@@ -505,6 +520,7 @@ exports[`A font parser \\boldsymbol should inherit mbin/mrel from argument 1`] =
     ],
     "depth": 0.19444,
     "height": 0.44444,
+    "italic": 0,
     "maxFontSize": 1,
     "style": {
     }
@@ -608,6 +624,7 @@ exports[`A parser that does not throw on unsupported commands should build katex
   ],
   "depth": 0,
   "height": 0,
+  "italic": 0,
   "maxFontSize": 0,
   "style": {
   }
@@ -655,6 +672,7 @@ exports[`An HTML extension builder should not affect spacing 1`] = `
         ],
         "depth": 0,
         "height": 0,
+        "italic": 0,
         "maxFontSize": 0,
         "style": {
           "marginRight": "0.2222em"
@@ -684,6 +702,7 @@ exports[`An HTML extension builder should not affect spacing 1`] = `
         ],
         "depth": 0,
         "height": 0,
+        "italic": 0,
         "maxFontSize": 0,
         "style": {
           "marginRight": "0.2222em"
@@ -695,6 +714,7 @@ exports[`An HTML extension builder should not affect spacing 1`] = `
     ],
     "depth": 0.08333,
     "height": 0.58333,
+    "italic": 0,
     "maxFontSize": 1,
     "style": {
     }
@@ -745,6 +765,7 @@ exports[`An HTML extension builder should render with trust and strict setting 1
     ],
     "depth": 0,
     "height": 0.43056,
+    "italic": 0,
     "maxFontSize": 1,
     "style": {
     }
@@ -775,6 +796,7 @@ exports[`An HTML extension builder should render with trust and strict setting 1
     ],
     "depth": 0,
     "height": 0.43056,
+    "italic": 0,
     "maxFontSize": 1,
     "style": {
     }
@@ -805,6 +827,7 @@ exports[`An HTML extension builder should render with trust and strict setting 1
     ],
     "depth": 0,
     "height": 0.43056,
+    "italic": 0,
     "maxFontSize": 1,
     "style": {
     }
@@ -836,6 +859,7 @@ exports[`An HTML extension builder should render with trust and strict setting 1
     ],
     "depth": 0,
     "height": 0.43056,
+    "italic": 0,
     "maxFontSize": 1,
     "style": {
     }
@@ -1029,6 +1053,7 @@ exports[`An includegraphics builder should not render without trust setting 1`] 
     ],
     "depth": 0.25,
     "height": 0.75,
+    "italic": 0,
     "maxFontSize": 1,
     "style": {
       "color": "#cc0000"
@@ -1403,6 +1428,7 @@ exports[`href and url commands should not affect spacing around 1`] = `
     ],
     "depth": 0,
     "height": 0,
+    "italic": 0,
     "maxFontSize": 0,
     "style": {
       "marginRight": "0.2222em"
@@ -1437,6 +1463,7 @@ exports[`href and url commands should not affect spacing around 1`] = `
         ],
         "depth": 0,
         "height": 0,
+        "italic": 0,
         "maxFontSize": 0,
         "style": {
           "marginRight": "0.2222em"

--- a/test/__snapshots__/katex-spec.ts.snap
+++ b/test/__snapshots__/katex-spec.ts.snap
@@ -173,7 +173,6 @@ exports[`A font parser \\boldsymbol should inherit mbin/mrel from argument 1`] =
         ],
         "depth": 0,
         "height": 0,
-        "italic": 0,
         "maxFontSize": 0,
         "style": {
         }
@@ -184,7 +183,6 @@ exports[`A font parser \\boldsymbol should inherit mbin/mrel from argument 1`] =
     ],
     "depth": 0,
     "height": 0,
-    "italic": 0,
     "maxFontSize": 0,
     "style": {
     }
@@ -214,7 +212,6 @@ exports[`A font parser \\boldsymbol should inherit mbin/mrel from argument 1`] =
     ],
     "depth": 0,
     "height": 0,
-    "italic": 0,
     "maxFontSize": 0,
     "style": {
       "marginRight": "0.2778em"
@@ -249,7 +246,6 @@ exports[`A font parser \\boldsymbol should inherit mbin/mrel from argument 1`] =
         ],
         "depth": 0,
         "height": 0.39111,
-        "italic": 0,
         "maxFontSize": 1,
         "style": {
         }
@@ -260,7 +256,6 @@ exports[`A font parser \\boldsymbol should inherit mbin/mrel from argument 1`] =
     ],
     "depth": 0,
     "height": 0.39111,
-    "italic": 0,
     "maxFontSize": 1,
     "style": {
     }
@@ -275,7 +270,6 @@ exports[`A font parser \\boldsymbol should inherit mbin/mrel from argument 1`] =
     ],
     "depth": 0,
     "height": 0,
-    "italic": 0,
     "maxFontSize": 0,
     "style": {
       "marginRight": "0.2778em"
@@ -306,7 +300,6 @@ exports[`A font parser \\boldsymbol should inherit mbin/mrel from argument 1`] =
     ],
     "depth": 0,
     "height": 0,
-    "italic": 0,
     "maxFontSize": 0,
     "style": {
       "marginRight": "0.2222em"
@@ -341,7 +334,6 @@ exports[`A font parser \\boldsymbol should inherit mbin/mrel from argument 1`] =
         ],
         "depth": 0.13333,
         "height": 0.63333,
-        "italic": 0,
         "maxFontSize": 1,
         "style": {
         }
@@ -352,7 +344,6 @@ exports[`A font parser \\boldsymbol should inherit mbin/mrel from argument 1`] =
     ],
     "depth": 0.13333,
     "height": 0.63333,
-    "italic": 0,
     "maxFontSize": 1,
     "style": {
     }
@@ -367,7 +358,6 @@ exports[`A font parser \\boldsymbol should inherit mbin/mrel from argument 1`] =
     ],
     "depth": 0,
     "height": 0,
-    "italic": 0,
     "maxFontSize": 0,
     "style": {
       "marginRight": "0.2222em"
@@ -398,7 +388,6 @@ exports[`A font parser \\boldsymbol should inherit mbin/mrel from argument 1`] =
     ],
     "depth": 0,
     "height": 0,
-    "italic": 0,
     "maxFontSize": 0,
     "style": {
       "marginRight": "0.2222em"
@@ -433,7 +422,6 @@ exports[`A font parser \\boldsymbol should inherit mbin/mrel from argument 1`] =
         ],
         "depth": 0.13333,
         "height": 0.63333,
-        "italic": 0,
         "maxFontSize": 1,
         "style": {
         }
@@ -444,7 +432,6 @@ exports[`A font parser \\boldsymbol should inherit mbin/mrel from argument 1`] =
     ],
     "depth": 0.13333,
     "height": 0.63333,
-    "italic": 0,
     "maxFontSize": 1,
     "style": {
     }
@@ -459,7 +446,6 @@ exports[`A font parser \\boldsymbol should inherit mbin/mrel from argument 1`] =
     ],
     "depth": 0,
     "height": 0,
-    "italic": 0,
     "maxFontSize": 0,
     "style": {
       "marginRight": "0.2222em"
@@ -509,7 +495,6 @@ exports[`A font parser \\boldsymbol should inherit mbin/mrel from argument 1`] =
         ],
         "depth": 0.19444,
         "height": 0.44444,
-        "italic": 0,
         "maxFontSize": 1,
         "style": {
         }
@@ -520,7 +505,6 @@ exports[`A font parser \\boldsymbol should inherit mbin/mrel from argument 1`] =
     ],
     "depth": 0.19444,
     "height": 0.44444,
-    "italic": 0,
     "maxFontSize": 1,
     "style": {
     }
@@ -624,7 +608,6 @@ exports[`A parser that does not throw on unsupported commands should build katex
   ],
   "depth": 0,
   "height": 0,
-  "italic": 0,
   "maxFontSize": 0,
   "style": {
   }
@@ -672,7 +655,6 @@ exports[`An HTML extension builder should not affect spacing 1`] = `
         ],
         "depth": 0,
         "height": 0,
-        "italic": 0,
         "maxFontSize": 0,
         "style": {
           "marginRight": "0.2222em"
@@ -702,7 +684,6 @@ exports[`An HTML extension builder should not affect spacing 1`] = `
         ],
         "depth": 0,
         "height": 0,
-        "italic": 0,
         "maxFontSize": 0,
         "style": {
           "marginRight": "0.2222em"
@@ -714,7 +695,6 @@ exports[`An HTML extension builder should not affect spacing 1`] = `
     ],
     "depth": 0.08333,
     "height": 0.58333,
-    "italic": 0,
     "maxFontSize": 1,
     "style": {
     }
@@ -765,7 +745,6 @@ exports[`An HTML extension builder should render with trust and strict setting 1
     ],
     "depth": 0,
     "height": 0.43056,
-    "italic": 0,
     "maxFontSize": 1,
     "style": {
     }
@@ -796,7 +775,6 @@ exports[`An HTML extension builder should render with trust and strict setting 1
     ],
     "depth": 0,
     "height": 0.43056,
-    "italic": 0,
     "maxFontSize": 1,
     "style": {
     }
@@ -827,7 +805,6 @@ exports[`An HTML extension builder should render with trust and strict setting 1
     ],
     "depth": 0,
     "height": 0.43056,
-    "italic": 0,
     "maxFontSize": 1,
     "style": {
     }
@@ -859,7 +836,6 @@ exports[`An HTML extension builder should render with trust and strict setting 1
     ],
     "depth": 0,
     "height": 0.43056,
-    "italic": 0,
     "maxFontSize": 1,
     "style": {
     }
@@ -1053,7 +1029,6 @@ exports[`An includegraphics builder should not render without trust setting 1`] 
     ],
     "depth": 0.25,
     "height": 0.75,
-    "italic": 0,
     "maxFontSize": 1,
     "style": {
       "color": "#cc0000"
@@ -1428,7 +1403,6 @@ exports[`href and url commands should not affect spacing around 1`] = `
     ],
     "depth": 0,
     "height": 0,
-    "italic": 0,
     "maxFontSize": 0,
     "style": {
       "marginRight": "0.2222em"
@@ -1463,7 +1437,6 @@ exports[`href and url commands should not affect spacing around 1`] = `
         ],
         "depth": 0,
         "height": 0,
-        "italic": 0,
         "maxFontSize": 0,
         "style": {
           "marginRight": "0.2222em"


### PR DESCRIPTION
Addresses technical debt from KaTeX's Flow-to-TypeScript migration. Eliminates ~50 `as any` casts across 19 source files, resolves almost all `TODO(ts)` comments, and enables `@typescript-eslint/no-explicit-any` as an error for `src/` and `contrib/` to prevent regressions.

### Approach

Rather than suppressing `any` with blanket eslint-disables, each cast was replaced with the narrowest viable alternative:

- **Runtime type guards** — `isAtom()`, `isMathDomNode()`, `isMiddleDelimNode()`, `isStyleStr()` — let TypeScript narrow control flow naturally instead of asserting through casts.
- **Union and intersection types** — `SettingsValue`, `MiddleDelimNode`, `ColorEnclosureNode` — model the actual shapes that were previously hidden behind `any`.
- **Structural narrowing** — e.g. `'base' in group` in `stretchy.ts`, guarded `Partial<CSSProperties>` iteration in `domTree.ts` — leverages TypeScript's built-in narrowing instead of casting.
- **Scoped variables** — in `arrow.ts`, `horizBrace.ts`, and `op.ts`, intermediate typed variables replace DOM navigation hacks and property mutation through casts.

Several `eslint-disable` comments remain, all on architectural boundaries where `any` is genuinely required: the global function/environment registries in `defineFunction.ts` and `defineEnvironment.ts`, the heterogeneous `cliProcessor` in `Settings.ts`, and the `processor` field in `Settings.ts` (where an `Object.keys` loop erases per-key type information — fixing this properly requires making `Schema` generic per setting key).