### PR TITLE
fix: allow braced arguments for delimsizing

### DIFF
--- a/src/functions/delimsizing.ts
+++ b/src/functions/delimsizing.ts
@@ -1,5 +1,5 @@
 import {makeSpan} from "../buildCommon";
-import defineFunction from "../defineFunction";
+import defineFunction, {normalizeArgument} from "../defineFunction";
 import {makeLeftRightDelim, makeSizedDelim, sizeToMaxHeight} from "../delimiter";
 import {MathNode} from "../mathMLTree";
 import ParseError from "../ParseError";
@@ -97,7 +97,7 @@ defineFunction({
     argTypes: ["primitive"],
 
     handler: (context, args) => {
-        const delim = checkDelimiter(args[0], context);
+        const delim = checkDelimiter(normalizeArgument(args[0]), context);
 
         return {
             type: "delimsizing",

--- a/test/errors-spec.ts
+++ b/test/errors-spec.ts
@@ -263,15 +263,9 @@ describe("functions.js:", function() {
                    "Invalid delimiter '=' after '\\bigr' at position 15:" +
                    " \\bigl(1+2\\bigr=̲3");
         });
-        it("reject group opening delimiters", function() {
-            expect`\bigl{(}1+2\bigr)3`.toFailWithParseError(
-                   "Invalid delimiter type 'ordgroup' at position 6:" +
-                   " \\bigl{̲(̲}̲1+2\\bigr)3");
-        });
-        it("reject group closing delimiters", function() {
-            expect`\bigl(1+2\bigr{)}3`.toFailWithParseError(
-                   "Invalid delimiter type 'ordgroup' at position 15:" +
-                   " \\bigl(1+2\\bigr{̲)̲}̲3");
+        it("reject multi-symbol group delimiters", function() {
+            expect`\bigl{((}1+2\bigr)3`.toFailWithParseError(
+                "Invalid delimiter type 'ordgroup' at position 6: \\bigl{̲(̲(̲}̲1+2\\bigr)3");
         });
     });
 

--- a/test/katex-spec.ts
+++ b/test/katex-spec.ts
@@ -1050,6 +1050,7 @@ describe("A delimiter sizing parser", function() {
         const bare = getParsed(normalDelim)[0];
 
         expect(braced.delim).toEqual(bare.delim);
+        expect(normalDelim).toParseLike(bracedDelim);
     });
 
     it("should produce the correct direction delimiter", function() {

--- a/test/katex-spec.ts
+++ b/test/katex-spec.ts
@@ -1023,20 +1023,33 @@ describe("A delimiter sizing parser", function() {
     const normalDelim = r`\bigl |`;
     const notDelim = r`\bigl x`;
     const bigDelim = r`\Biggr \langle`;
+    const bracedDelim = r`\bigl{|}`;
 
     it("should parse normal delimiters", function() {
         expect(normalDelim).toParse();
         expect(bigDelim).toParse();
     });
 
+    it("should accept a single braced delimiter", function() {
+        expect(bracedDelim).toParse();
+    });
+
     it("should not parse not-delimiters", function() {
         expect(notDelim).not.toParse();
+        expect(r`\bigl{x}`).not.toParse();
     });
 
     it("should produce a delimsizing", function() {
         const parse = getParsed(normalDelim)[0];
 
         expect(parse.type).toEqual("delimsizing");
+    });
+
+    it("should produce the same delim for braced and unbraced forms", function() {
+        const braced = getParsed(bracedDelim)[0];
+        const bare = getParsed(normalDelim)[0];
+
+        expect(braced.delim).toEqual(bare.delim);
     });
 
     it("should produce the correct direction delimiter", function() {


### PR DESCRIPTION
<!-- PR title should follow Angular Commit Message Conventions (https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines) -->

**What is the previous behavior before this PR?**
`delimsizing` functions accepted only unbraced arguments, like `\big|`

**What is the new behavior after this PR?**
`delimsizing` functions also accept braced arguments e.g. `\big{|}`

<img width="264" height="628" alt="image" src="https://github.com/user-attachments/assets/91496a15-b943-49f9-8fe7-44d6ecae7cf8" />

**Mismatch with LaTeX behavior**:
LaTeX silently fails on multi-symbol group delimiters like `\big{||}`, first delimiter would be _big_ while other remains regular size. In current implementation KaTeX will fail with 
> Invalid delimiter type 'ordgroup'

Which, to me, doesn't look that bad because it clearly signals that the argument format is wrong, but it's still a mismatch to consider.

<!-- If this PR contains a breaking change, please uncomment following line -->
<!-- BREAKING CHANGE: describe its impact and migration methods -->

<!-- If this PR fixes or closes issues, please uncomment following line and change the issue number -->
Fixes #3828
