### PR TITLE
docs: expand self-hosting instructions

### DIFF
--- a/docs/browser.md
+++ b/docs/browser.md
@@ -127,7 +127,7 @@ infrastructure. There are two ways to get a release:
 
 Each release ships pre-built `katex.tar.gz` and `katex.zip` archives.
 Download one from the [KaTeX releases page](https://github.com/KaTeX/KaTeX/releases) —
-look under **Assets** for `katex.tar.gz` or `katex.zip`, **not** the
+look under **Assets** for `katex.tar.gz` or `katex.zip`, *not* the
 auto-generated "Source code" download, which only contains the repo
 source tree without the built files.
 
@@ -173,7 +173,7 @@ yarn add katex
 After installing, the files you want for hosting live under
 `node_modules/katex/dist/` — same layout as the `katex/` folder above.
 
-> The npm package also ships the un-built source (`node_modules/katex/src/`,
+> The npm package also ships the unbuilt TypeScript source (`node_modules/katex/src/`,
 > `node_modules/katex/contrib/`, `node_modules/katex/katex.ts`) for
 > bundler users. Do not link those from your HTML — only the files
 > under `dist/` are meant to be served as-is.
@@ -223,7 +223,7 @@ updating is a drop-in replace. To update:
 1. Get the new release files:
    - **Archive:** download a fresh `katex.tar.gz` (or `katex.zip`) and
      extract it.
-   - **npm:** run `npm update katex` (or `yarn upgrade katex`). The new
+   - **npm:** run `npm install katex@latest` (or `yarn upgrade katex@latest`). The new
      files appear in `node_modules/katex/dist/`.
 2. Replace the `katex/` directory on your web server with the new
    files — extracted from the archive, or copied from

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -113,17 +113,124 @@ for more detail.
 > Use [`nomodule` attribute](https://developer.mozilla.org/en/HTML/Element/script#Attributes)
 to provide a fallback for older browsers that do not support ES modules.
 
-## Download & Host Things Yourself
-Download a [KaTeX release](https://github.com/KaTeX/KaTeX/releases),
-copy `katex.js`, `katex.css`
-(or `katex.min.js` and `katex.min.css` to use minified versions),
-and the `fonts` directory, and include or import it like above.
-
-You can also build from source. See [Building from Source](node.md#building-from-source)
-for more details.
-
 ## Bundler
 [Use Node.js package managers to install KaTeX and import it](node.md) in your
 project. Then bundle using bundlers like [webpack](https://webpack.js.org/) or
 [rollup.js](https://rollupjs.org/). Note that you have to bundle the stylesheet
 (`katex.css`) or include it manually.
+
+## Download & Host Things Yourself
+If you do not want to rely on a CDN, you can serve KaTeX from your own
+infrastructure. There are two ways to get a release:
+
+### Option 1: Pre-built release from GitHub
+
+Each release ships pre-built `katex.tar.gz` and `katex.zip` archives.
+Download one from the [KaTeX releases page](https://github.com/KaTeX/KaTeX/releases) —
+look under **Assets** for `katex.tar.gz` or `katex.zip`, **not** the
+auto-generated "Source code" download, which only contains the repo
+source tree without the built files.
+
+After extracting, you will get a `katex/` folder containing every file you need:
+
+```
+katex/
+├── README.md
+├── katex.js              # unminified UMD build
+├── katex.min.js          # minified UMD build (recommended for production)
+├── katex.mjs             # ES module build
+├── katex.css             # stylesheet (font-display: block)
+├── katex.min.css         # minified stylesheet
+├── katex-swap.css        # stylesheet variant (font-display: swap)
+├── katex-swap.min.css
+├── contrib/              # optional extensions (each shipped as .js, .min.js, and .mjs)
+│   ├── auto-render.js
+│   ├── auto-render.min.js
+│   ├── auto-render.mjs
+│   ├── copy-tex.js
+│   ├── copy-tex.min.js
+│   ├── copy-tex.mjs
+│   ├── mathtex-script-type.js
+│   ├── mathtex-script-type.min.js
+│   ├── mathtex-script-type.mjs
+│   ├── mhchem.js
+│   ├── mhchem.min.js
+│   ├── mhchem.mjs
+│   ├── render-a11y-string.js
+│   ├── render-a11y-string.min.js
+│   └── render-a11y-string.mjs
+└── fonts/                # WOFF2/WOFF/TTF font files (required)
+```
+
+### Option 2: npm
+
+```bash
+npm install katex
+# or
+yarn add katex
+```
+
+After installing, the files you want for hosting live under
+`node_modules/katex/dist/` — same layout as the `katex/` folder above.
+
+> The npm package also ships the un-built source (`node_modules/katex/src/`,
+> `node_modules/katex/contrib/`, `node_modules/katex/katex.ts`) for
+> bundler users. Do not link those from your HTML — only the files
+> under `dist/` are meant to be served as-is.
+
+### Serving the files
+
+Copy the entire folder (or just the pieces you need plus `fonts/`) into
+your web server's static directory. **The `fonts/` directory must stay
+alongside the CSS file** — `katex.css` references the fonts using
+relative URLs (e.g. `url("fonts/KaTeX_AMS-Regular.woff2")`), so moving
+or renaming `fonts/` will break math rendering.
+
+Assuming you copied `katex/` to the root of your site, the following
+HTML will load KaTeX with auto-rendering enabled:
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" href="/katex/katex.min.css">
+
+    <!-- The loading of KaTeX is deferred to speed up page rendering -->
+    <script defer src="/katex/katex.min.js"></script>
+
+    <!-- To automatically render math in text elements, include the auto-render extension: -->
+    <script defer src="/katex/contrib/auto-render.min.js"
+        onload="renderMathInElement(document.body);"></script>
+  </head>
+  <body>
+    ...
+  </body>
+</html>
+```
+
+Adjust the `/katex/` prefix to match wherever you placed the files. If
+you only need to render math via the JavaScript API (and not the
+auto-render extension), you can omit the `auto-render.min.js` script.
+Swap `katex.min.css`, `katex.min.js`, and `contrib/auto-render.min.js`
+for the unminified `katex.css`, `katex.js`, and `contrib/auto-render.js`
+if you prefer readable files for debugging.
+
+### Keeping your copy up to date
+
+Every release publishes the same file names at the same paths, so
+updating is a drop-in replace. To update:
+
+1. Get the new release files:
+   - **Archive:** download a fresh `katex.tar.gz` (or `katex.zip`) and
+     extract it.
+   - **npm:** run `npm update katex` (or `yarn upgrade katex`). The new
+     files appear in `node_modules/katex/dist/`.
+2. Replace the `katex/` directory on your web server with the new
+   files — extracted from the archive, or copied from
+   `node_modules/katex/dist/`. Keep the same folder name so existing
+   HTML keeps working.
+3. Skim the [CHANGELOG](https://github.com/KaTeX/KaTeX/blob/main/CHANGELOG.md)
+   for any breaking changes between your old version and the new one.
+
+You can also build from source. See [Building from Source](node.md#building-from-source)
+for more details.


### PR DESCRIPTION
# Summary

Closes #4131.

The "Download & Host Things Yourself" section of docs/browser.md was a single short paragraph that left readers guessing about where to download from, where the files end up, what HTML to wire up, and how to update later. This PR rewrites the section so each of those questions has a concrete answer.

## Changes
docs/browser.md
- Added Option 1: Pre-built release from GitHub — explicit "use katex.tar.gz / katex.zip Assets, not the auto-generated 'Source code' download" warning, plus an annotated directory tree of the extracted katex/ folder.
- Added Option 2: npm — npm install / yarn add, with a blockquote warning that the top-level src/, contrib/, and katex.ts are un-built source for bundler users; only files under dist/ are meant to be served as-is.
- Added Serving the files subsection with a copy-paste HTML snippet (CSS, JS, auto-render) using relative /katex/... paths, plus a callout that fonts/ must stay alongside katex.css because the stylesheet references font files via relative URLs.
- Added Keeping your copy up to date subsection with a 3-step recipe (download archive / npm update, replace folder in place, skim CHANGELOG for breaking changes).
- No version strings introduced in new prose, so update-sri.js on release won't leave it stale.

## Verification
- Downloaded the actual `v0.17.0/katex.tar.gz` from GitHub and confirmed every documented tree entry matches the archive (24 non-font entries + fonts/).
- `yarn build` ✅ — local dist/ matches the documented layout file-for-file.
- `npm pack --dry-run` ✅ — node_modules/katex/dist/ mirrors the archive, and the top-level warning is accurate (e.g. contrib/mhchem/mhchem.js and contrib/auto-render/auto-render.ts are indeed unbundled source).
- `yarn test:lint` ✅
- `cd website && yarn build` ✅ — rendered HTML shows the four sub-sections with proper `<h3>` headings, ToC entries, code blocks, blockquote, and ordered list; all links resolve.
