### PR TITLE
fix(auto-render, parser): add shouldRender callback and handle braced commas in \htmlData

### DIFF
--- a/contrib/auto-render/auto-render.ts
+++ b/contrib/auto-render/auto-render.ts
@@ -12,6 +12,13 @@ interface RenderMathInElementOptions {
     errorCallback?: (msg: string, err: Error) => void;
     displayMode?: boolean;
     macros?: Record<string, string>;
+
+    /**
+     * An optional callback invoked for each element that is not excluded by
+     * `ignoredTags` or `ignoredClasses`. Return `false` to skip rendering
+     * math inside that element and its descendants.
+     */
+    shouldRender?: (node: HTMLElement) => boolean;
 }
 
 interface RenderMathInElementOptionsCopy {
@@ -22,6 +29,7 @@ interface RenderMathInElementOptionsCopy {
     errorCallback: (msg: string, err: Error) => void;
     displayMode?: boolean;
     macros?: Record<string, string>;
+    shouldRender?: (node: HTMLElement) => boolean;
 }
 
 /* Note: optionsCopy is mutated by this method. If it is ever exposed in the
@@ -78,6 +86,10 @@ const renderElem = function(
     elem: HTMLElement,
     optionsCopy: RenderMathInElementOptionsCopy
 ) {
+    if (optionsCopy.shouldRender &&
+            !optionsCopy.shouldRender(elem)) {
+        return;
+    }
     for (let i = 0; i < elem.childNodes.length; i++) {
         const childNode = elem.childNodes[i];
         if (childNode.nodeType === 3) {
@@ -109,12 +121,13 @@ const renderElem = function(
         } else if (childNode.nodeType === 1) {
             // Element node
             const className = ' ' + (childNode as HTMLElement).className + ' ';
-            const shouldRender = !optionsCopy.ignoredTags.has(
+            const isAllowed = !optionsCopy.ignoredTags.has(
                 childNode.nodeName.toLowerCase()) &&
                   optionsCopy.ignoredClasses.every(
                       (x: string) => !className.includes(' ' + x + ' '));
 
-            if (shouldRender) {
+            if (isAllowed && (!optionsCopy.shouldRender ||
+                    optionsCopy.shouldRender(childNode as HTMLElement))) {
                 renderElem(childNode as HTMLElement, optionsCopy);
             }
         }

--- a/contrib/auto-render/test/auto-render-spec.ts
+++ b/contrib/auto-render/test/auto-render-spec.ts
@@ -331,6 +331,69 @@ describe("Pre-process callback", function() {
     });
 });
 
+describe("The shouldRender callback", function() {
+    it("should render when callback returns true", function() {
+        const el = document.createElement('div');
+        el.textContent = 'Equation: $x^2$';
+        const delimiters = [{left: "$", right: "$", display: false}];
+        renderMathInElement(el, {
+            delimiters,
+            shouldRender: () => true,
+        });
+        expect(el.innerHTML).toContain('class="katex"');
+    });
+
+    it("should skip rendering when callback returns false", function() {
+        const el = document.createElement('div');
+        el.textContent = 'Equation: $x^2$';
+        const delimiters = [{left: "$", right: "$", display: false}];
+        renderMathInElement(el, {
+            delimiters,
+            shouldRender: () => false,
+        });
+        expect(el.innerHTML).not.toContain('class="katex"');
+    });
+
+    it("should skip child elements when callback returns false for parent", function() {
+        const parent = document.createElement('div');
+        const child = document.createElement('span');
+        child.textContent = '$x^2$';
+        parent.appendChild(child);
+        const delimiters = [{left: "$", right: "$", display: false}];
+        renderMathInElement(parent, {
+            delimiters,
+            shouldRender: (node) => node !== parent,
+        });
+        expect(parent.innerHTML).not.toContain('class="katex"');
+    });
+
+    it("should render math when no callback provided", function() {
+        const el = document.createElement('div');
+        el.textContent = 'Equation: $x^2$';
+        const delimiters = [{left: "$", right: "$", display: false}];
+        renderMathInElement(el, {delimiters});
+        expect(el.innerHTML).toContain('class="katex"');
+    });
+
+    it("should not invoke callback for elements excluded by ignoredTags", function() {
+        const spy = jest.fn(() => true);
+        const el = document.createElement('div');
+        const code = document.createElement('code');
+        code.textContent = '$x^2$';
+        el.appendChild(code);
+        const delimiters = [{left: "$", right: "$", display: false}];
+        renderMathInElement(el, {
+            delimiters,
+            shouldRender: spy,
+            ignoredTags: ["code"],
+        });
+        // The callback should be called for the root div but not for the
+        // <code> element (which is excluded by ignoredTags first).
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith(el);
+    });
+});
+
 describe("Parse adjacent text nodes", function() {
     it("parse adjacent text nodes with math", function() {
         const textNodes = ['\\[',

--- a/src/functions/html.ts
+++ b/src/functions/html.ts
@@ -49,7 +49,29 @@ defineFunction({
                 };
                 break;
             case "\\htmlData": {
-                const data = value.split(",");
+                // Split on commas at brace depth 0 so that users can wrap
+                // values containing literal commas in braces, e.g.
+                //   \htmlData{annotation_text={[a,b]}}{[a, b]}
+                const data = [];
+                let current = "";
+                let depth = 0;
+                for (let i = 0; i < value.length; i++) {
+                    const ch = value[i];
+                    if (ch === "{" && depth === 0) {
+                        current += ch;
+                        depth++;
+                    } else if (ch === "}") {
+                        depth--;
+                        current += ch;
+                    } else if (ch === "," && depth === 0) {
+                        data.push(current);
+                        current = "";
+                    } else {
+                        current += ch;
+                    }
+                }
+                data.push(current);
+
                 for (let i = 0; i < data.length; i++) {
                     const item = data[i];
                     const firstEquals = item.indexOf("=");
@@ -59,7 +81,23 @@ defineFunction({
                     }
                     const key = item.slice(0, firstEquals);
                     const value = item.slice(firstEquals + 1);
-                    attributes["data-" + key.trim()] = value;
+                    // Strip outer braces from the value if they enclose
+                    // the entire value (used for grouping to protect commas).
+                    let trimmed = value;
+                    if (value.length > 1 && value[0] === "{" &&
+                            value[value.length - 1] === "}") {
+                        let d = 0;
+                        let balanced = true;
+                        for (let j = 1; j < value.length - 1; j++) {
+                            if (value[j] === "{") { d++; }
+                            else if (value[j] === "}") { d--; }
+                            if (d < 0) { balanced = false; break; }
+                        }
+                        if (balanced && d === 0) {
+                            trimmed = value.slice(1, -1);
+                        }
+                    }
+                    attributes["data-" + key.trim()] = trimmed;
                 }
 
                 trustContext = {

--- a/test/katex-spec.ts
+++ b/test/katex-spec.ts
@@ -2378,6 +2378,31 @@ describe("The \\htmlData macro", function() {
         expect(built[0].attributes["data-foo"]).toEqual(" bar ");
     });
 
+    it("should handle values with commas wrapped in braces", () => {
+        const built = getBuilt(
+            "\\htmlData{annotation_text={[a,b]}}{x}",
+            trustNonStrictSettings);
+        expect(built[0].attributes["data-annotation_text"])
+            .toEqual("[a,b]");
+    });
+
+    it("should handle multiple pairs where one has brace-wrapped value", () => {
+        const built = getBuilt(
+            "\\htmlData{foo={a,b}, bar=c}{x}",
+            trustNonStrictSettings);
+        expect(built[0].attributes["data-foo"]).toEqual("a,b");
+        expect(built[0].attributes["data-bar"]).toEqual("c");
+    });
+
+    it("should not strip braces when inner content is unbalanced", () => {
+        const built = getBuilt(
+            "\\htmlData{foo={a}{b}}{x}", trustNonStrictSettings);
+        // The value starts with { and ends with }, but inner braces
+        // are not balanced (depth goes negative), so outer braces
+        // are preserved as-is.
+        expect(built[0].attributes["data-foo"]).toEqual("{a}{b}");
+    });
+
     it("should throw Error if an argument contains no equals signs", () => {
         try {
             katex.renderToString(


### PR DESCRIPTION
## Summary

- Fixes #691: `renderMathInElement` now accepts an optional `shouldRender` callback to conditionally skip rendering.
- Fixes #4204: `\\htmlData` now correctly parses key-value pairs within brace-delimited groups so that values can contain literal commas.

## Changes

### #691: shouldRender callback

- Added optional `shouldRender?: (node: HTMLElement) => boolean` property to `renderMathInElement` options
- Callback is invoked after the `ignoredTags`/`ignoredClasses` check, so excluded elements are never passed to it
- If the callback returns `false`, the element and its descendants are skipped
- Backward compatible: no callback means unchanged behavior

### #4204: Braced values in \\htmlData

- Replaced naive `value.split(',')` with a brace-depth-aware parser that only splits on commas at depth 0
- Values wrapped in balanced outer braces have those braces stripped automatically
- Example: `\\htmlData{annotation_text={[a,b]}}{[a, b]}` sets `data-annotation_text="[a,b]"`
- All existing behavior preserved

## Test plan

- [x] Added 5 unit tests for `shouldRender` (true/false/not provided/child skipping/ignoredTags interaction)
- [x] Added 3 integration tests for `\\htmlData` with brace-wrapped commas (single pair, multiple pairs, unbalanced braces)
- [x] All 1295 tests pass locally
- [x] TypeScript type check passes
- [x] ESLint passes
- [x] Build succeeds (Rollup + Webpack)

## Notes for reviewers

- The `shouldRender` callback is invoked at the start of `renderElem` for every element, including the root element. This differs from `ignoredTags` which only applies to child elements.
- For `\\htmlData`, the brace-depth splitter preserves backward compatibility with all existing usage patterns. Only values that start and end with balanced outer braces will have those braces stripped; all other values are passed through unchanged.

No breaking changes — both additions are backward-compatible.