### PR TITLE
chore: add prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
     "build": "rimraf dist/ && mkdirp dist && cp README.md dist && rollup -c --failAfterWarnings && webpack && node update-sri.js package dist/README.md",
     "build:fonts": "dockers/fonts/buildFonts.sh",
     "build:metrics": "dockers/fonts/buildMetrics.sh",
+    "prepare": "node -e \"process.env.INIT_CWD !== process.cwd() && process.exit(1)\" || npm run build",
     "watch": "yarn build --watch",
     "postversion": "yarn dist && node update-sri.js package README.md contrib/*/README.md docs/*.md website/pages/index.html",
     "semantic-release": "semantic-release",


### PR DESCRIPTION
<!-- PR title should follow Angular Commit Message Conventions (https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines) -->

**What is the previous behavior before this PR?**

**What is the new behavior after this PR?**
Now installing from source repo works. Example:

```shell
npm install github:UlyssesZh/KaTeX#prepare-script
```

Notice that we have to use `npm run` instead of `yarn` in the script to support other package managers. When `yarn` sees `npm run`, it will cleverly use `yarn` instead, so there will be no problem.

<!-- If this PR contains a breaking change, please uncomment following line -->
<!-- BREAKING CHANGE: describe its impact and migration methods -->

<!-- If this PR fixes or closes issues, please uncomment following line and change the issue number -->
<!-- Fixes #1, Closes #2 -->
