### PR TITLE
perf: simplify `defineFunction` to avoid destructuring, improve typing

### DIFF
--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -477,7 +477,7 @@ export default class Parser {
         } else if (this.mode === "text" && !funcData.allowedInText) {
             throw new ParseError(
                 "Can't use function '" + func + "' in text mode", token);
-        } else if (this.mode === "math" && !funcData.allowedInMath) {
+        } else if (this.mode === "math" && funcData.allowedInMath === false) {
             throw new ParseError(
                 "Can't use function '" + func + "' in math mode", token);
         }
@@ -520,7 +520,8 @@ export default class Parser {
         args: AnyParseNode[];
         optArgs: (AnyParseNode | null)[];
     } {
-        const totalArgs = funcData.numArgs + funcData.numOptionalArgs;
+        const numOptionalArgs = funcData.numOptionalArgs ?? 0;
+        const totalArgs = funcData.numArgs + numOptionalArgs;
         if (totalArgs === 0) {
             return {args: [], optArgs: []};
         }
@@ -530,7 +531,7 @@ export default class Parser {
 
         for (let i = 0; i < totalArgs; i++) {
             let argType = funcData.argTypes?.[i];
-            const isOptional = i < funcData.numOptionalArgs;
+            const isOptional = i < numOptionalArgs;
 
             if (("primitive" in funcData && funcData.primitive && argType == null) ||
                 // \sqrt expands into primitive if optional argument doesn't exist

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -474,9 +474,11 @@ export default class Parser {
             throw new ParseError(
                 "Got function '" + func + "' with no arguments" +
                 (name ? " as " + name : ""), token);
+        // Treat undefined allowedInText as false.
         } else if (this.mode === "text" && !funcData.allowedInText) {
             throw new ParseError(
                 "Can't use function '" + func + "' in text mode", token);
+        // Treat undefined allowedInMath as true.
         } else if (this.mode === "math" && funcData.allowedInMath === false) {
             throw new ParseError(
                 "Can't use function '" + func + "' in math mode", token);

--- a/src/defineFunction.ts
+++ b/src/defineFunction.ts
@@ -33,88 +33,103 @@ export type MathMLBuilder<NODETYPE extends NodeType> =
 export type HtmlBuilderSupSub<NODETYPE extends NodeType> =
     (group: ParseNode<"supsub"> | ParseNode<NODETYPE>, options: Options) => HtmlDomNode;
 
-export type FunctionPropSpec = {
-    // The number of arguments the function takes.
-    numArgs: number;
-
-    // An array corresponding to each argument of the function, giving the
-    // type of argument that should be parsed. Its length should be equal
-    // to `numOptionalArgs + numArgs`, and types for optional arguments
-    // should appear before types for mandatory arguments.
-    argTypes?: ArgType[];
-
-    // Whether it expands to a single token or a braced group of tokens.
-    // If it's grouped, it can be used as an argument to primitive commands,
-    // such as \sqrt (without the optional argument) and super/subscript.
-    allowedInArgument?: boolean;
-
-    // Whether or not the function is allowed inside text mode
-    // (default false)
-    allowedInText?: boolean;
-
-    // Whether or not the function is allowed inside text mode
-    // (default true)
-    allowedInMath?: boolean;
-
-    // (optional) The number of optional arguments the function
-    // should parse. If the optional arguments aren't found,
-    // `null` will be passed to the handler in their place.
-    // (default 0)
-    numOptionalArgs?: number;
-
-    // Must be true if the function is an infix operator.
-    infix?: boolean;
-
-    // Whether or not the function is a TeX primitive.
-    primitive?: boolean;
-};
-
-type FunctionDefSpec<NODETYPE extends NodeType> = {
-    // Unique string to differentiate parse nodes.
-    // Also determines the type of the value returned by `handler`.
+/**
+ * Parser-facing function spec.  Optional properties should use the defaults
+ * documented below.
+ */
+export type FunctionSpec<NODETYPE extends NodeType> = {
+    /**
+     * Unique string to differentiate parse nodes.
+     * Also determines the type of the value returned by `handler`.
+     */
     type: NODETYPE;
 
-    // The first argument to defineFunction is a single name or a list of names.
-    // All functions named in such a list will share a single implementation.
-    names: Array<string>;
+    /** The number of arguments the function takes. */
+    numArgs: number;
 
-    // Properties that control how the functions are parsed.
-    props: FunctionPropSpec;
+    /**
+     * An array corresponding to each argument of the function, giving the
+     * type of argument that should be parsed. Its length should be equal
+     * to `numOptionalArgs + numArgs`, and types for optional arguments
+     * should appear before types for mandatory arguments.
+     */
+    argTypes?: ArgType[];
 
-    // The handler is called to handle these functions and their arguments and
-    // returns a `ParseNode`.
+    /**
+     * Whether it expands to a single token or a braced group of tokens.
+     * If it's grouped, it can be used as an argument to primitive commands,
+     * such as \sqrt (without the optional argument) and super/subscript.
+     * (default false)
+     */
+    allowedInArgument?: boolean;
+
+    /**
+     * Whether or not the function is allowed inside text mode
+     * (default false)
+     */
+    allowedInText?: boolean;
+
+    /**
+     * Whether or not the function is allowed inside math mode
+     * (default true)
+     */
+    allowedInMath?: boolean;
+
+    /**
+     * The number of optional arguments the function should parse. If the
+     * optional arguments aren't found, `null` will be passed to the handler in
+     * their place.
+     * (default 0)
+     */
+    numOptionalArgs?: number;
+
+    /** Must be true if the function is an infix operator. */
+    infix?: boolean;
+
+    /** Whether or not the function is a TeX primitive. */
+    primitive?: boolean;
+
+    /**
+     * The handler is called to handle these functions and their arguments and
+     * returns a `ParseNode`.  It must be specified unless it's handled directly
+     * in the parser.
+     */
     handler: FunctionHandler<NODETYPE> | null | undefined;
+};
 
-    // This function returns an object representing the DOM structure to be
-    // created when rendering the defined LaTeX function.
-    // This should not modify the `ParseNode`.
+/**
+ * Builder fields consumed during registration.  These are stored separately in
+ * `_htmlGroupBuilders` and `_mathmlGroupBuilders`, and are not used by Parser.
+ */
+export type FunctionBuilders<NODETYPE extends NodeType> = {
+    /**
+     * This function returns an object representing the DOM structure to be
+     * created when rendering the defined LaTeX function.
+     * This should not modify the `ParseNode`.
+     */
     htmlBuilder?: HtmlBuilder<NODETYPE>;
 
-    // This function returns an object representing the MathML structure to be
-    // created when rendering the defined LaTeX function.
-    // This should not modify the `ParseNode`.
+    /**
+     * This function returns an object representing the MathML structure to be
+     * created when rendering the defined LaTeX function.
+     * This should not modify the `ParseNode`.
+     */
     mathmlBuilder?: MathMLBuilder<NODETYPE>;
 };
 
 /**
- * Final function spec for use at parse time.
- * This is almost identical to `FunctionPropSpec`, except it
- * 1. includes the function handler, and
- * 2. requires all arguments except argTypes.
- * It is generated by `defineFunction()` below.
+ * Full registration spec passed to `defineFunction`.  It combines the
+ * parser-facing fields with optional builder fields and the names being
+ * registered.
  */
-export type FunctionSpec<NODETYPE extends NodeType> = {
-    type: NODETYPE; // Need to use the type to avoid error. See NOTES below.
-    numArgs: number;
-    argTypes?: ArgType[];
-    allowedInArgument: boolean;
-    allowedInText: boolean;
-    allowedInMath: boolean;
-    numOptionalArgs: number;
-    infix: boolean;
-    primitive: boolean;
-    handler: FunctionHandler<NodeType> | null | undefined;
-};
+type FunctionDefSpec<NODETYPE extends NodeType> =
+    FunctionSpec<NODETYPE> & FunctionBuilders<NODETYPE> & {
+        /**
+         * The first argument to defineFunction is a single name or a list of names.
+         * All functions named in such a list will share a single implementation.
+         */
+        names: Array<string>;
+    };
 
 /**
  * All registered functions.
@@ -142,30 +157,14 @@ export const _htmlGroupBuilders: Record<string, HtmlBuilder<any>> = {};
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const _mathmlGroupBuilders: Record<string, MathMLBuilder<any>> = {};
 
-export default function defineFunction<NODETYPE extends NodeType>({
-    type,
-    names,
-    props,
-    handler,
-    htmlBuilder,
-    mathmlBuilder,
-}: FunctionDefSpec<NODETYPE>) {
-    // Set default values of functions
-    const data = {
-        type,
-        numArgs: props.numArgs,
-        argTypes: props.argTypes,
-        allowedInArgument: !!props.allowedInArgument,
-        allowedInText: !!props.allowedInText,
-        allowedInMath: (props.allowedInMath === undefined)
-            ? true
-            : props.allowedInMath,
-        numOptionalArgs: props.numOptionalArgs || 0,
-        infix: !!props.infix,
-        primitive: !!props.primitive,
-        handler,
-    };
+export default function defineFunction<NODETYPE extends NodeType>(
+    data: FunctionDefSpec<NODETYPE>,
+) {
+    const {type, names, htmlBuilder, mathmlBuilder} = data;
     for (let i = 0; i < names.length; ++i) {
+        // To avoid destructuring and rebuilding an object,
+        // we store the entire FunctionDefSpec object,
+        // even though Parser only needs the FunctionSpec fields.
         _functions[names[i]] = data;
     }
     if (type) {
@@ -190,14 +189,12 @@ export function defineFunctionBuilders<NODETYPE extends NodeType>({
     htmlBuilder?: HtmlBuilder<NODETYPE>;
     mathmlBuilder: MathMLBuilder<NODETYPE>;
 }) {
-    defineFunction({
-        type,
-        names: [],
-        props: {numArgs: 0},
-        handler() { throw new Error('Should never be called.'); },
-        htmlBuilder,
-        mathmlBuilder,
-    });
+    if (htmlBuilder) {
+        _htmlGroupBuilders[type] = htmlBuilder;
+    }
+    if (mathmlBuilder) {
+        _mathmlGroupBuilders[type] = mathmlBuilder;
+    }
 }
 
 export const normalizeArgument = function(arg: AnyParseNode): AnyParseNode {

--- a/src/defineFunction.ts
+++ b/src/defineFunction.ts
@@ -7,15 +7,18 @@ import type {Token} from "./Token";
 import type {MathDomNode} from "./mathMLTree";
 
 /** Context provided to function handlers for error messages. */
-export type FunctionContext = {
-    funcName: string;
+export type FunctionContext<FUNCNAME extends string = string> = {
+    funcName: FUNCNAME;
     parser: Parser;
     token?: Token;
     breakOnTokenText?: BreakToken;
 };
 
-export type FunctionHandler<NODETYPE extends NodeType> = (
-    context: FunctionContext,
+export type FunctionHandler<
+    NODETYPE extends NodeType,
+    FUNCNAME extends string = string,
+> = (
+    context: FunctionContext<FUNCNAME>,
     args: AnyParseNode[],
     optArgs: (AnyParseNode | null)[],
 ) => UnsupportedCmdParseNode | ParseNode<NODETYPE>;
@@ -37,7 +40,10 @@ export type HtmlBuilderSupSub<NODETYPE extends NodeType> =
  * Parser-facing function spec.  Optional properties should use the defaults
  * documented below.
  */
-export type FunctionSpec<NODETYPE extends NodeType> = {
+export type FunctionSpec<
+    NODETYPE extends NodeType,
+    FUNCNAME extends string = string,
+> = {
     /**
      * Unique string to differentiate parse nodes.
      * Also determines the type of the value returned by `handler`.
@@ -94,7 +100,7 @@ export type FunctionSpec<NODETYPE extends NodeType> = {
      * returns a `ParseNode`.  It must be specified unless it's handled directly
      * in the parser.
      */
-    handler: FunctionHandler<NODETYPE> | null | undefined;
+    handler: FunctionHandler<NODETYPE, FUNCNAME> | null | undefined;
 };
 
 /**
@@ -122,13 +128,16 @@ export type FunctionBuilders<NODETYPE extends NodeType> = {
  * parser-facing fields with optional builder fields and the names being
  * registered.
  */
-type FunctionDefSpec<NODETYPE extends NodeType> =
-    FunctionSpec<NODETYPE> & FunctionBuilders<NODETYPE> & {
+type FunctionDefSpec<
+    NODETYPE extends NodeType,
+    NAMES extends readonly string[],
+> =
+    FunctionSpec<NODETYPE, NAMES[number]> & FunctionBuilders<NODETYPE> & {
         /**
          * The first argument to defineFunction is a single name or a list of names.
          * All functions named in such a list will share a single implementation.
          */
-        names: Array<string>;
+        names: NAMES;
     };
 
 /**
@@ -157,8 +166,11 @@ export const _htmlGroupBuilders: Record<string, HtmlBuilder<any>> = {};
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const _mathmlGroupBuilders: Record<string, MathMLBuilder<any>> = {};
 
-export default function defineFunction<NODETYPE extends NodeType>(
-    data: FunctionDefSpec<NODETYPE>,
+export default function defineFunction<
+    NODETYPE extends NodeType,
+    const NAMES extends readonly string[],
+>(
+    data: FunctionDefSpec<NODETYPE, NAMES>,
 ) {
     const {type, names, htmlBuilder, mathmlBuilder} = data;
     for (let i = 0; i < names.length; ++i) {

--- a/src/environments/array.ts
+++ b/src/environments/array.ts
@@ -1121,11 +1121,10 @@ defineMacro("\\notag", "\\nonumber");
 defineFunction({
     type: "text", // Doesn't matter what this is.
     names: ["\\hline", "\\hdashline"],
-    props: {
-        numArgs: 0,
-        allowedInText: true,
-        allowedInMath: true,
-    },
+    numArgs: 0,
+    allowedInText: true,
+    allowedInMath: true,
+
     handler(context, args) {
         throw new ParseError(
             `${context.funcName} valid only within array environment`);

--- a/src/environments/cd.ts
+++ b/src/environments/cd.ts
@@ -245,17 +245,15 @@ export function parseCD(parser: Parser): ParseNode<"array"> {
 // We don't need any such functions for horizontal arrows because we can reuse
 // the functionality that already exists for extensible arrows.
 
-type CDLabelFunctionName = "\\\\cdleft" | "\\\\cdright";
-
 defineFunction({
     type: "cdlabel",
-    names: ["\\\\cdleft", "\\\\cdright"] satisfies CDLabelFunctionName[],
+    names: ["\\\\cdleft", "\\\\cdright"],
     numArgs: 1,
     handler({parser, funcName}, args) {
         return {
             type: "cdlabel",
             mode: parser.mode,
-            side: funcName.slice(4) as Slice4<CDLabelFunctionName>,
+            side: funcName.slice(4) as Slice4<typeof funcName>,
             label: args[0],
         };
     },

--- a/src/environments/cd.ts
+++ b/src/environments/cd.ts
@@ -250,9 +250,7 @@ type CDLabelFunctionName = "\\\\cdleft" | "\\\\cdright";
 defineFunction({
     type: "cdlabel",
     names: ["\\\\cdleft", "\\\\cdright"] satisfies CDLabelFunctionName[],
-    props: {
-        numArgs: 1,
-    },
+    numArgs: 1,
     handler({parser, funcName}, args) {
         return {
             type: "cdlabel",
@@ -261,6 +259,7 @@ defineFunction({
             label: args[0],
         };
     },
+
     htmlBuilder(group, options) {
         const newOptions = options.havingStyle(options.style.sup());
         const label = wrapFragment(
@@ -294,9 +293,8 @@ defineFunction({
 defineFunction({
     type: "cdlabelparent",
     names: ["\\\\cdparent"],
-    props: {
-        numArgs: 1,
-    },
+    numArgs: 1,
+
     handler({parser}, args) {
         return {
             type: "cdlabelparent",
@@ -304,6 +302,7 @@ defineFunction({
             fragment: args[0],
         };
     },
+
     htmlBuilder(group, options) {
         // Wrap the vertical arrow and its labels.
         // The parent gets position: relative. The child gets position: absolute.

--- a/src/functions/accent.ts
+++ b/src/functions/accent.ts
@@ -223,9 +223,8 @@ defineFunction({
         "\\Overrightarrow", "\\overleftrightarrow", "\\overgroup",
         "\\overlinesegment", "\\overleftharpoon", "\\overrightharpoon",
     ],
-    props: {
-        numArgs: 1,
-    },
+    numArgs: 1,
+
     handler: (context, args) => {
         const base = normalizeArgument(args[0]);
 
@@ -244,6 +243,7 @@ defineFunction({
             base: base,
         };
     },
+
     htmlBuilder,
     mathmlBuilder,
 });
@@ -255,12 +255,11 @@ defineFunction({
         "\\'", "\\`", "\\^", "\\~", "\\=", "\\u", "\\.", '\\"',
         "\\c", "\\r", "\\H", "\\v", "\\textcircled",
     ],
-    props: {
-        numArgs: 1,
-        allowedInText: true,
-        allowedInMath: true, // unless in strict mode
-        argTypes: ["primitive"],
-    },
+    numArgs: 1,
+    allowedInText: true,
+    allowedInMath: true, // unless in strict mode
+    argTypes: ["primitive"],
+
     handler: (context, args) => {
         const base = args[0];
         let mode = context.parser.mode;
@@ -280,6 +279,4 @@ defineFunction({
             base: base,
         };
     },
-    htmlBuilder,
-    mathmlBuilder,
 });

--- a/src/functions/accentunder.ts
+++ b/src/functions/accentunder.ts
@@ -15,9 +15,8 @@ defineFunction({
         "\\underleftarrow", "\\underrightarrow", "\\underleftrightarrow",
         "\\undergroup", "\\underlinesegment", "\\utilde",
     ],
-    props: {
-        numArgs: 1,
-    },
+    numArgs: 1,
+
     handler: ({parser, funcName}, args) => {
         const base = args[0];
         return {
@@ -27,6 +26,7 @@ defineFunction({
             base: base,
         };
     },
+
     htmlBuilder: (group: ParseNode<"accentUnder">, options) => {
         // Treat under accents much like underlines.
         const innerGroup = html.buildGroup(group.base, options);

--- a/src/functions/arrow.ts
+++ b/src/functions/arrow.ts
@@ -33,10 +33,9 @@ defineFunction({
         // The next 3 functions are here only to support the {CD} environment.
         "\\\\cdrightarrow", "\\\\cdleftarrow", "\\\\cdlongequal",
     ],
-    props: {
-        numArgs: 1,
-        numOptionalArgs: 1,
-    },
+    numArgs: 1,
+    numOptionalArgs: 1,
+
     handler({parser, funcName}, args, optArgs) {
         return {
             type: "xArrow",
@@ -46,6 +45,7 @@ defineFunction({
             below: optArgs[0],
         };
     },
+
     htmlBuilder(group: ParseNode<"xArrow">, options) {
         const style = options.style;
 

--- a/src/functions/char.ts
+++ b/src/functions/char.ts
@@ -8,10 +8,9 @@ import {assertNodeType} from "../parseNode";
 defineFunction({
     type: "textord",
     names: ["\\@char"],
-    props: {
-        numArgs: 1,
-        allowedInText: true,
-    },
+    numArgs: 1,
+    allowedInText: true,
+
     handler({parser}, args) {
         const arg = assertNodeType(args[0], "ordgroup");
         const group = arg.body;

--- a/src/functions/color.ts
+++ b/src/functions/color.ts
@@ -36,11 +36,10 @@ const mathmlBuilder: MathMLBuilder<"color"> = (group, options) => {
 defineFunction({
     type: "color",
     names: ["\\textcolor"],
-    props: {
-        numArgs: 2,
-        allowedInText: true,
-        argTypes: ["color", "original"],
-    },
+    numArgs: 2,
+    allowedInText: true,
+    argTypes: ["color", "original"],
+
     handler({parser}, args) {
         const color = assertNodeType(args[0], "color-token").color;
         const body = args[1];
@@ -51,6 +50,7 @@ defineFunction({
             body: (ordargument(body) as AnyParseNode[]),
         };
     },
+
     htmlBuilder,
     mathmlBuilder,
 });
@@ -58,11 +58,10 @@ defineFunction({
 defineFunction({
     type: "color",
     names: ["\\color"],
-    props: {
-        numArgs: 1,
-        allowedInText: true,
-        argTypes: ["color"],
-    },
+    numArgs: 1,
+    allowedInText: true,
+    argTypes: ["color"],
+
     handler({parser, breakOnTokenText}, args) {
         const color = assertNodeType(args[0], "color-token").color;
 
@@ -82,6 +81,4 @@ defineFunction({
             body,
         };
     },
-    htmlBuilder,
-    mathmlBuilder,
 });

--- a/src/functions/cr.ts
+++ b/src/functions/cr.ts
@@ -10,11 +10,10 @@ import {assertNodeType} from "../parseNode";
 defineFunction({
     type: "cr",
     names: ["\\\\"],
-    props: {
-        numArgs: 0,
-        numOptionalArgs: 0,
-        allowedInText: true,
-    },
+    numArgs: 0,
+    numOptionalArgs: 0,
+    allowedInText: true,
+
 
     handler({parser}, args, optArgs) {
         const size = parser.gullet.future().text === "[" ?
@@ -45,6 +44,7 @@ defineFunction({
         }
         return span;
     },
+
 
     mathmlBuilder(group, options) {
         const node = new MathNode("mspace");

--- a/src/functions/cr.ts
+++ b/src/functions/cr.ts
@@ -14,7 +14,6 @@ defineFunction({
     numOptionalArgs: 0,
     allowedInText: true,
 
-
     handler({parser}, args, optArgs) {
         const size = parser.gullet.future().text === "[" ?
             parser.parseSizeGroup(true) : null;
@@ -44,7 +43,6 @@ defineFunction({
         }
         return span;
     },
-
 
     mathmlBuilder(group, options) {
         const node = new MathNode("mspace");

--- a/src/functions/def.ts
+++ b/src/functions/def.ts
@@ -62,10 +62,9 @@ defineFunction({
         "\\global", "\\long",
         "\\\\globallong", // can’t be entered directly
     ],
-    props: {
-        numArgs: 0,
-        allowedInText: true,
-    },
+    numArgs: 0,
+    allowedInText: true,
+
     handler({parser, funcName}) {
         parser.consumeSpaces();
         const token = parser.fetch();
@@ -87,11 +86,10 @@ defineFunction({
 defineFunction({
     type: "internal",
     names: ["\\def", "\\gdef", "\\edef", "\\xdef"],
-    props: {
-        numArgs: 0,
-        allowedInText: true,
-        primitive: true,
-    },
+    numArgs: 0,
+    allowedInText: true,
+    primitive: true,
+
     handler({parser, funcName}) {
         let tok = parser.gullet.popToken();
         const name = tok.text;
@@ -168,11 +166,10 @@ defineFunction({
         "\\let",
         "\\\\globallet", // can’t be entered directly
     ],
-    props: {
-        numArgs: 0,
-        allowedInText: true,
-        primitive: true,
-    },
+    numArgs: 0,
+    allowedInText: true,
+    primitive: true,
+
     handler({parser, funcName}) {
         const name = checkControlSequence(parser.gullet.popToken());
         parser.gullet.consumeSpaces();
@@ -192,11 +189,10 @@ defineFunction({
         "\\futurelet",
         "\\\\globalfuture", // can’t be entered directly
     ],
-    props: {
-        numArgs: 0,
-        allowedInText: true,
-        primitive: true,
-    },
+    numArgs: 0,
+    allowedInText: true,
+    primitive: true,
+
     handler({parser, funcName}) {
         const name = checkControlSequence(parser.gullet.popToken());
         const middle = parser.gullet.popToken();

--- a/src/functions/delimsizing.ts
+++ b/src/functions/delimsizing.ts
@@ -92,10 +92,9 @@ defineFunction({
         "\\bigm", "\\Bigm", "\\biggm", "\\Biggm",
         "\\big",  "\\Big",  "\\bigg",  "\\Bigg",
     ],
-    props: {
-        numArgs: 1,
-        argTypes: ["primitive"],
-    },
+    numArgs: 1,
+    argTypes: ["primitive"],
+
     handler: (context, args) => {
         const delim = checkDelimiter(args[0], context);
 
@@ -107,6 +106,7 @@ defineFunction({
             delim: delim.text,
         };
     },
+
     htmlBuilder: (group, options) => {
         if (group.delim === ".") {
             // Empty delimiters still count as elements, even though they don't
@@ -157,10 +157,9 @@ function assertParsed(group: ParseNode<"leftright">) {
 defineFunction({
     type: "leftright-right",
     names: ["\\right"],
-    props: {
-        numArgs: 1,
-        primitive: true,
-    },
+    numArgs: 1,
+    primitive: true,
+
     handler: (context, args) => {
         // \left case below triggers parsing of \right in
         //   `const right = parser.parseFunction();`
@@ -183,10 +182,9 @@ defineFunction({
 defineFunction({
     type: "leftright",
     names: ["\\left"],
-    props: {
-        numArgs: 1,
-        primitive: true,
-    },
+    numArgs: 1,
+    primitive: true,
+
     handler: (context, args) => {
         const delim = checkDelimiter(args[0], context);
 
@@ -208,6 +206,7 @@ defineFunction({
             rightColor: right.color,
         };
     },
+
     htmlBuilder: (group, options) => {
         assertParsed(group);
         // Build the inner expression
@@ -312,10 +311,9 @@ defineFunction({
 defineFunction({
     type: "middle",
     names: ["\\middle"],
-    props: {
-        numArgs: 1,
-        primitive: true,
-    },
+    numArgs: 1,
+    primitive: true,
+
     handler: (context, args) => {
         const delim = checkDelimiter(args[0], context);
         if (!context.parser.leftrightDepth) {
@@ -328,6 +326,7 @@ defineFunction({
             delim: delim.text,
         };
     },
+
     htmlBuilder: (group, options) => {
         let middleDelim;
         if (group.delim === ".") {

--- a/src/functions/delimsizing.ts
+++ b/src/functions/delimsizing.ts
@@ -15,10 +15,7 @@ import type {HtmlDomNode} from "../domTree";
 import type {AnyParseNode, ParseNode, SymbolParseNode} from "../types/nodes";
 
 // Extra data needed for the delimiter handler down below
-const delimiterSizes: Record<string, {
-    mclass: "mopen" | "mclose" | "mrel" | "mord";
-    size: 1 | 2 | 3 | 4;
-}> = {
+const delimiterSizes = {
     "\\bigl" : {mclass: "mopen",    size: 1},
     "\\Bigl" : {mclass: "mopen",    size: 2},
     "\\biggl": {mclass: "mopen",    size: 3},
@@ -35,7 +32,10 @@ const delimiterSizes: Record<string, {
     "\\Big"  : {mclass: "mord",     size: 2},
     "\\bigg" : {mclass: "mord",     size: 3},
     "\\Bigg" : {mclass: "mord",     size: 4},
-};
+} as const satisfies Record<string, {
+    mclass: "mopen" | "mclose" | "mrel" | "mord";
+    size: 1 | 2 | 3 | 4;
+}>;
 
 const delimiters = new Set([
     "(", "\\lparen", ")", "\\rparen",

--- a/src/functions/delimsizing.ts
+++ b/src/functions/delimsizing.ts
@@ -12,6 +12,7 @@ import * as mml from "../buildMathML";
 import type Options from "../Options";
 import type {FunctionContext} from "../defineFunction";
 import type {HtmlDomNode} from "../domTree";
+import type {DelimiterSize, MathClass} from "../types";
 import type {AnyParseNode, ParseNode, SymbolParseNode} from "../types/nodes";
 
 // Extra data needed for the delimiter handler down below
@@ -33,8 +34,8 @@ const delimiterSizes = {
     "\\bigg" : {mclass: "mord",     size: 3},
     "\\Bigg" : {mclass: "mord",     size: 4},
 } as const satisfies Record<string, {
-    mclass: "mopen" | "mclose" | "mrel" | "mord";
-    size: 1 | 2 | 3 | 4;
+    mclass: MathClass;
+    size: DelimiterSize;
 }>;
 
 const delimiters = new Set([

--- a/src/functions/enclose.ts
+++ b/src/functions/enclose.ts
@@ -220,11 +220,10 @@ const mathmlBuilder: MathMLBuilder<"enclose"> = (group, options) => {
 defineFunction({
     type: "enclose",
     names: ["\\colorbox"],
-    props: {
-        numArgs: 2,
-        allowedInText: true,
-        argTypes: ["color", "hbox"],
-    },
+    numArgs: 2,
+    allowedInText: true,
+    argTypes: ["color", "hbox"],
+
     handler({parser, funcName}, args, optArgs) {
         const color = assertNodeType(args[0], "color-token").color;
         const body = args[1];
@@ -236,6 +235,7 @@ defineFunction({
             body,
         };
     },
+
     htmlBuilder,
     mathmlBuilder,
 });
@@ -243,11 +243,10 @@ defineFunction({
 defineFunction({
     type: "enclose",
     names: ["\\fcolorbox"],
-    props: {
-        numArgs: 3,
-        allowedInText: true,
-        argTypes: ["color", "color", "hbox"],
-    },
+    numArgs: 3,
+    allowedInText: true,
+    argTypes: ["color", "color", "hbox"],
+
     handler({parser, funcName}, args, optArgs) {
         const borderColor = assertNodeType(args[0], "color-token").color;
         const backgroundColor = assertNodeType(args[1], "color-token").color;
@@ -261,18 +260,15 @@ defineFunction({
             body,
         };
     },
-    htmlBuilder,
-    mathmlBuilder,
 });
 
 defineFunction({
     type: "enclose",
     names: ["\\fbox"],
-    props: {
-        numArgs: 1,
-        argTypes: ["hbox"],
-        allowedInText: true,
-    },
+    numArgs: 1,
+    argTypes: ["hbox"],
+    allowedInText: true,
+
     handler({parser}, args) {
         return {
             type: "enclose",
@@ -286,9 +282,8 @@ defineFunction({
 defineFunction({
     type: "enclose",
     names: ["\\cancel", "\\bcancel", "\\xcancel", "\\phase"],
-    props: {
-        numArgs: 1,
-    },
+    numArgs: 1,
+
     handler({parser, funcName}, args) {
         const body = args[0];
         return {
@@ -298,17 +293,14 @@ defineFunction({
             body,
         };
     },
-    htmlBuilder,
-    mathmlBuilder,
 });
 
 defineFunction({
     type: "enclose",
     names: ["\\sout"],
-    props: {
-        numArgs: 1,
-        allowedInText: true,
-    },
+    numArgs: 1,
+    allowedInText: true,
+
     handler({parser, funcName}, args) {
         if (parser.mode === "math") {
             parser.settings.reportNonstrict("mathVsSout",
@@ -322,18 +314,15 @@ defineFunction({
             body,
         };
     },
-    htmlBuilder,
-    mathmlBuilder,
 });
 
 defineFunction({
     type: "enclose",
     names: ["\\angl"],
-    props: {
-        numArgs: 1,
-        argTypes: ["hbox"],
-        allowedInText: false,
-    },
+    numArgs: 1,
+    argTypes: ["hbox"],
+    allowedInText: false,
+
     handler({parser}, args) {
         return {
             type: "enclose",

--- a/src/functions/environment.ts
+++ b/src/functions/environment.ts
@@ -10,10 +10,9 @@ import type {ParseNode} from "../types/nodes";
 defineFunction({
     type: "environment",
     names: ["\\begin", "\\end"],
-    props: {
-        numArgs: 1,
-        argTypes: ["text"],
-    },
+    numArgs: 1,
+    argTypes: ["text"],
+
     handler({parser, funcName}, args) {
         const nameGroup = args[0];
         if (nameGroup.type !== "ordgroup") {

--- a/src/functions/font.ts
+++ b/src/functions/font.ts
@@ -29,13 +29,6 @@ const fontAliases = {
     "\\frak": "\\mathfrak",
 } as const;
 
-type FontCommands =
-    "\\mathrm" | "\\mathit" | "\\mathbf" | "\\mathnormal" | "\\mathsfit" |
-    "\\mathbb" | "\\mathcal" | "\\mathfrak" | "\\mathscr" | "\\mathsf" |
-    "\\mathtt";
-
-type OldFontCommands = "\\rm" | "\\sf" | "\\tt" | "\\bf" | "\\it" | "\\cal";
-
 defineFunction({
     type: "font",
     names: [
@@ -48,20 +41,19 @@ defineFunction({
 
         // aliases, except \bm defined below
         "\\Bbb", "\\bold", "\\frak",
-    ] satisfies (FontCommands | keyof typeof fontAliases)[],
+    ],
     numArgs: 1,
     allowedInArgument: true,
 
     handler: ({parser, funcName}, args) => {
         const body = normalizeArgument(args[0]);
-        let func = funcName;
-        if (func in fontAliases) {
-            func = fontAliases[func as keyof typeof fontAliases];
-        }
+        const func = funcName in fontAliases
+            ? fontAliases[funcName as keyof typeof fontAliases]
+            : funcName as Exclude<typeof funcName, keyof typeof fontAliases>;
         return {
             type: "font",
             mode: parser.mode,
-            font: func.slice(1) as Slice1<FontCommands>,
+            font: func.slice(1) as Slice1<typeof func>,
             body,
         };
     },
@@ -99,7 +91,7 @@ defineFunction({
 // Old font changing functions
 defineFunction({
     type: "font",
-    names: ["\\rm", "\\sf", "\\tt", "\\bf", "\\it", "\\cal"] satisfies OldFontCommands[],
+    names: ["\\rm", "\\sf", "\\tt", "\\bf", "\\it", "\\cal"],
     numArgs: 0,
     allowedInText: true,
     handler: ({parser, funcName, breakOnTokenText}, args) => {
@@ -109,7 +101,7 @@ defineFunction({
         return {
             type: "font",
             mode: mode,
-            font: `math${funcName.slice(1) as Slice1<OldFontCommands>}` as const,
+            font: `math${funcName.slice(1) as Slice1<typeof funcName>}` as const,
             body: {
                 type: "ordgroup",
                 mode: parser.mode,

--- a/src/functions/font.ts
+++ b/src/functions/font.ts
@@ -49,10 +49,9 @@ defineFunction({
         // aliases, except \bm defined below
         "\\Bbb", "\\bold", "\\frak",
     ] satisfies (FontCommands | keyof typeof fontAliases)[],
-    props: {
-        numArgs: 1,
-        allowedInArgument: true,
-    },
+    numArgs: 1,
+    allowedInArgument: true,
+
     handler: ({parser, funcName}, args) => {
         const body = normalizeArgument(args[0]);
         let func = funcName;
@@ -66,6 +65,7 @@ defineFunction({
             body,
         };
     },
+
     htmlBuilder,
     mathmlBuilder,
 });
@@ -73,9 +73,8 @@ defineFunction({
 defineFunction({
     type: "mclass",
     names: ["\\boldsymbol", "\\bm"],
-    props: {
-        numArgs: 1,
-    },
+    numArgs: 1,
+
     handler: ({parser}, args) => {
         const body = args[0];
         // amsbsy.sty's \boldsymbol uses \binrel spacing to inherit the
@@ -101,10 +100,8 @@ defineFunction({
 defineFunction({
     type: "font",
     names: ["\\rm", "\\sf", "\\tt", "\\bf", "\\it", "\\cal"] satisfies OldFontCommands[],
-    props: {
-        numArgs: 0,
-        allowedInText: true,
-    },
+    numArgs: 0,
+    allowedInText: true,
     handler: ({parser, funcName, breakOnTokenText}, args) => {
         const {mode} = parser;
         const body = parser.parseExpression(true, breakOnTokenText);
@@ -120,6 +117,4 @@ defineFunction({
             },
         };
     },
-    htmlBuilder,
-    mathmlBuilder,
 });

--- a/src/functions/genfrac.ts
+++ b/src/functions/genfrac.ts
@@ -239,10 +239,9 @@ defineFunction({
         "\\\\atopfrac", // can’t be entered directly
         "\\\\bracefrac", "\\\\brackfrac",   // ditto
     ],
-    props: {
-        numArgs: 2,
-        allowedInArgument: true,
-    },
+    numArgs: 2,
+    allowedInArgument: true,
+
     handler: ({parser, funcName}, args) => {
         const numer = args[0];
         const denom = args[1];
@@ -302,6 +301,7 @@ defineFunction({
         }, style);
     },
 
+
     htmlBuilder,
     mathmlBuilder,
 });
@@ -311,10 +311,9 @@ defineFunction({
 defineFunction({
     type: "infix",
     names: ["\\over", "\\choose", "\\atop", "\\brace", "\\brack"],
-    props: {
-        numArgs: 0,
-        infix: true,
-    },
+    numArgs: 0,
+    infix: true,
+
     handler({parser, funcName, token}) {
         let replaceWith;
         switch (funcName) {
@@ -359,11 +358,10 @@ const delimFromValue = function(delimString: string): string | null {
 defineFunction({
     type: "genfrac",
     names: ["\\genfrac"],
-    props: {
-        numArgs: 6,
-        allowedInArgument: true,
-        argTypes: ["math", "math", "size", "text", "math", "math"],
-    },
+    numArgs: 6,
+    allowedInArgument: true,
+    argTypes: ["math", "math", "size", "text", "math", "math"],
+
     handler({parser}, args) {
         const numer = args[4];
         const denom = args[5];
@@ -420,11 +418,10 @@ defineFunction({
 defineFunction({
     type: "infix",
     names: ["\\above"],
-    props: {
-        numArgs: 1,
-        argTypes: ["size"],
-        infix: true,
-    },
+    numArgs: 1,
+    argTypes: ["size"],
+    infix: true,
+
     handler({parser, funcName, token}, args) {
         return {
             type: "infix",
@@ -439,10 +436,9 @@ defineFunction({
 defineFunction({
     type: "genfrac",
     names: ["\\\\abovefrac"],
-    props: {
-        numArgs: 3,
-        argTypes: ["math", "size", "math"],
-    },
+    numArgs: 3,
+    argTypes: ["math", "size", "math"],
+
     handler: ({parser, funcName}, args) => {
         const numer = args[0];
         const barSize = assertNodeType(args[1], "infix").size;

--- a/src/functions/hbox.ts
+++ b/src/functions/hbox.ts
@@ -13,12 +13,11 @@ import * as mml from "../buildMathML";
 defineFunction({
     type: "hbox",
     names: ["\\hbox"],
-    props: {
-        numArgs: 1,
-        argTypes: ["text"],
-        allowedInText: true,
-        primitive: true,
-    },
+    numArgs: 1,
+    argTypes: ["text"],
+    allowedInText: true,
+    primitive: true,
+
     handler({parser}, args) {
         return {
             type: "hbox",
@@ -26,6 +25,7 @@ defineFunction({
             body: ordargument(args[0]),
         };
     },
+
     htmlBuilder(group, options) {
         const elements = html.buildExpression(group.body, options.withFont(''), false);
         return makeFragment(elements);

--- a/src/functions/horizBrace.ts
+++ b/src/functions/horizBrace.ts
@@ -117,9 +117,8 @@ const mathmlBuilder: MathMLBuilder<"horizBrace"> = (group, options) => {
 defineFunction({
     type: "horizBrace",
     names: ["\\overbrace", "\\underbrace", "\\overbracket", "\\underbracket"],
-    props: {
-        numArgs: 1,
-    },
+    numArgs: 1,
+
     handler({parser, funcName}, args) {
         return {
             type: "horizBrace",
@@ -129,6 +128,7 @@ defineFunction({
             base: args[0],
         };
     },
+
     htmlBuilder,
     mathmlBuilder,
 });

--- a/src/functions/href.ts
+++ b/src/functions/href.ts
@@ -10,11 +10,10 @@ import type {ParseNode} from "../types/nodes";
 defineFunction({
     type: "href",
     names: ["\\href"],
-    props: {
-        numArgs: 2,
-        argTypes: ["url", "original"],
-        allowedInText: true,
-    },
+    numArgs: 2,
+    argTypes: ["url", "original"],
+    allowedInText: true,
+
     handler: ({parser}, args) => {
         const body = args[1];
         const href = assertNodeType(args[0], "url").url;
@@ -33,6 +32,7 @@ defineFunction({
             body: ordargument(body),
         };
     },
+
     htmlBuilder: (group, options) => {
         const elements = html.buildExpression(group.body, options, false);
         return makeAnchor(group.href, [], elements, options);
@@ -50,11 +50,10 @@ defineFunction({
 defineFunction({
     type: "href",
     names: ["\\url"],
-    props: {
-        numArgs: 1,
-        argTypes: ["url"],
-        allowedInText: true,
-    },
+    numArgs: 1,
+    argTypes: ["url"],
+    allowedInText: true,
+
     handler: ({parser}, args) => {
         const href = assertNodeType(args[0], "url").url;
 

--- a/src/functions/html.ts
+++ b/src/functions/html.ts
@@ -10,11 +10,10 @@ import type {AnyTrustContext} from "../Settings";
 defineFunction({
     type: "html",
     names: ["\\htmlClass", "\\htmlId", "\\htmlStyle", "\\htmlData"],
-    props: {
-        numArgs: 2,
-        argTypes: ["raw", "original"],
-        allowedInText: true,
-    },
+    numArgs: 2,
+    argTypes: ["raw", "original"],
+    allowedInText: true,
+
     handler: ({parser, funcName, token}, args) => {
         const value = assertNodeType(args[0], "raw").string;
         const body = args[1];
@@ -83,6 +82,7 @@ defineFunction({
             body: ordargument(body),
         };
     },
+
     htmlBuilder: (group, options) => {
         const elements = html.buildExpression(group.body, options, false);
 

--- a/src/functions/htmlmathml.ts
+++ b/src/functions/htmlmathml.ts
@@ -7,11 +7,10 @@ import * as mml from "../buildMathML";
 defineFunction({
     type: "htmlmathml",
     names: ["\\html@mathml"],
-    props: {
-        numArgs: 2,
-        allowedInArgument: true,
-        allowedInText: true,
-    },
+    numArgs: 2,
+    allowedInArgument: true,
+    allowedInText: true,
+
     handler: ({parser}, args) => {
         return {
             type: "htmlmathml",
@@ -20,6 +19,7 @@ defineFunction({
             mathml: ordargument(args[1]),
         };
     },
+
     htmlBuilder: (group, options) => {
         const elements = html.buildExpression(
             group.html,

--- a/src/functions/includegraphics.ts
+++ b/src/functions/includegraphics.ts
@@ -33,12 +33,11 @@ const sizeData = function(str: string): Measurement {
 defineFunction({
     type: "includegraphics",
     names: ["\\includegraphics"],
-    props: {
-        numArgs: 1,
-        numOptionalArgs: 1,
-        argTypes: ["raw", "url"],
-        allowedInText: false,
-    },
+    numArgs: 1,
+    numOptionalArgs: 1,
+    argTypes: ["raw", "url"],
+    allowedInText: false,
+
     handler: ({parser}, args, optArgs) => {
         let width = {number: 0, unit: "em"};
         let height = {number: 0.9, unit: "em"};    // sorta character sized.
@@ -101,6 +100,7 @@ defineFunction({
             src: src,
         };
     },
+
     htmlBuilder: (group, options) => {
         const height = calculateSize(group.height, options);
         let depth = 0;

--- a/src/functions/kern.ts
+++ b/src/functions/kern.ts
@@ -11,12 +11,11 @@ import {assertNodeType} from "../parseNode";
 defineFunction({
     type: "kern",
     names: ["\\kern", "\\mkern", "\\hskip", "\\mskip"],
-    props: {
-        numArgs: 1,
-        argTypes: ["size"],
-        primitive: true,
-        allowedInText: true,
-    },
+    numArgs: 1,
+    argTypes: ["size"],
+    primitive: true,
+    allowedInText: true,
+
     handler({parser, funcName}, args) {
         const size = assertNodeType(args[0], "size");
         if (parser.settings.strict) {
@@ -45,6 +44,7 @@ defineFunction({
             dimension: size.value,
         };
     },
+
     htmlBuilder(group, options) {
         return makeGlue(group.dimension, options);
     },

--- a/src/functions/lap.ts
+++ b/src/functions/lap.ts
@@ -10,10 +10,9 @@ import * as mml from "../buildMathML";
 defineFunction({
     type: "lap",
     names: ["\\mathllap", "\\mathrlap", "\\mathclap"],
-    props: {
-        numArgs: 1,
-        allowedInText: true,
-    },
+    numArgs: 1,
+    allowedInText: true,
+
     handler: ({parser, funcName}, args) => {
         const body = args[0];
         return {
@@ -23,6 +22,7 @@ defineFunction({
             body,
         };
     },
+
     htmlBuilder: (group, options) => {
         // mathllap, mathrlap, mathclap
         let inner;

--- a/src/functions/math.ts
+++ b/src/functions/math.ts
@@ -5,11 +5,10 @@ import ParseError from "../ParseError";
 defineFunction({
     type: "styling",
     names: ["\\(", "$"],
-    props: {
-        numArgs: 0,
-        allowedInText: true,
-        allowedInMath: false,
-    },
+    numArgs: 0,
+    allowedInText: true,
+    allowedInMath: false,
+
     handler({funcName, parser}, args) {
         const outerMode = parser.mode;
         parser.switchMode("math");
@@ -31,11 +30,10 @@ defineFunction({
 defineFunction({
     type: "text", // Doesn't matter what this is.
     names: ["\\)", "\\]"],
-    props: {
-        numArgs: 0,
-        allowedInText: true,
-        allowedInMath: false,
-    },
+    numArgs: 0,
+    allowedInText: true,
+    allowedInMath: false,
+
     handler(context, args) {
         throw new ParseError(`Mismatched ${context.funcName}`);
     },

--- a/src/functions/mathchoice.ts
+++ b/src/functions/mathchoice.ts
@@ -21,10 +21,9 @@ const chooseMathStyle = (group: ParseNode<"mathchoice">, options: Options) => {
 defineFunction({
     type: "mathchoice",
     names: ["\\mathchoice"],
-    props: {
-        numArgs: 4,
-        primitive: true,
-    },
+    numArgs: 4,
+    primitive: true,
+
     handler: ({parser}, args) => {
         return {
             type: "mathchoice",
@@ -35,6 +34,7 @@ defineFunction({
             scriptscript: ordargument(args[3]),
         };
     },
+
     htmlBuilder: (group, options) => {
         const body = chooseMathStyle(group, options);
         const elements = html.buildExpression(

--- a/src/functions/mclass.ts
+++ b/src/functions/mclass.ts
@@ -65,10 +65,8 @@ defineFunction({
         "\\mathord", "\\mathbin", "\\mathrel", "\\mathopen",
         "\\mathclose", "\\mathpunct", "\\mathinner",
     ] satisfies MathClassCommand[],
-    props: {
-        numArgs: 1,
-        primitive: true,
-    },
+    numArgs: 1,
+    primitive: true,
     handler({parser, funcName}, args) {
         const body = args[0];
         return {
@@ -79,6 +77,7 @@ defineFunction({
             isCharacterBox: isCharacterBox(body),
         };
     },
+
     htmlBuilder,
     mathmlBuilder,
 });
@@ -101,9 +100,8 @@ export const binrelClass = (arg: AnyParseNode): MathClass => {
 defineFunction({
     type: "mclass",
     names: ["\\@binrel"],
-    props: {
-        numArgs: 2,
-    },
+    numArgs: 2,
+
     handler({parser}, args) {
         return {
             type: "mclass",
@@ -119,9 +117,8 @@ defineFunction({
 defineFunction({
     type: "mclass",
     names: ["\\stackrel", "\\overset", "\\underset"],
-    props: {
-        numArgs: 2,
-    },
+    numArgs: 2,
+
     handler({parser, funcName}, args) {
         const baseArg = args[1];
         const shiftedArg = args[0];
@@ -157,6 +154,4 @@ defineFunction({
             isCharacterBox: isCharacterBox(supsub),
         };
     },
-    htmlBuilder,
-    mathmlBuilder,
 });

--- a/src/functions/mclass.ts
+++ b/src/functions/mclass.ts
@@ -54,17 +54,13 @@ function mathmlBuilder(group: ParseNode<"mclass">, options: Options) {
     return node;
 }
 
-type MathClassCommand =
-    "\\mathord" | "\\mathbin" | "\\mathrel" | "\\mathopen" |
-    "\\mathclose" | "\\mathpunct" | "\\mathinner";
-
 // Math class commands except \mathop
 defineFunction({
     type: "mclass",
     names: [
         "\\mathord", "\\mathbin", "\\mathrel", "\\mathopen",
         "\\mathclose", "\\mathpunct", "\\mathinner",
-    ] satisfies MathClassCommand[],
+    ],
     numArgs: 1,
     primitive: true,
     handler({parser, funcName}, args) {
@@ -72,7 +68,7 @@ defineFunction({
         return {
             type: "mclass",
             mode: parser.mode,
-            mclass: `m${funcName.slice(5) as Slice5<MathClassCommand>}`,
+            mclass: `m${funcName.slice(5) as Slice5<typeof funcName>}`,
             body: ordargument(body),
             isCharacterBox: isCharacterBox(body),
         };

--- a/src/functions/op.ts
+++ b/src/functions/op.ts
@@ -203,7 +203,7 @@ defineFunction({
     numArgs: 0,
 
     handler: ({parser, funcName}, args) => {
-        let fName = funcName;
+        let fName: string = funcName;
         if (fName.length === 1) {
             fName = singleCharBigOps[fName];
         }
@@ -307,7 +307,7 @@ defineFunction({
     allowedInArgument: true,
 
     handler({parser, funcName}) {
-        let fName = funcName;
+        let fName: string = funcName;
         if (fName.length === 1) {
             fName = singleCharIntegrals[fName];
         }

--- a/src/functions/op.ts
+++ b/src/functions/op.ts
@@ -200,9 +200,8 @@ defineFunction({
         "\u2210", "\u2211", "\u22c0", "\u22c1", "\u22c2", "\u22c3", "\u2a00",
         "\u2a01", "\u2a02", "\u2a04", "\u2a06",
     ],
-    props: {
-        numArgs: 0,
-    },
+    numArgs: 0,
+
     handler: ({parser, funcName}, args) => {
         let fName = funcName;
         if (fName.length === 1) {
@@ -217,19 +216,17 @@ defineFunction({
             name: fName,
         };
     },
+
     htmlBuilder,
     mathmlBuilder,
 });
 
-// Note: calling defineFunction with a type that's already been defined only
-// works because the same htmlBuilder and mathmlBuilder are being used.
 defineFunction({
     type: "op",
     names: ["\\mathop"],
-    props: {
-        numArgs: 1,
-        primitive: true,
-    },
+    numArgs: 1,
+    primitive: true,
+
     handler: ({parser}, args) => {
         const body = args[0];
         return {
@@ -241,8 +238,6 @@ defineFunction({
             body: ordargument(body),
         };
     },
-    htmlBuilder,
-    mathmlBuilder,
 });
 
 // There are 2 flags for operators; whether they produce limits in
@@ -267,9 +262,8 @@ defineFunction({
         "\\hom", "\\ker", "\\lg", "\\ln", "\\log", "\\sec", "\\sin",
         "\\sinh", "\\sh", "\\tan", "\\tanh", "\\tg", "\\th",
     ],
-    props: {
-        numArgs: 0,
-    },
+    numArgs: 0,
+
     handler({parser, funcName}) {
         return {
             type: "op",
@@ -280,8 +274,6 @@ defineFunction({
             name: funcName,
         };
     },
-    htmlBuilder,
-    mathmlBuilder,
 });
 
 // Limits, not symbols
@@ -290,9 +282,8 @@ defineFunction({
     names: [
         "\\det", "\\gcd", "\\inf", "\\lim", "\\max", "\\min", "\\Pr", "\\sup",
     ],
-    props: {
-        numArgs: 0,
-    },
+    numArgs: 0,
+
     handler({parser, funcName}) {
         return {
             type: "op",
@@ -303,8 +294,6 @@ defineFunction({
             name: funcName,
         };
     },
-    htmlBuilder,
-    mathmlBuilder,
 });
 
 // No limits, symbols
@@ -314,10 +303,9 @@ defineFunction({
         "\\int", "\\iint", "\\iiint", "\\oint", "\\oiint", "\\oiiint",
         "\u222b", "\u222c", "\u222d", "\u222e", "\u222f", "\u2230",
     ],
-    props: {
-        numArgs: 0,
-        allowedInArgument: true,
-    },
+    numArgs: 0,
+    allowedInArgument: true,
+
     handler({parser, funcName}) {
         let fName = funcName;
         if (fName.length === 1) {
@@ -332,6 +320,4 @@ defineFunction({
             name: fName,
         };
     },
-    htmlBuilder,
-    mathmlBuilder,
 });

--- a/src/functions/operatorname.ts
+++ b/src/functions/operatorname.ts
@@ -139,9 +139,8 @@ const mathmlBuilder: MathMLBuilder<"operatorname"> = (group, options) => {
 defineFunction({
     type: "operatorname",
     names: ["\\operatorname@", "\\operatornamewithlimits"],
-    props: {
-        numArgs: 1,
-    },
+    numArgs: 1,
+
     handler: ({parser, funcName}, args) => {
         const body = args[0];
         return {
@@ -153,6 +152,7 @@ defineFunction({
             parentIsSupSub: false,
         };
     },
+
     htmlBuilder,
     mathmlBuilder,
 });

--- a/src/functions/overline.ts
+++ b/src/functions/overline.ts
@@ -8,9 +8,8 @@ import * as mml from "../buildMathML";
 defineFunction({
     type: "overline",
     names: ["\\overline"],
-    props: {
-        numArgs: 1,
-    },
+    numArgs: 1,
+
     handler({parser}, args) {
         const body = args[0];
         return {
@@ -19,6 +18,7 @@ defineFunction({
             body,
         };
     },
+
     htmlBuilder(group, options) {
         // Overlines are handled in the TeXbook pg 443, Rule 9.
 

--- a/src/functions/phantom.ts
+++ b/src/functions/phantom.ts
@@ -9,10 +9,9 @@ import * as mml from "../buildMathML";
 defineFunction({
     type: "phantom",
     names: ["\\phantom"],
-    props: {
-        numArgs: 1,
-        allowedInText: true,
-    },
+    numArgs: 1,
+    allowedInText: true,
+
     handler: ({parser}, args) => {
         const body = args[0];
         return {
@@ -21,6 +20,7 @@ defineFunction({
             body: ordargument(body),
         };
     },
+
     htmlBuilder: (group, options) => {
         const elements = html.buildExpression(
             group.body,
@@ -43,10 +43,9 @@ defineMacro("\\hphantom", "\\smash{\\phantom{#1}}");
 defineFunction({
     type: "vphantom",
     names: ["\\vphantom"],
-    props: {
-        numArgs: 1,
-        allowedInText: true,
-    },
+    numArgs: 1,
+    allowedInText: true,
+
     handler: ({parser}, args) => {
         const body = args[0];
         return {
@@ -55,6 +54,7 @@ defineFunction({
             body,
         };
     },
+
     htmlBuilder: (group, options) => {
         const inner = makeSpan(
             ["inner"],

--- a/src/functions/pmb.ts
+++ b/src/functions/pmb.ts
@@ -15,10 +15,9 @@ import type {ParseNode} from "../types/nodes";
 defineFunction({
     type: "pmb",
     names: ["\\pmb"],
-    props: {
-        numArgs: 1,
-        allowedInText: true,
-    },
+    numArgs: 1,
+    allowedInText: true,
+
     handler({parser}, args) {
         return {
             type: "pmb",
@@ -27,6 +26,7 @@ defineFunction({
             body: ordargument(args[0]),
         };
     },
+
     htmlBuilder(group: ParseNode<"pmb">, options) {
         const elements = html.buildExpression(group.body, options, true);
         const node = makeSpan([group.mclass], elements, options);

--- a/src/functions/raisebox.ts
+++ b/src/functions/raisebox.ts
@@ -11,11 +11,10 @@ import * as mml from "../buildMathML";
 defineFunction({
     type: "raisebox",
     names: ["\\raisebox"],
-    props: {
-        numArgs: 2,
-        argTypes: ["size", "hbox"],
-        allowedInText: true,
-    },
+    numArgs: 2,
+    argTypes: ["size", "hbox"],
+    allowedInText: true,
+
     handler({parser}, args) {
         const amount = assertNodeType(args[0], "size").value;
         const body = args[1];
@@ -26,6 +25,7 @@ defineFunction({
             body,
         };
     },
+
     htmlBuilder(group, options) {
         const body = html.buildGroup(group.body, options);
         const dy = calculateSize(group.dy, options);

--- a/src/functions/relax.ts
+++ b/src/functions/relax.ts
@@ -3,11 +3,10 @@ import defineFunction from "../defineFunction";
 defineFunction({
     type: "internal",
     names: ["\\relax"],
-    props: {
-        numArgs: 0,
-        allowedInText: true,
-        allowedInArgument: true,
-    },
+    numArgs: 0,
+    allowedInText: true,
+    allowedInArgument: true,
+
     handler({parser}) {
         return {
             type: "internal",

--- a/src/functions/rule.ts
+++ b/src/functions/rule.ts
@@ -7,13 +7,12 @@ import {calculateSize, makeEm} from "../units";
 defineFunction({
     type: "rule",
     names: ["\\rule"],
-    props: {
-        numArgs: 2,
-        numOptionalArgs: 1,
-        allowedInText: true,
-        allowedInMath: true,
-        argTypes: ["size", "size", "size"],
-    },
+    numArgs: 2,
+    numOptionalArgs: 1,
+    allowedInText: true,
+    allowedInMath: true,
+    argTypes: ["size", "size", "size"],
+
     handler({parser}, args, optArgs) {
         const shift = optArgs[0];
         const width = assertNodeType(args[0], "size");
@@ -26,6 +25,7 @@ defineFunction({
             height: height.value,
         };
     },
+
     htmlBuilder(group, options) {
         // Make an empty span for the rule
         const rule = makeSpan(["mord", "rule"], [], options);

--- a/src/functions/sizing.ts
+++ b/src/functions/sizing.ts
@@ -43,7 +43,7 @@ export function sizingGroup(
 const sizeFuncs = [
     "\\tiny", "\\sixptsize", "\\scriptsize", "\\footnotesize", "\\small",
     "\\normalsize", "\\large", "\\Large", "\\LARGE", "\\huge", "\\Huge",
-];
+] as const;
 
 export const htmlBuilder: HtmlBuilder<"sizing"> = (group, options) => {
     // Handle sizing operators like \Huge. Real TeX doesn't actually allow

--- a/src/functions/sizing.ts
+++ b/src/functions/sizing.ts
@@ -56,10 +56,9 @@ export const htmlBuilder: HtmlBuilder<"sizing"> = (group, options) => {
 defineFunction({
     type: "sizing",
     names: sizeFuncs,
-    props: {
-        numArgs: 0,
-        allowedInText: true,
-    },
+    numArgs: 0,
+    allowedInText: true,
+
     handler: ({breakOnTokenText, funcName, parser}, args) => {
         const body = parser.parseExpression(false, breakOnTokenText);
 
@@ -71,6 +70,7 @@ defineFunction({
             body,
         };
     },
+
     htmlBuilder,
     mathmlBuilder: (group, options) => {
         const newOptions = options.havingSize(group.size);

--- a/src/functions/smash.ts
+++ b/src/functions/smash.ts
@@ -10,11 +10,10 @@ import * as mml from "../buildMathML";
 defineFunction({
     type: "smash",
     names: ["\\smash"],
-    props: {
-        numArgs: 1,
-        numOptionalArgs: 1,
-        allowedInText: true,
-    },
+    numArgs: 1,
+    numOptionalArgs: 1,
+    allowedInText: true,
+
     handler: ({parser}, args, optArgs) => {
         let smashHeight = false;
         let smashDepth = false;
@@ -51,6 +50,7 @@ defineFunction({
             smashDepth,
         };
     },
+
     htmlBuilder: (group, options) => {
         const node = makeSpan(
             [], [html.buildGroup(group.body, options)]);

--- a/src/functions/sqrt.ts
+++ b/src/functions/sqrt.ts
@@ -11,10 +11,9 @@ import * as mml from "../buildMathML";
 defineFunction({
     type: "sqrt",
     names: ["\\sqrt"],
-    props: {
-        numArgs: 1,
-        numOptionalArgs: 1,
-    },
+    numArgs: 1,
+    numOptionalArgs: 1,
+
     handler({parser}, args, optArgs) {
         const index = optArgs[0];
         const body = args[0];
@@ -25,6 +24,7 @@ defineFunction({
             index,
         };
     },
+
     htmlBuilder(group, options) {
         // Square roots are handled in the TeXbook pg. 443, Rule 11.
 

--- a/src/functions/styling.ts
+++ b/src/functions/styling.ts
@@ -23,11 +23,10 @@ defineFunction({
         "\\displaystyle", "\\textstyle", "\\scriptstyle",
         "\\scriptscriptstyle",
     ],
-    props: {
-        numArgs: 0,
-        allowedInText: true,
-        primitive: true,
-    },
+    numArgs: 0,
+    allowedInText: true,
+    primitive: true,
+
     handler({breakOnTokenText, funcName, parser}, args) {
         // parse out the implicit body
         const body = parser.parseExpression(true, breakOnTokenText);
@@ -47,6 +46,7 @@ defineFunction({
             body,
         };
     },
+
     htmlBuilder(group, options) {
         // Style changes are handled in the TeXbook on pg. 442, Rule 3.
         const newStyle = styleMap[group.style];

--- a/src/functions/text.ts
+++ b/src/functions/text.ts
@@ -54,12 +54,11 @@ defineFunction({
         // Font Shapes
         "\\textit", "\\textup", "\\emph",
     ],
-    props: {
-        numArgs: 1,
-        argTypes: ["text"],
-        allowedInArgument: true,
-        allowedInText: true,
-    },
+    numArgs: 1,
+    argTypes: ["text"],
+    allowedInArgument: true,
+    allowedInText: true,
+
     handler({parser, funcName}, args) {
         const body = args[0];
         return {
@@ -69,6 +68,7 @@ defineFunction({
             font: funcName,
         };
     },
+
     htmlBuilder(group, options) {
         const newOptions = optionsWithFont(group, options);
         const inner = html.buildExpression(group.body, newOptions, true);

--- a/src/functions/underline.ts
+++ b/src/functions/underline.ts
@@ -8,10 +8,9 @@ import * as mml from "../buildMathML";
 defineFunction({
     type: "underline",
     names: ["\\underline"],
-    props: {
-        numArgs: 1,
-        allowedInText: true,
-    },
+    numArgs: 1,
+    allowedInText: true,
+
     handler({parser}, args) {
         return {
             type: "underline",
@@ -19,6 +18,7 @@ defineFunction({
             body: args[0],
         };
     },
+
     htmlBuilder(group, options) {
         // Underlines are handled in the TeXbook pg 443, Rule 10.
         // Build the inner group.

--- a/src/functions/vcenter.ts
+++ b/src/functions/vcenter.ts
@@ -10,11 +10,10 @@ import * as mml from "../buildMathML";
 defineFunction({
     type: "vcenter",
     names: ["\\vcenter"],
-    props: {
-        numArgs: 1,
-        argTypes: ["original"], // In LaTeX, \vcenter can act only on a box.
-        allowedInText: false,
-    },
+    numArgs: 1,
+    argTypes: ["original"], // In LaTeX, \vcenter can act only on a box.
+    allowedInText: false,
+
     handler({parser}, args) {
         return {
             type: "vcenter",
@@ -22,6 +21,7 @@ defineFunction({
             body: args[0],
         };
     },
+
     htmlBuilder(group, options) {
         const body = html.buildGroup(group.body, options);
         const axisHeight = options.fontMetrics().axisHeight;

--- a/src/functions/verb.ts
+++ b/src/functions/verb.ts
@@ -8,10 +8,9 @@ import type {ParseNode} from "../types/nodes";
 defineFunction({
     type: "verb",
     names: ["\\verb"],
-    props: {
-        numArgs: 0,
-        allowedInText: true,
-    },
+    numArgs: 0,
+    allowedInText: true,
+
     handler(context, args, optArgs) {
         // \verb and \verb* are dealt with directly in Parser.js.
         // If we end up here, it's because of a failure to match the two delimiters
@@ -20,6 +19,7 @@ defineFunction({
         throw new ParseError(
             "\\verb ended by end of line instead of matching delimiter");
     },
+
     htmlBuilder(group, options) {
         const text = makeVerb(group);
         const body = [];


### PR DESCRIPTION
**What is the previous behavior before this PR?**

1. `defineFunction` normalized each function registration by constructing a new parser-facing function spec, applying defaults, and storing HTML/MathML builders through separate helper tables. This added work during module initialization, even though most defaults can be handled at use sites.

2. The `names` field on function registrations was typed broadly, so handlers saw `funcName` as `string` even when a registration listed a fixed set of command names. Some files used separate command-name union types with `satisfies` to recover that information manually.

**What is the new behavior after this PR?**

1. `defineFunction` now stores the registration data directly and registers builders from the same object, avoiding the previous normalization/wrapping step during initialization. Parser call sites now apply defaults where needed for optional fields.
   * Local benchmark runs showed about a 2-2.5% median improvement in minified bundle require time (from 1.5398ms to 1.5046ms, a 0.0352ms improvement), with a small minified bundle-size reduction (from 272,537 to 271,179 bytes, a 1,358-byte or 0.5% improvement, or about half that when gzipped).
   * Should also reduce memory thrashing a little. Does result in `names` getting permanently stored, instead of garbage collected. 
   * Another argument for this change is that the code is a lot simpler.
   * Also removed a few redundant specifications of duplicate builders on shared types, which was unnecessary.
   * Originally inspired by https://github.com/KaTeX/KaTeX/pull/4219#discussion_r3282426680

2. Function registrations now infer the handler `funcName` type from `names`. For example, `names: ["\\foo", "\\bar"]` gives the handler `funcName` type `"\\foo" | "\\bar"`. This removes several redundant command-name union types (Slices are getting cleaner!) and lets supporting maps/arrays, such as delimiter sizes and sizing commands, be checked more precisely.

BREAKING CHANGE: The internal API for `__defineFunction` changed: you should no longer wrap properties in `props`.

BUT: I'm not totally sure this should be considered a breaking change. It would affect any third-party modules that use `__defineFunction`. But looking at https://github.com/search?q=katex+%22__defineFunction%22&type=code I'm not sure there are any. Whereas I know of examples of `__defineMacro` and `__defineSymbol`. I'd like feedback on whether we should bump minor version for this.
