### PR TITLE
docs: support for persian/arabic numerals

### DIFF
--- a/docs/supported.md
+++ b/docs/supported.md
@@ -192,7 +192,7 @@ $\allowbreak α β γ δ ϵ ζ η θ ι κ λ μ ν ξ o π \allowbreak ρ σ τ
 |$\eth$ `\eth`|$\hslash$ `\hslash`|$\reals$ `\reals`|$\text{\oe}$ `\text{\oe}`
 
 **Persian/Arabic Numerals**
-KaTeX doesn't support Persian/Arabic numerals, but you can use [third party plugin](https://github.com/HosseinAgha/persian-katex-plugin), extend KaTeX with `__defineSymbol` or use direct input.
+KaTeX has no dedicated commands for Persian/Arabic numerals, but direct Unicode input works. You can also use a [third-party plugin](https://github.com/HosseinAgha/persian-katex-plugin) or extend KaTeX with `__defineSymbol`.
 
 Direct Input: $∂ ∇ ℑ Ⅎ ℵ ℶ ℷ ℸ ⅁ ℏ ð − ∗$
 ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖÙÚÛÜÝÞßàáâãäåçèéêëìíîïðñòóôöùúûüýþÿ

--- a/docs/supported.md
+++ b/docs/supported.md
@@ -191,6 +191,9 @@ $\allowbreak α β γ δ ϵ ζ η θ ι κ λ μ ν ξ o π \allowbreak ρ σ τ
 |$\daleth$ `\daleth`|$\hbar$ `\hbar`|$\real$ `\real`|$\text{\AE}$ `\text{\AE}`
 |$\eth$ `\eth`|$\hslash$ `\hslash`|$\reals$ `\reals`|$\text{\oe}$ `\text{\oe}`
 
+**Persian/Arabic Numerals**
+KaTeX doesn't support Persian/Arabic numerals, but you can use [third party plugin](https://github.com/HosseinAgha/persian-katex-plugin), extend KaTeX with `__defineSymbol` or use direct input.
+
 Direct Input: $∂ ∇ ℑ Ⅎ ℵ ℶ ℷ ℸ ⅁ ℏ ð − ∗$
 ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖÙÚÛÜÝÞßàáâãäåçèéêëìíîïðñòóôöùúûüýþÿ
 ₊₋₌₍₎₀₁₂₃₄₅₆₇₈₉ₐₑₕᵢⱼₖₗₘₙₒₚᵣₛₜᵤᵥₓᵦᵧᵨᵩᵪ⁺⁻⁼⁽⁾⁰¹²³⁴⁵⁶⁷⁸⁹ᵃᵇᶜᵈᵉᵍʰⁱʲᵏˡᵐⁿᵒᵖʳˢᵗᵘʷˣʸᶻᵛᵝᵞᵟᵠᵡ

--- a/docs/supported.md
+++ b/docs/supported.md
@@ -192,7 +192,7 @@ $\allowbreak α β γ δ ϵ ζ η θ ι κ λ μ ν ξ o π \allowbreak ρ σ τ
 |$\eth$ `\eth`|$\hslash$ `\hslash`|$\reals$ `\reals`|$\text{\oe}$ `\text{\oe}`
 
 **Persian/Arabic Numerals**
-KaTeX has no dedicated commands for Persian/Arabic numerals, but direct Unicode input works. You can also use a [third-party plugin](https://github.com/HosseinAgha/persian-katex-plugin) or extend KaTeX with `__defineSymbol`.
+KaTeX doesn't support Persian/Arabic numerals, but you can use [third party plugin](https://github.com/HosseinAgha/persian-katex-plugin) or extend KaTeX with `__defineSymbol`.
 
 Direct Input: $∂ ∇ ℑ Ⅎ ℵ ℶ ℷ ℸ ⅁ ℏ ð − ∗$
 ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖÙÚÛÜÝÞßàáâãäåçèéêëìíîïðñòóôöùúûüýþÿ

--- a/docs/supported.md
+++ b/docs/supported.md
@@ -191,14 +191,14 @@ $\allowbreak α β γ δ ϵ ζ η θ ι κ λ μ ν ξ o π \allowbreak ρ σ τ
 |$\daleth$ `\daleth`|$\hbar$ `\hbar`|$\real$ `\real`|$\text{\AE}$ `\text{\AE}`
 |$\eth$ `\eth`|$\hslash$ `\hslash`|$\reals$ `\reals`|$\text{\oe}$ `\text{\oe}`
 
-**Persian/Arabic Numerals**
-KaTeX doesn't support Persian/Arabic numerals, but you can use [third party plugin](https://github.com/HosseinAgha/persian-katex-plugin) or extend KaTeX with `__defineSymbol`.
-
 Direct Input: $∂ ∇ ℑ Ⅎ ℵ ℶ ℷ ℸ ⅁ ℏ ð − ∗$
 ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖÙÚÛÜÝÞßàáâãäåçèéêëìíîïðñòóôöùúûüýþÿ
 ₊₋₌₍₎₀₁₂₃₄₅₆₇₈₉ₐₑₕᵢⱼₖₗₘₙₒₚᵣₛₜᵤᵥₓᵦᵧᵨᵩᵪ⁺⁻⁼⁽⁾⁰¹²³⁴⁵⁶⁷⁸⁹ᵃᵇᶜᵈᵉᵍʰⁱʲᵏˡᵐⁿᵒᵖʳˢᵗᵘʷˣʸᶻᵛᵝᵞᵟᵠᵡ
 
 Math-mode Unicode (sub|super)script characters will render as if you had written regular characters in a subscript or superscript. For instance, `A²⁺³` will render the same as `A^{2+3}`.
+
+**Persian/Arabic Numerals**
+For support of Persian/Arabic numerals, try the third-party [persian-katex-plugin](https://github.com/HosseinAgha/persian-katex-plugin).
 
 </div>
 <div class="katex-cards" id="math-alpha">


### PR DESCRIPTION
<!-- PR title should follow Angular Commit Message Conventions (https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines) -->
This is a documentation update to mention Persian and Arabic numerals. Worth to mention that direct input [works fine](https://katex.org/?data=%7B%22displayMode%22%3Atrue%2C%22leqno%22%3Afalse%2C%22fleqn%22%3Afalse%2C%22throwOnError%22%3Atrue%2C%22errorColor%22%3A%22%23cc0000%22%2C%22strict%22%3A%22warn%22%2C%22output%22%3A%22htmlAndMathml%22%2C%22trust%22%3Afalse%2C%22macros%22%3A%7B%22%5C%5Cf%22%3A%22%231f(%232)%22%7D%2C%22code%22%3A%22%5C%5Cunderbrace%7B%5C%5Csqrt%7B%DB%B0-%DB%B1%7D%7D_%7B%DB%B7-%DB%B9%7D%22%7D).

<!-- If this PR contains a breaking change, please uncomment following line -->
<!-- BREAKING CHANGE: describe its impact and migration methods -->

<!-- If this PR fixes or closes issues, please uncomment following line and change the issue number -->
Closes #212
