### PR TITLE
fix(auto-render): recover math split across <em> tags from Markdown

### DIFF
--- a/contrib/auto-render/README.md
+++ b/contrib/auto-render/README.md
@@ -5,4 +5,5 @@ searches all of the text nodes in a given element for the given delimiters, and
 renders the math in place.
 
 See [Auto-render extension documentation](https://katex.org/docs/autorender.html)
-for more information.
+for more information, including how math split into `<em>` tags by Markdown
+preprocessors such as rustdoc is recovered.

--- a/contrib/auto-render/auto-render.ts
+++ b/contrib/auto-render/auto-render.ts
@@ -82,20 +82,39 @@ const renderElem = function(
         const childNode = elem.childNodes[i];
         if (childNode.nodeType === 3) {
             // Text node
-            // Concatenate all sibling text nodes.
-            // Webkit browsers split very large text nodes into smaller ones,
-            // so the delimiters may be split across different nodes.
+            // Concatenate adjacent sibling text nodes. WebKit browsers split
+            // very large text nodes into smaller ones, so the delimiters may
+            // be split across different nodes.
+            // Markdown preprocessors such as rustdoc also split math by
+            // turning `_..._` subscripts into <em> tags; absorb those and
+            // restore the underscores so the delimiters reunite.
             let textContentConcat = childNode.textContent ?? "";
             let sibling = childNode.nextSibling;
             let nSiblings = 0;
-            while (sibling && (sibling.nodeType === Node.TEXT_NODE)) {
-                textContentConcat += sibling.textContent ?? "";
+            while (sibling) {
+                if (sibling.nodeType === Node.TEXT_NODE) {
+                    textContentConcat += sibling.textContent ?? "";
+                } else if (sibling.nodeType === Node.ELEMENT_NODE &&
+                        sibling.nodeName.toLowerCase() === "em") {
+                    const emText = sibling.textContent ?? "";
+                    const emHasDelimiter = optionsCopy.delimiters.some(
+                        (d) => emText.includes(d.left) ||
+                            emText.includes(d.right));
+                    // Leave the <em> for normal recursion when it holds its
+                    // own delimiters, so emphasized math keeps rendering.
+                    if (emHasDelimiter) {
+                        break;
+                    }
+                    textContentConcat += "_" + emText + "_";
+                } else {
+                    break;
+                }
                 sibling = sibling.nextSibling;
                 nSiblings++;
             }
             const frag = renderMathInText(textContentConcat, optionsCopy);
             if (frag) {
-                // Remove extra text nodes
+                // Remove the consumed sibling nodes
                 for (let j = 0; j < nSiblings; j++) {
                     childNode.nextSibling!.remove();
                 }

--- a/contrib/auto-render/test/auto-render-spec.ts
+++ b/contrib/auto-render/test/auto-render-spec.ts
@@ -369,3 +369,60 @@ describe("Parse adjacent text nodes", function() {
         expect(el).toStrictEqual(el2);
     });
 });
+
+describe("Markdown <em> recovery (#4234)", function() {
+    const delimiters = [{left: "\\(", right: "\\)", display: false}];
+
+    // Markdown preprocessors such as rustdoc render `\(...\)` math by turning
+    // the `_..._` subscripts into <em> tags, dropping the underscores and
+    // splitting the delimiters across DOM nodes. Swapping each <em> tag back
+    // for a literal underscore reproduces the original, un-corrupted math.
+    const combinedHtml = "<p>\\( " +
+        "\\frac{\\partial \\mathbb{E^Q} [\\bar{C}<em>t] }{\\partial \\xi} = " +
+        "\\frac{Nd}{10000} ( Q(m</em>{a.e.}) V(m_t) + I_{pa} X_{pa} " +
+        "V(m_{a.e.}) ) = \\frac{Nd}{10000} ( Q(m_{a.e.}) V(m_t) + I_{pa} " +
+        "X_{pa} V(m_{a.e.}) ) \\)</p>";
+
+    const splitFirstHtml = "<p>\\( " +
+        "\\frac{\\partial \\mathbb{E^Q} [\\bar{C}<em>t] }{\\partial \\xi} = " +
+        "\\frac{Nd}{10000} ( Q(m</em>{a.e.}) V(m_t) + I_{pa} X_{pa} " +
+        "V(m_{a.e.}) ) \\)</p>";
+
+    const renderHtml = function(html: string) {
+        const el = document.createElement("div");
+        el.innerHTML = html;
+        renderMathInElement(el, {delimiters});
+        return el;
+    };
+
+    it("recovers math whose delimiters are split by an <em>", function() {
+        const withEm = renderHtml(combinedHtml);
+        const restored = renderHtml(combinedHtml.replace(/<\/?em>/g, "_"));
+        expect(withEm.querySelector(".katex")).not.toBeNull();
+        expect(withEm.innerHTML).toEqual(restored.innerHTML);
+    });
+
+    it("recovers a single line split by an <em>", function() {
+        const withEm = renderHtml(splitFirstHtml);
+        const restored = renderHtml(splitFirstHtml.replace(/<\/?em>/g, "_"));
+        expect(withEm.querySelector(".katex")).not.toBeNull();
+        expect(withEm.innerHTML).toEqual(restored.innerHTML);
+    });
+
+    it("leaves <em> tags outside math untouched", function() {
+        const el = document.createElement("div");
+        el.innerHTML = "Hello <em>world</em>!";
+        const original = el.innerHTML;
+        renderMathInElement(el, {delimiters});
+        expect(el.querySelector(".katex")).toBeNull();
+        expect(el.innerHTML).toEqual(original);
+    });
+
+    it("renders complete math inside an <em>", function() {
+        const el = document.createElement("div");
+        el.innerHTML = "see <em>\\(x^2\\)</em> here";
+        renderMathInElement(el, {delimiters});
+        expect(el.querySelector("em .katex")).not.toBeNull();
+        expect(el.textContent).not.toContain("_");
+    });
+});

--- a/docs/autorender.md
+++ b/docs/autorender.md
@@ -135,3 +135,23 @@ instead taken from the `display` key of the corresponding entry in the
 The same `options.macros` object (which defaults to an empty object `{}`)
 is passed into several calls to `katex.render`, so that consecutive equations
 can build up shared macros by `\gdef`.
+
+## Markdown preprocessors
+Some Markdown preprocessors run before KaTeX and rewrite the math text. A common
+example is rustdoc: an underscore subscript such as `\(\bar{C}_t\)` is treated
+as Markdown emphasis, so the underscores are dropped and the content between
+them becomes an `<em>` tag (`\(\bar{C}<em>t\)</em>`). This splits the `\(` and
+`\)` delimiters across separate DOM nodes, and a longer expression that uses
+two underscores can leave the whole formula unrendered (see
+[issue #4234](https://github.com/KaTeX/KaTeX/issues/4234)).
+
+To handle this case, auto-render absorbs an adjacent `<em>` tag while scanning a
+run of text for delimiters and restores the surrounding underscores, so the
+delimiters reunite and the math renders as written. An `<em>` that contains a
+complete delimiter of its own is left untouched and rendered by the normal
+recursion, so intentionally emphasized math still works.
+
+This is a best-effort recovery for underscore emphasis. If you emphasize text
+with asterisks (`*...*`) inside a formula, the resulting `<em>` is still
+restored with underscores; in that case escape the markers (for example, write
+`\_` instead of `_`) or keep each formula in its own `\(...\)` span.


### PR DESCRIPTION
Addressing #4234, where two equations that each render fine on their own fail the moment you combine them into a single `\(...\)` line.

### Tracing the issue

1. The TeX itself wasn't the problem — feeding the full expression straight to `katex.renderToString` works. The breakage happens earlier, in how the math reaches KaTeX. rustdoc (and other Markdown preprocessors) run **before** KaTeX and rewrite the source: an underscore subscript like `\(\bar{C}_t\)` reads as emphasis, so the underscores get consumed and the text between them turns into an `<em>`:

   ```html
   \(\bar{C}<em>t] ... Q(m</em>{a.e.}) ... \)
   ```

2. Now `\(` and `\)` sit in different DOM nodes. auto-render only stitches together adjacent **text nodes** (to undo WebKit splitting large ones), so it walks right past the `<em>` and never sees a complete delimiter pair. The single-line case fails because that longer run is the one that trips the `<em>` boundary; the split version survives only because each `\(...\)` happens to land inside one text node. And once the underscores are gone from the HTML, nothing downstream can rebuild the subscripts.

### New behaviour

1. In that same sibling-walk in `renderElem`, auto-render now also absorbs an adjacent `<em>` and wraps its text back in `_`, undoing exactly what the Markdown emphasis did. The delimiters reunite and the formula renders identically to clean LaTeX.
   - An `<em>` that already holds a full delimiter pair (e.g. `see <em>\(x^2\)</em> here`) is left untouched for the normal recursion, so deliberately emphasised math keeps working.

2. Tests and docs:
   - Regression tests use the exact rustdoc-style HTML from #4234 and assert it renders to the same `innerHTML` as the un-corrupted `\(...\)` source — red on `main`, green here. Full suite still passes.
   - [`docs/autorender.md`](docs/autorender.md) documents the behavior and its one caveat: the recovery assumes `_..._` emphasis, so asterisk emphasis (`*...*`) inside math would be restored with underscores too. Escaping `\_` or keeping each formula in its own `\(...\)` span is the workaround.