### PR TITLE
fix: preserve math font in some styling commands

### DIFF
--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -580,13 +580,15 @@ export default class Parser {
                 return this.parseArgumentGroup(optional, type);
             case "hbox": {
                 // hbox argument type wraps the argument in the equivalent of
-                // \hbox, which is like \text but switching to \textstyle size.
+                // \hbox, which is like \text but switching to \textstyle size
+                // and resetting math font.
                 const group = this.parseArgumentGroup(optional, "text");
                 return group != null ? {
                     type: "styling",
                     mode: group.mode,
                     body: [group],
                     style: "text", // simulate \textstyle
+                    resetFont: true,
                 } : null;
             }
             case "raw": {

--- a/src/buildMathML.ts
+++ b/src/buildMathML.ts
@@ -78,26 +78,28 @@ export const getVariant = (
     // Handle \text... font specifiers as best we can.
     // MathML has a limited list of allowable mathvariant specifiers; see
     // https://www.w3.org/TR/MathML3/chapter3.html#presm.commatt
-    if (options.fontFamily === "texttt") {
-        return "monospace";
-    } else if (options.fontFamily === "textsf") {
-        if (options.fontShape === "textit" &&
-            options.fontWeight === "textbf") {
-            return "sans-serif-bold-italic";
+    if (group.mode === "text") {
+        if (options.fontFamily === "texttt") {
+            return "monospace";
+        } else if (options.fontFamily === "textsf") {
+            if (options.fontShape === "textit" &&
+                options.fontWeight === "textbf") {
+                return "sans-serif-bold-italic";
+            } else if (options.fontShape === "textit") {
+                return "sans-serif-italic";
+            } else if (options.fontWeight === "textbf") {
+                return "bold-sans-serif";
+            } else {
+                return "sans-serif";
+            }
+        } else if (options.fontShape === "textit" &&
+                   options.fontWeight === "textbf") {
+            return "bold-italic";
         } else if (options.fontShape === "textit") {
-            return "sans-serif-italic";
+            return "italic";
         } else if (options.fontWeight === "textbf") {
-            return "bold-sans-serif";
-        } else {
-            return "sans-serif";
+            return "bold";
         }
-    } else if (options.fontShape === "textit" &&
-               options.fontWeight === "textbf") {
-        return "bold-italic";
-    } else if (options.fontShape === "textit") {
-        return "italic";
-    } else if (options.fontWeight === "textbf") {
-        return "bold";
     }
 
     const font = options.font;

--- a/src/environments/array.ts
+++ b/src/environments/array.ts
@@ -183,6 +183,7 @@ function parseArray(
                 type: "styling",
                 mode: parser.mode,
                 style,
+                resetFont: true,
                 body: [cell],
             };
         }

--- a/src/environments/cd.ts
+++ b/src/environments/cd.ts
@@ -25,7 +25,13 @@ const newCell = (): ParseNode<"styling"> => {
     // The parseTree from this module must be constructed like the
     // one created by parseArray(), so an empty CD cell must
     // be a ParseNode<"styling">. And CD is always displaystyle.
-    return {type: "styling", body: [], mode: "math", style: "display"};
+    return {
+        type: "styling",
+        body: [],
+        mode: "math",
+        style: "display",
+        resetFont: true,
+    };
 };
 
 const isStartOfArrow = (node: AnyParseNode) => {
@@ -183,6 +189,7 @@ export function parseCD(parser: Parser): ParseNode<"array"> {
                     body: [arrow],
                     mode: "math",
                     style: "display", // CD is always displaystyle.
+                    resetFont: true,
                 };
                 row.push(wrappedArrow);
                 // In CD's syntax, cells are implicit. That is, everything that

--- a/src/functions/enclose.ts
+++ b/src/functions/enclose.ts
@@ -223,7 +223,7 @@ defineFunction({
     props: {
         numArgs: 2,
         allowedInText: true,
-        argTypes: ["color", "text"],
+        argTypes: ["color", "hbox"],
     },
     handler({parser, funcName}, args, optArgs) {
         const color = assertNodeType(args[0], "color-token").color;
@@ -246,7 +246,7 @@ defineFunction({
     props: {
         numArgs: 3,
         allowedInText: true,
-        argTypes: ["color", "color", "text"],
+        argTypes: ["color", "color", "hbox"],
     },
     handler({parser, funcName}, args, optArgs) {
         const borderColor = assertNodeType(args[0], "color-token").color;

--- a/src/functions/hbox.ts
+++ b/src/functions/hbox.ts
@@ -27,12 +27,12 @@ defineFunction({
         };
     },
     htmlBuilder(group, options) {
-        const elements = html.buildExpression(group.body, options, false);
+        const elements = html.buildExpression(group.body, options.withFont(''), false);
         return makeFragment(elements);
     },
     mathmlBuilder(group, options) {
         return new MathNode(
-          "mrow", mml.buildExpression(group.body, options)
+          "mrow", mml.buildExpression(group.body, options.withFont(''))
         );
     },
 });

--- a/src/functions/math.ts
+++ b/src/functions/math.ts
@@ -21,6 +21,7 @@ defineFunction({
             type: "styling",
             mode: parser.mode,
             style: "text",
+            resetFont: true,
             body,
         };
     },

--- a/src/functions/styling.ts
+++ b/src/functions/styling.ts
@@ -50,13 +50,19 @@ defineFunction({
     htmlBuilder(group, options) {
         // Style changes are handled in the TeXbook on pg. 442, Rule 3.
         const newStyle = styleMap[group.style];
-        const newOptions = options.havingStyle(newStyle).withFont('');
+        let newOptions = options.havingStyle(newStyle);
+        if (group.resetFont) {
+            newOptions = newOptions.withFont('');
+        }
         return sizingGroup(group.body, newOptions, options);
     },
     mathmlBuilder(group, options) {
         // Figure out what style we're changing to.
         const newStyle = styleMap[group.style];
-        const newOptions = options.havingStyle(newStyle);
+        let newOptions = options.havingStyle(newStyle);
+        if (group.resetFont) {
+            newOptions = newOptions.withFont('');
+        }
 
         const inner = mml.buildExpression(group.body, newOptions);
 

--- a/src/parseNode.ts
+++ b/src/parseNode.ts
@@ -123,6 +123,7 @@ type ParseNodeTypes = {
         mode: Mode;
         loc?: SourceLocation | null | undefined;
         style: StyleStr;
+        resetFont?: boolean;
         body: AnyParseNode[];
     };
     "supsub": {

--- a/test/__snapshots__/katex-spec.ts.snap
+++ b/test/__snapshots__/katex-spec.ts.snap
@@ -31,6 +31,7 @@ exports[`A begin/end parser should grab \\arraystretch 1`] = `
             }
           ],
           "mode": "math",
+          "resetFont": true,
           "style": "text"
         },
         {
@@ -57,6 +58,7 @@ exports[`A begin/end parser should grab \\arraystretch 1`] = `
             }
           ],
           "mode": "math",
+          "resetFont": true,
           "style": "text"
         }
       ],
@@ -85,6 +87,7 @@ exports[`A begin/end parser should grab \\arraystretch 1`] = `
             }
           ],
           "mode": "math",
+          "resetFont": true,
           "style": "text"
         },
         {
@@ -111,6 +114,7 @@ exports[`A begin/end parser should grab \\arraystretch 1`] = `
             }
           ],
           "mode": "math",
+          "resetFont": true,
           "style": "text"
         }
       ]

--- a/test/__snapshots__/mathml-spec.ts.snap
+++ b/test/__snapshots__/mathml-spec.ts.snap
@@ -886,9 +886,13 @@ exports[`A MathML builder should use <menclose> for colorbox 1`] = `
                voffset="3pt"
                mathbackground="red"
       >
-        <mtext>
-          b
-        </mtext>
+        <mstyle scriptlevel="0"
+                displaystyle="false"
+        >
+          <mtext>
+            b
+          </mtext>
+        </mstyle>
       </mpadded>
     </mrow>
     <annotation encoding="application/x-tex">

--- a/test/katex-spec.ts
+++ b/test/katex-spec.ts
@@ -703,6 +703,21 @@ describe("A genfrac builder", function() {
         expect`x_{y_{\dfrac{a}{b}}}`
             .toBuildLike`x_{y_{\displaystyle\frac{a}{b}}}`;
     });
+
+    it("should preserve math font in forced-style fractions", function() {
+        const expressions = [
+            r`\mathsf{\dfrac{ABC123}{xyz456}}`,
+            r`\mathsf{\tfrac{ABC123}{xyz456}}`,
+            r`\mathsf{\cfrac{ABC123}{xyz456}}`,
+            r`\mathsf{\genfrac{}{}{0.8pt}{0}{ABC123}{xyz456}}`,
+        ];
+
+        for (const expression of expressions) {
+            const markup = katex.renderToString(expression);
+            expect(markup).toMatch(/<span class="mord mathsf(?: mtight)?">ABC123<\/span>/);
+            expect(markup).toMatch(/<span class="mord mathsf(?: mtight)?">xyz456<\/span>/);
+        }
+    });
 });
 
 describe("A infix builder", function() {
@@ -1648,6 +1663,58 @@ describe("A style change parser", function() {
 
         expect(displayBody).toHaveLength(2);
         expect(displayBody[0].text).toEqual("e");
+    });
+
+    it("should preserve math font across style changes", function() {
+        const styles = [
+            r`\displaystyle`,
+            r`\textstyle`,
+            r`\scriptstyle`,
+            r`\scriptscriptstyle`,
+        ];
+
+        for (const style of styles) {
+            const markup = katex.renderToString(`\\mathsf{x + ${style} y}`);
+            expect(markup).toMatch(/<span class="mord mathsf[^"]*"[^>]*>y<\/span>/);
+        }
+    });
+
+    it("should reset math font when switching from text to math", function() {
+        for (const expression of [r`\text{\sf $x$}`, r`\textsf{$x$}`]) {
+            const markup = katex.renderToString(expression);
+            expect(markup).toMatch(/<span class="mord mathnormal">x<\/span>/);
+            expect(markup).not.toMatch(/<span class="mord mathsf(?: mtight)?">x<\/span>/);
+            expect(markup).not.toContain("textsf\">x</span>");
+        }
+    });
+
+    it("should preserve text font after switching back from math to text", function() {
+        const markup = katex.renderToString(r`\textsf{$\text{x}$}`);
+        expect(markup).toContain("<span class=\"mord textsf\">x</span>");
+        expect(markup).not.toMatch(/<span class="mord mathnormal">x<\/span>/);
+        expect(markup).not.toMatch(/<span class="mord mathsf(?: mtight)?">x<\/span>/);
+    });
+
+    it("should reset math font in array style wrappers", function() {
+        for (const expression of [
+            r`\mathsf{\begin{matrix}x\end{matrix}}`,
+            r`\mathsf{\begin{array}{c}x\end{array}}`,
+        ]) {
+            const markup = katex.renderToString(expression);
+            expect(markup).toMatch(/<span class="mord mathnormal">x<\/span>/);
+            expect(markup).not.toMatch(/<span class="mord mathsf(?: mtight)?">x<\/span>/);
+        }
+    });
+
+    it("should reset math font in CD style wrappers", function() {
+        const cdMarkup = katex.renderToString(
+            r`\mathsf{\begin{CD}A @>x>> B\end{CD}}`,
+            new Settings({displayMode: true}),
+        );
+        expect(cdMarkup).toMatch(/<span class="mord mathnormal">A<\/span>/);
+        expect(cdMarkup).toMatch(/<span class="mord mathnormal"[^>]*>B<\/span>/);
+        expect(cdMarkup).toMatch(/<span class="mord mathnormal mtight">x<\/span>/);
+        expect(cdMarkup).not.toMatch(/<span class="mord mathsf(?: mtight)?">[ABx]<\/span>/);
     });
 });
 

--- a/test/katex-spec.ts
+++ b/test/katex-spec.ts
@@ -1716,6 +1716,19 @@ describe("A style change parser", function() {
         expect(cdMarkup).toMatch(/<span class="mord mathnormal mtight">x<\/span>/);
         expect(cdMarkup).not.toMatch(/<span class="mord mathsf(?: mtight)?">[ABx]<\/span>/);
     });
+
+    it("should not leak math font into hbox/text contexts", function() {
+        for (const expression of [
+            r`\mathsf{\text{x}}`,
+            r`\mathsf{\raisebox{2pt}{x}}`,
+            r`\mathsf{\fbox{x}}`,
+            r`\mathsf{\hbox{x}}`,
+        ]) {
+            const markup = katex.renderToString(expression);
+            expect(markup).toMatch(/<span class="mord(?: text)?">x<\/span>/);
+            expect(markup).not.toMatch(/<span class="mord mathsf(?: mtight)?">x<\/span>/);
+        }
+    });
 });
 
 describe("A font parser", function() {

--- a/test/katex-spec.ts
+++ b/test/katex-spec.ts
@@ -1722,11 +1722,30 @@ describe("A style change parser", function() {
             r`\mathsf{\text{x}}`,
             r`\mathsf{\raisebox{2pt}{x}}`,
             r`\mathsf{\fbox{x}}`,
+            r`\mathsf{\colorbox{red}{x}}`,
+            r`\mathsf{\fcolorbox{blue}{red}{x}}`,
+            r`\mathsf{\angl{x}}`,
             r`\mathsf{\hbox{x}}`,
         ]) {
             const markup = katex.renderToString(expression);
             expect(markup).toMatch(/<span class="mord(?: text)?">x<\/span>/);
             expect(markup).not.toMatch(/<span class="mord mathsf(?: mtight)?">x<\/span>/);
+        }
+    });
+
+    it("should reset hbox math to textstyle", function() {
+        const scriptMarkup = katex.renderToString(r`\scriptstyle x`);
+        expect(scriptMarkup).toMatch(/<span class="mord mathnormal mtight[^"]*">x<\/span>/);
+
+        for (const expression of [
+            r`\scriptstyle \hbox{$x$}`,
+            r`\scriptstyle \fbox{$x$}`,
+            r`\scriptstyle \colorbox{red}{$x$}`,
+            r`\scriptstyle \fcolorbox{blue}{red}{$x$}`,
+        ]) {
+            const markup = katex.renderToString(expression);
+            expect(markup).toMatch(/<span class="mord mathnormal[^"]*">x<\/span>/);
+            expect(markup).not.toMatch(/<span class="mord mathnormal mtight[^"]*">x<\/span>/);
         }
     });
 });

--- a/test/mathml-spec.ts
+++ b/test/mathml-spec.ts
@@ -157,6 +157,78 @@ describe("A MathML builder", function() {
             .toMatchSnapshot();
     });
 
+    it("should preserve math font across style changes", () => {
+        const styles = [
+            "\\displaystyle",
+            "\\textstyle",
+            "\\scriptstyle",
+            "\\scriptscriptstyle",
+        ];
+
+        for (const style of styles) {
+            const mathml = getMathML(`\\mathsf{x ${style} y}`);
+            expect(mathml).toContain("<mi mathvariant=\"sans-serif\">x</mi>");
+            expect(mathml).toContain("<mi mathvariant=\"sans-serif\">y</mi>");
+        }
+    });
+
+    it("should preserve math font in forced-style fractions", () => {
+        const expressions = [
+            "\\mathsf{\\dfrac{ABC123}{xyz456}}",
+            "\\mathsf{\\tfrac{ABC123}{xyz456}}",
+            "\\mathsf{\\cfrac{ABC123}{xyz456}}",
+            "\\mathsf{\\genfrac{}{}{0.8pt}{0}{ABC123}{xyz456}}",
+        ];
+
+        for (const expression of expressions) {
+            const mathml = getMathML(expression);
+            expect(mathml).toContain("<mi mathvariant=\"sans-serif\">A</mi>");
+            expect(mathml).toContain("<mn mathvariant=\"sans-serif\">123</mn>");
+            expect(mathml).toContain("<mi mathvariant=\"sans-serif\">x</mi>");
+            expect(mathml).toContain("<mn mathvariant=\"sans-serif\">456</mn>");
+        }
+    });
+
+    it("should reset math font when switching from text to math", () => {
+        for (const expression of ["\\text{\\sf $x$}", "\\textsf{$x$}"]) {
+            const mathml = getMathML(expression);
+            expect(mathml).toContain("<mi>x</mi>");
+            expect(mathml).not.toContain("<mi mathvariant=\"sans-serif\">x</mi>");
+            expect(mathml).not.toContain("<mtext>x</mtext>");
+        }
+    });
+
+    it("should preserve text font after switching back from math to text", () => {
+        const mathml = getMathML("\\textsf{$\\text{x}$}");
+        expect(mathml).toContain("<mtext mathvariant=\"sans-serif\">x</mtext>");
+        expect(mathml).not.toContain("<mi>x</mi>");
+        expect(mathml).not.toContain("<mi mathvariant=\"sans-serif\">x</mi>");
+    });
+
+    it("should reset math font in array style wrappers", () => {
+        for (const expression of [
+            "\\mathsf{\\begin{matrix}x\\end{matrix}}",
+            "\\mathsf{\\begin{array}{c}x\\end{array}}",
+        ]) {
+            const mathml = getMathML(expression);
+            expect(mathml).toContain("<mi>x</mi>");
+            expect(mathml).not.toContain("<mi mathvariant=\"sans-serif\">x</mi>");
+        }
+    });
+
+    it("should reset math font in CD style wrappers", () => {
+        const cdMathml = getMathML(
+            "\\mathsf{\\begin{CD}A @>x>> B\\end{CD}}",
+            new Settings({displayMode: true}),
+        );
+        expect(cdMathml).toContain("<mi>A</mi>");
+        expect(cdMathml).toContain("<mi>B</mi>");
+        expect(cdMathml).toContain("<mi>x</mi>");
+        expect(cdMathml).not.toContain("<mi mathvariant=\"sans-serif\">A</mi>");
+        expect(cdMathml).not.toContain("<mi mathvariant=\"sans-serif\">B</mi>");
+        expect(cdMathml).not.toContain("<mi mathvariant=\"sans-serif\">x</mi>");
+    });
+
     it('\\html@mathml makes clean symbols', () => {
         expect(getMathML("\\copyright\\neq\\notin\u2258\\KaTeX"))
             .toMatchSnapshot();

--- a/test/mathml-spec.ts
+++ b/test/mathml-spec.ts
@@ -229,6 +229,19 @@ describe("A MathML builder", function() {
         expect(cdMathml).not.toContain("<mi mathvariant=\"sans-serif\">x</mi>");
     });
 
+    it("should not leak math font into hbox/text contexts", () => {
+        for (const expression of [
+            "\\mathsf{\\text{x}}",
+            "\\mathsf{\\raisebox{2pt}{x}}",
+            "\\mathsf{\\fbox{x}}",
+            "\\mathsf{\\hbox{x}}",
+        ]) {
+            const mathml = getMathML(expression);
+            expect(mathml).toContain("<mtext>x</mtext>");
+            expect(mathml).not.toContain("<mtext mathvariant=\"sans-serif\">x</mtext>");
+        }
+    });
+
     it('\\html@mathml makes clean symbols', () => {
         expect(getMathML("\\copyright\\neq\\notin\u2258\\KaTeX"))
             .toMatchSnapshot();

--- a/test/mathml-spec.ts
+++ b/test/mathml-spec.ts
@@ -234,11 +234,31 @@ describe("A MathML builder", function() {
             "\\mathsf{\\text{x}}",
             "\\mathsf{\\raisebox{2pt}{x}}",
             "\\mathsf{\\fbox{x}}",
+            "\\mathsf{\\colorbox{red}{x}}",
+            "\\mathsf{\\fcolorbox{blue}{red}{x}}",
+            "\\mathsf{\\angl{x}}",
             "\\mathsf{\\hbox{x}}",
         ]) {
             const mathml = getMathML(expression);
             expect(mathml).toContain("<mtext>x</mtext>");
             expect(mathml).not.toContain("<mtext mathvariant=\"sans-serif\">x</mtext>");
+        }
+    });
+
+    it("should reset hbox math to textstyle", () => {
+        const scriptMathml = getMathML("\\scriptstyle x");
+        expect(scriptMathml).toContain("<mstyle scriptlevel=\"1\"");
+
+        for (const expression of [
+            "\\scriptstyle \\hbox{$x$}",
+            "\\scriptstyle \\fbox{$x$}",
+            "\\scriptstyle \\colorbox{red}{$x$}",
+            "\\scriptstyle \\fcolorbox{blue}{red}{$x$}",
+        ]) {
+            const mathml = getMathML(expression);
+            expect(mathml).toContain("<mstyle scriptlevel=\"1\"");
+            expect(mathml).toContain("<mstyle scriptlevel=\"0\"");
+            expect(mathml).toContain("<mi>x</mi>");
         }
     });
 


### PR DESCRIPTION
**What is the previous behavior before this PR?**

PR [#4137](https://github.com/KaTeX/KaTeX/pull/4137) introduced a regression by making forced-style fractions like `\dfrac`, `\tfrac`, `\cfrac`, and styled `\genfrac` use `"styling"` parse nodes.

Before this PR, all `"styling"` nodes reset `options.font`. That was correct for some `"styling"` nodes, such as `$...$` inside text and array/CD style wrappers, but incorrect for ordinary TeX style changes such as `\scriptstyle`. As a result, expressions like `\mathsf{\dfrac{ABC}{xyz}}` lost the surrounding `\mathsf` font.

The root issue was that `"styling"` nodes were conflating two purposes:

| Purpose | Should reset font? | Examples |
|---|:---:|---|
| TeX style changes within math | No | `\displaystyle`, `\textstyle`, `\scriptstyle`, `\scriptscriptstyle`, forced-style fractions |
| Switching into a context that starts fresh math | Yes | `$...$` inside text, array/matrix cell wrappers, CD cell/arrow wrappers |

In addition, `buildMathML.ts` had a bug where text-font options such as `\textsf` leak into nested math mode in MathML.

**What is the new behavior after this PR?**

This PR makes that distinction explicit with `resetFont: true` on the `"styling"` nodes that need it. Plain style changes now preserve the active math font, while `$...$`, array/matrix wrappers, and CD wrappers still reset math font.

`buildMathML.ts` also fixed to prevent text-font options such as `\textsf` from leaking onto nested math mode in MathML. Text font family/weight/shape are still used when building text-mode symbols, so `\textsf{$\text{x}$}` produces sans-serif text, but `$x$` inside `\textsf` now produces default math italic rather than `<mi mathvariant="sans-serif">x</mi>`, matching LaTeX.

Added HTML and MathML regression coverage for:

- all four `\...style` commands preserving math font
- forced-style fractions preserving math font: `\dfrac`, `\tfrac`, `\cfrac`, styled `\genfrac`
- `$...$` inside text resetting math font
- `\textsf{$x$}` resetting math font
- `\textsf{$\text{x}$}` preserving text font after switching back to text
- `matrix` and `array` wrappers resetting math font
- `CD` wrappers resetting math font

This behavior can be verified with `pdflatex` using `\showbox`:

```tex
\documentclass{article}
\usepackage{amsmath,amscd}
\tracingonline=1
\showboxbreadth=1000
\showboxdepth=1000
\begin{document}

\setbox0=\hbox{$\mathsf{x \displaystyle y}$}\showbox0
\setbox1=\hbox{$\mathsf{x \textstyle y}$}\showbox1
\setbox2=\hbox{$\mathsf{x \scriptstyle y}$}\showbox2
\setbox3=\hbox{$\mathsf{x \scriptscriptstyle y}$}\showbox3

\setbox4=\hbox{$\mathsf{\dfrac{ABC}{xyz}}$}\showbox4
\setbox5=\hbox{$\mathsf{\tfrac{ABC}{xyz}}$}\showbox5
\setbox6=\hbox{$\mathsf{\cfrac{ABC}{xyz}}$}\showbox6
\setbox7=\hbox{$\mathsf{\genfrac{}{}{0.8pt}{0}{ABC}{xyz}}$}\showbox7

\setbox8=\hbox{\text{\sf $x$}}\showbox8
\setbox9=\hbox{\textsf{$x$}}\showbox9
\setbox10=\hbox{\textsf{$\text{x}$}}\showbox10

\setbox11=\hbox{$\mathsf{\begin{matrix}ABC&xyz\end{matrix}}$}\showbox11
\setbox12=\hbox{$\mathsf{\begin{array}{cc}ABC&xyz\end{array}}$}\showbox12
\setbox13=\hbox{$\mathsf{\begin{CD} A @>x>> B\end{CD}}$}\showbox13

\end{document}
```

Results:

| Case | Relevant LaTeX output | Result |
|---|---|---|
| `\mathsf{x \displaystyle y}` | `x`, `y`: `OT1/cmss/m/n/10` | font preserved |
| `\mathsf{x \textstyle y}` | `x`, `y`: `OT1/cmss/m/n/10` | font preserved |
| `\mathsf{x \scriptstyle y}` | `x`: `OT1/cmss/m/n/10`; `y`: `OT1/cmss/m/n/7` | font preserved |
| `\mathsf{x \scriptscriptstyle y}` | `x`: `OT1/cmss/m/n/10`; `y`: `OT1/cmss/m/n/5` | font preserved |
| `\mathsf{\dfrac{ABC}{xyz}}` | numerator/denominator letters: `OT1/cmss/m/n/10` | font preserved |
| `\mathsf{\tfrac{ABC}{xyz}}` | numerator/denominator letters: `OT1/cmss/m/n/7` | font preserved |
| `\mathsf{\cfrac{ABC}{xyz}}` | numerator/denominator letters: `OT1/cmss/m/n/10` | font preserved |
| `\mathsf{\genfrac{}{}{0.8pt}{0}{ABC}{xyz}}` | numerator/denominator letters: `OT1/cmss/m/n/10` | font preserved |
| `\text{\sf $x$}` | `x`: `OML/cmm/m/it/10` | font reset |
| `\textsf{$x$}` | `x`: `OML/cmm/m/it/10` | font reset |
| `\textsf{$\text{x}$}` | `x`: `OT1/cmss/m/n/10` | text font preserved after returning to text |
| `\mathsf{\begin{matrix}ABC&xyz\end{matrix}}` | cell letters: `OML/cmm/m/it/10` | font reset |
| `\mathsf{\begin{array}{cc}ABC&xyz\end{array}}` | cell letters: `OML/cmm/m/it/10` | font reset |
| `\mathsf{\begin{CD} A @>x>> B\end{CD}}` | `A`, `B`: `OML/cmm/m/it/10`; arrow label `x`: `OML/cmm/m/it/7` | font reset |

Fixes #4213.

