### PR TITLE
docs: add working math examples to browser starter template

### DIFF
--- a/docs/browser.md
+++ b/docs/browser.md
@@ -20,9 +20,21 @@ title: Browser
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.18.1/dist/contrib/auto-render.min.js" integrity="sha384-bjyGPfbij8/NDKJhSGZNP/khQVgtHUE5exjm4Ydllo42FwIgYsdLO2lXGmRBf5Mz" crossorigin="anonymous"
         onload="renderMathInElement(document.body);"></script>
   </head>
-  ...
+  <body>
+    <p>Inline math: \(e^{i\pi} + 1 = 0\)</p>
+    <p>Display math:</p>
+    $$
+    \int_{-\infty}^{\infty} e^{-x^2} \, dx = \sqrt{\pi}
+    $$
+  </body>
 </html>
 ```
+
+These examples use the [default auto-render delimiters](autorender.md#usage)
+(`$$…$$` for display math and `\(...\)` for inline math). Single `$…$` is not
+enabled by default. To use other delimiters or environments, pass an `options`
+object to `renderMathInElement` as shown in the
+[auto-render documentation](autorender.md).
 
 ## Loading as Global
 If you include the `katex.js` directly, the `katex` object will be available as

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -23,9 +23,11 @@ title: Browser
   <body>
     <p>Inline math: \(e^{i\pi} + 1 = 0\)</p>
     <p>Display math:</p>
+    <p>
     $$
     \int_{-\infty}^{\infty} e^{-x^2} \, dx = \sqrt{\pi}
     $$
+    </p>
   </body>
 </html>
 ```


### PR DESCRIPTION
## Summary
- Replace the `...` placeholder in the browser starter template with a `<body>` that includes inline (`\(...\)`) and display (`$$...$$`) math examples that work with default auto-render delimiters.
- Note that single `$...$` is not enabled by default, and point to the auto-render docs for customizing delimiters via `options`.

Fixes #3662

## Test plan
- [ ] Open the Starter template section on the browser docs page and confirm the HTML example includes a body with math.
- [ ] Copy the starter HTML into a local file and open it in a browser; confirm both inline and display math render.
- [ ] Confirm the note about default delimiters and the link to autorender docs are correct.