### PR TITLE
fix(environment): report invalid environment names as ParseError

### DIFF
--- a/src/environments/array.ts
+++ b/src/environments/array.ts
@@ -6,8 +6,12 @@ import defineFunction from "../defineFunction";
 import defineMacro from "../defineMacro";
 import {MathNode} from "../mathMLTree";
 import ParseError from "../ParseError";
-import {assertNodeType, assertSymbolNodeType} from "../parseNode";
-import {assertCharacterGroup, checkSymbolNodeType} from "../parseNode";
+import {
+    assertCharacterGroup,
+    assertNodeType,
+    assertSymbolNodeType,
+    checkSymbolNodeType,
+} from "../parseNode";
 import {Token} from "../Token";
 import {calculateSize, makeEm} from "../units";
 
@@ -734,8 +738,12 @@ const alignedHandler = function(context: EnvContextLike, args: AnyParseNode[]) {
         body: [],
     };
     if (args[0] && args[0].type === "ordgroup") {
-        numMaths = Number(
-            assertCharacterGroup(args[0], "Invalid number of columns"));
+        const message = "Number of columns should be a positive integer";
+        const numColumns = assertCharacterGroup(args[0], message);
+        if (!/^[0-9]+$/.test(numColumns) || Number(numColumns) < 1) {
+            throw new ParseError(message, args[0]);
+        }
+        numMaths = Number(numColumns);
         numCols = numMaths * 2;
     }
     const isAligned = !numCols;

--- a/src/environments/array.ts
+++ b/src/environments/array.ts
@@ -7,7 +7,7 @@ import defineMacro from "../defineMacro";
 import {MathNode} from "../mathMLTree";
 import ParseError from "../ParseError";
 import {assertNodeType, assertSymbolNodeType} from "../parseNode";
-import {checkSymbolNodeType} from "../parseNode";
+import {assertCharacterGroup, checkSymbolNodeType} from "../parseNode";
 import {Token} from "../Token";
 import {calculateSize, makeEm} from "../units";
 
@@ -734,12 +734,8 @@ const alignedHandler = function(context: EnvContextLike, args: AnyParseNode[]) {
         body: [],
     };
     if (args[0] && args[0].type === "ordgroup") {
-        let arg0 = "";
-        for (let i = 0; i < args[0].body.length; i++) {
-            const textord = assertNodeType(args[0].body[i], "textord");
-            arg0 += textord.text;
-        }
-        numMaths = Number(arg0);
+        numMaths = Number(
+            assertCharacterGroup(args[0], "Invalid number of columns"));
         numCols = numMaths * 2;
     }
     const isAligned = !numCols;

--- a/src/functions/char.ts
+++ b/src/functions/char.ts
@@ -1,6 +1,6 @@
 import defineFunction from "../defineFunction";
 import ParseError from "../ParseError";
-import {assertNodeType} from "../parseNode";
+import {assertCharacterGroup, assertNodeType} from "../parseNode";
 
 // \@char is an internal function that takes a grouped decimal argument like
 // {123} and converts into symbol with code 123.  It is used by the *macro*
@@ -13,12 +13,8 @@ defineFunction({
 
     handler({parser}, args) {
         const arg = assertNodeType(args[0], "ordgroup");
-        const group = arg.body;
-        let number = "";
-        for (let i = 0; i < group.length; i++) {
-            const node = assertNodeType(group[i], "textord");
-            number += node.text;
-        }
+        const number = assertCharacterGroup(
+            arg, "\\@char has non-numeric argument");
         let code = parseInt(number);
         let text;
         if (isNaN(code)) {

--- a/src/functions/environment.ts
+++ b/src/functions/environment.ts
@@ -19,7 +19,9 @@ defineFunction({
             throw new ParseError("Invalid environment name", nameGroup);
         }
         const envName = assertCharacterGroup(
-            nameGroup, "An environment name should be text characters", true);
+            nameGroup,
+            "Environment name should contain only text characters and spaces",
+            true);
 
         if (funcName === "\\begin") {
             // begin...end is similar to left...right

--- a/src/functions/environment.ts
+++ b/src/functions/environment.ts
@@ -18,9 +18,16 @@ defineFunction({
         if (nameGroup.type !== "ordgroup") {
             throw new ParseError("Invalid environment name", nameGroup);
         }
+        // An environment name is plain characters. Anything else -- a macro,
+        // a space -- is user error, so report it as a ParseError rather than
+        // an assertion failure that would escape `throwOnError: false`.
         let envName = "";
         for (let i = 0; i < nameGroup.body.length; ++i) {
-            envName += assertNodeType(nameGroup.body[i], "textord").text;
+            const node = nameGroup.body[i];
+            if (node.type !== "textord") {
+                throw new ParseError("Invalid environment name", nameGroup);
+            }
+            envName += node.text;
         }
 
         if (funcName === "\\begin") {

--- a/src/functions/environment.ts
+++ b/src/functions/environment.ts
@@ -18,14 +18,12 @@ defineFunction({
         if (nameGroup.type !== "ordgroup") {
             throw new ParseError("Invalid environment name", nameGroup);
         }
-        // An environment name is plain characters. Anything else -- a macro,
-        // a space -- is user error, so report it as a ParseError rather than
-        // an assertion failure that would escape `throwOnError: false`.
         let envName = "";
         for (let i = 0; i < nameGroup.body.length; ++i) {
             const node = nameGroup.body[i];
             if (node.type !== "textord") {
-                throw new ParseError("Invalid environment name", nameGroup);
+                throw new ParseError(
+                    "An environment name should be text characters", nameGroup);
             }
             envName += node.text;
         }

--- a/src/functions/environment.ts
+++ b/src/functions/environment.ts
@@ -1,6 +1,6 @@
 import defineFunction from "../defineFunction";
 import ParseError from "../ParseError";
-import {assertNodeType} from "../parseNode";
+import {assertCharacterGroup, assertNodeType} from "../parseNode";
 import environments from "../environments";
 
 import type {ParseNode} from "../types/nodes";
@@ -18,15 +18,8 @@ defineFunction({
         if (nameGroup.type !== "ordgroup") {
             throw new ParseError("Invalid environment name", nameGroup);
         }
-        let envName = "";
-        for (let i = 0; i < nameGroup.body.length; ++i) {
-            const node = nameGroup.body[i];
-            if (node.type !== "textord") {
-                throw new ParseError(
-                    "An environment name should be text characters", nameGroup);
-            }
-            envName += node.text;
-        }
+        const envName = assertCharacterGroup(
+            nameGroup, "An environment name should be text characters", true);
 
         if (funcName === "\\begin") {
             // begin...end is similar to left...right

--- a/src/parseNode.ts
+++ b/src/parseNode.ts
@@ -45,16 +45,9 @@ export function checkSymbolNodeType(node: AnyParseNode): SymbolParseNode | null 
 }
 
 /**
- * Returns the string spelled out by a group that should hold nothing but plain
- * characters, such as an environment name or a column count. Such a group is
- * user input rather than an internal invariant -- with `throwOnError: false` an
- * unsupported command in it parses to a "color" node -- so anything else in it
- * is reported as a ParseError instead of an assertion failure.
- *
- * A space parses to a spacing node rather than a textord, so callers that read
- * a name rather than a number pass allowSpaces: an environment may be defined
- * with a space in its name. Only a literal space is taken as one, so `~` and
- * `\ ` are rejected either way.
+ * Returns the string spelled out by a group of plain characters, throwing the
+ * given ParseError if the group holds anything else. With allowSpaces, a
+ * literal space counts as a character; `~` and `\ ` do not.
  */
 export function assertCharacterGroup(
     group: ParseNode<"ordgroup">,

--- a/src/parseNode.ts
+++ b/src/parseNode.ts
@@ -1,4 +1,5 @@
 import {NonAtoms} from "./atoms";
+import ParseError from "./ParseError";
 import type {AnyParseNode, NodeType, ParseNode, SymbolParseNode} from "./types/nodes";
 
 /**
@@ -41,4 +42,34 @@ export function checkSymbolNodeType(node: AnyParseNode): SymbolParseNode | null 
         return node as SymbolParseNode;
     }
     return null;
+}
+
+/**
+ * Returns the string spelled out by a group that should hold nothing but plain
+ * characters, such as an environment name or a column count. Such a group is
+ * user input rather than an internal invariant -- with `throwOnError: false` an
+ * unsupported command in it parses to a "color" node -- so anything else in it
+ * is reported as a ParseError instead of an assertion failure.
+ *
+ * A space parses to a spacing node rather than a textord, so callers that read
+ * a name rather than a number pass allowSpaces: an environment may be defined
+ * with a space in its name. Only a literal space is taken as one, so `~` and
+ * `\ ` are rejected either way.
+ */
+export function assertCharacterGroup(
+    group: ParseNode<"ordgroup">,
+    errorMessage: string,
+    allowSpaces?: boolean,
+): string {
+    let text = "";
+    for (const node of group.body) {
+        if (node.type === "textord") {
+            text += node.text;
+        } else if (allowSpaces && node.type === "spacing" && node.text === " ") {
+            text += " ";
+        } else {
+            throw new ParseError(errorMessage, group);
+        }
+    }
+    return text;
 }

--- a/test/errors-spec.ts
+++ b/test/errors-spec.ts
@@ -80,11 +80,11 @@ describe("Parser:", function() {
         });
         it("reports environment names that aren't plain characters", function() {
             expect`\begin{ma trix}x\end{ma trix}`.toFailWithParseError(
-                   "Invalid environment name at position 7:" +
-                   " \\begin{̲m̲a̲ ̲t̲r̲i̲x̲}̲x\\end{ma trix}");
+                   "An environment name should be text characters" +
+                   " at position 7: \\begin{̲m̲a̲ ̲t̲r̲i̲x̲}̲x\\end{ma trix}");
             expect`\begin{\text{a}}`.toFailWithParseError(
-                   "Invalid environment name at position 7:" +
-                   " \\begin{̲\\̲t̲e̲x̲t̲{̲a̲}̲}̲");
+                   "An environment name should be text characters" +
+                   " at position 7: \\begin{̲\\̲t̲e̲x̲t̲{̲a̲}̲}̲");
         });
     });
 

--- a/test/errors-spec.ts
+++ b/test/errors-spec.ts
@@ -78,6 +78,14 @@ describe("Parser:", function() {
                    "Mismatch: \\begin{pmatrix} matched by \\end{bmatrix}" +
                    " at position 24: …matrix}1&2\\\\3&4\\̲e̲n̲d̲{bmatrix}+5");
         });
+        it("reports environment names that aren't plain characters", function() {
+            expect`\begin{ma trix}x\end{ma trix}`.toFailWithParseError(
+                   "Invalid environment name at position 7:" +
+                   " \\begin{̲m̲a̲ ̲t̲r̲i̲x̲}̲x\\end{ma trix}");
+            expect`\begin{\text{a}}`.toFailWithParseError(
+                   "Invalid environment name at position 7:" +
+                   " \\begin{̲\\̲t̲e̲x̲t̲{̲a̲}̲}̲");
+        });
     });
 
     describe("#parseFunction", function() {

--- a/test/errors-spec.ts
+++ b/test/errors-spec.ts
@@ -85,17 +85,28 @@ describe("Parser:", function() {
         });
         it("reports environment names that aren't plain characters", function() {
             expect`\begin{\text{a}}`.toFailWithParseError(
-                   "An environment name should be text characters" +
-                   " at position 7: \\begin{̲\\̲t̲e̲x̲t̲{̲a̲}̲}̲");
+                   "Environment name should contain only text characters" +
+                   " and spaces at position 7: \\begin{̲\\̲t̲e̲x̲t̲{̲a̲}̲}̲");
             expect`\begin{ma~trix}x\end{ma~trix}`.toFailWithParseError(
-                   "An environment name should be text characters" +
-                   " at position 7: \\begin{̲m̲a̲~̲t̲r̲i̲x̲}̲x\\end{ma~trix}");
+                   "Environment name should contain only text characters" +
+                   " and spaces at position 7:" +
+                   " \\begin{̲m̲a̲~̲t̲r̲i̲x̲}̲x\\end{ma~trix}");
         });
-        it("reports column counts that aren't plain characters", function() {
+        it("rejects a column count that isn't a positive integer", function() {
             expect`\begin{alignedat}{\text{2}}a&b\end{alignedat}`
                 .toFailWithParseError(
-                   "Invalid number of columns at position 18:" +
+                   "Number of columns should be a positive integer" +
+                   " at position 18:" +
                    " …egin{alignedat}{̲\\̲t̲e̲x̲t̲{̲2̲}̲}̲a&b\\end{aligned…");
+            expect`\begin{alignedat}{2.5}a&b\end{alignedat}`
+                .toFailWithParseError(
+                   "Number of columns should be a positive integer" +
+                   " at position 18:" +
+                   " …egin{alignedat}{̲2̲.̲5̲}̲a&b\\end{aligned…");
+            expect`\begin{alignedat}{0}a&b\end{alignedat}`
+                .toFailWithParseError(
+                   "Number of columns should be a positive integer" +
+                   " at position 18: …egin{alignedat}{̲0̲}̲a&b\\end{aligned…");
         });
     });
 

--- a/test/errors-spec.ts
+++ b/test/errors-spec.ts
@@ -78,13 +78,24 @@ describe("Parser:", function() {
                    "Mismatch: \\begin{pmatrix} matched by \\end{bmatrix}" +
                    " at position 24: …matrix}1&2\\\\3&4\\̲e̲n̲d̲{bmatrix}+5");
         });
-        it("reports environment names that aren't plain characters", function() {
+        it("keeps spaces in an environment name", function() {
             expect`\begin{ma trix}x\end{ma trix}`.toFailWithParseError(
-                   "An environment name should be text characters" +
-                   " at position 7: \\begin{̲m̲a̲ ̲t̲r̲i̲x̲}̲x\\end{ma trix}");
+                   "No such environment: ma trix at position 7:" +
+                   " \\begin{̲m̲a̲ ̲t̲r̲i̲x̲}̲x\\end{ma trix}");
+        });
+        it("reports environment names that aren't plain characters", function() {
             expect`\begin{\text{a}}`.toFailWithParseError(
                    "An environment name should be text characters" +
                    " at position 7: \\begin{̲\\̲t̲e̲x̲t̲{̲a̲}̲}̲");
+            expect`\begin{ma~trix}x\end{ma~trix}`.toFailWithParseError(
+                   "An environment name should be text characters" +
+                   " at position 7: \\begin{̲m̲a̲~̲t̲r̲i̲x̲}̲x\\end{ma~trix}");
+        });
+        it("reports column counts that aren't plain characters", function() {
+            expect`\begin{alignedat}{\text{2}}a&b\end{alignedat}`
+                .toFailWithParseError(
+                   "Invalid number of columns at position 18:" +
+                   " …egin{alignedat}{̲\\̲t̲e̲x̲t̲{̲2̲}̲}̲a&b\\end{aligned…");
         });
     });
 

--- a/test/katex-spec.ts
+++ b/test/katex-spec.ts
@@ -3512,6 +3512,15 @@ describe("A parser that does not throw on unsupported commands", function() {
             expect`\begin{\error}x\end{\error}`.toBuild(noThrowSettings);
             expect`\begin{matrix}a\end{\pmatrix}`.toBuild(noThrowSettings);
         });
+
+        it("in a column count", function() {
+            expect`\begin{alignedat}{\error}a&b\end{alignedat}`
+                .toBuild(noThrowSettings);
+        });
+
+        it("in a \\@char argument", function() {
+            expect`\@char{\error}`.toBuild(noThrowSettings);
+        });
     });
 
     it("should produce color nodes with a color value given by errorColor", function() {
@@ -3851,6 +3860,15 @@ describe("A macro expander", function() {
         expect`\char'a`.not.toParse();
         expect`\char"g`.not.toParse();
         expect`\char"g`.not.toParse();
+    });
+
+    it("\\@char reports a non-character argument", () => {
+        expect`\@char{\text{2}}`.toFailWithParseError(
+               "\\@char has non-numeric argument at position 7:" +
+               " \\@char{̲\\̲t̲e̲x̲t̲{̲2̲}̲}̲");
+        // A space is part of an environment name but not of a code point, and
+        // in text mode it reaches the argument as a spacing node.
+        expect`\text{\@char{6 5}}`.not.toParse();
     });
 
     it("\\char escapes ~ correctly", () => {

--- a/test/katex-spec.ts
+++ b/test/katex-spec.ts
@@ -3505,6 +3505,13 @@ describe("A parser that does not throw on unsupported commands", function() {
         it("in text boxes", function() {
             expect`\text{\error}`.toBuild(noThrowSettings);
         });
+
+        it("in environment names", function() {
+            expect`\begin{\pmatrix}`.toBuild(noThrowSettings);
+            expect`\begin{\error}`.toBuild(noThrowSettings);
+            expect`\begin{\error}x\end{\error}`.toBuild(noThrowSettings);
+            expect`\begin{matrix}a\end{\pmatrix}`.toBuild(noThrowSettings);
+        });
     });
 
     it("should produce color nodes with a color value given by errorColor", function() {


### PR DESCRIPTION
**What is the previous behavior before this PR?**

`\begin` and `\end` build the environment name by asserting that every node in the name group is a `textord` (`src/functions/environment.ts`). `assertNodeType` throws a plain `Error`, not a `ParseError`, so an environment name that doesn't parse to plain characters is reported as an internal failure.

With `throwOnError: false` that plain `Error` escapes the error handling entirely and crashes the caller instead of rendering error markup, which is the blank `react-katex` page described in #3760:

```js
katex.renderToString("\\begin{\\pmatrix}", {throwOnError: false});
// Uncaught Error: Expected node of type textord, but got node of type color
```

This isn't specific to `\pmatrix`. Under the default settings `\begin{\pmatrix}` fails earlier on the undefined control sequence, which is why it looks fine there, but a name that reaches the assertion by another route throws the plain `Error` under the default settings too:

```js
katex.renderToString("\\begin{\\text{a}}");
// Uncaught Error: Expected node of type textord, but got node of type text
```

`\end` is affected the same way, since one handler serves both: `\begin{matrix}a\end{\pmatrix}` with `throwOnError: false` throws instead of rendering.

The same assertion also rejects `\begin{ma trix}`, because a space parses to a `spacing` node rather than a `textord`. LaTeX lets an environment be defined with a space in its name, so that name should be read and then reported as missing, not refused for holding a space.

Two other argument readers have the same shape and the same bug: the column count of `\begin{alignedat}{n}` and the argument of `\@char`. The column count is then read with `Number()`, which takes anything numeric, so `\begin{alignedat}{2.5}` asks for five columns and `\begin{alignedat}{0}` silently falls back to the automatic column counting of `aligned`.

**What is the new behavior after this PR?**

`assertCharacterGroup()` in `src/parseNode.ts` reads a group that should hold nothing but plain characters and throws a `ParseError` for anything else. `\begin`/`\end`, `\begin{alignedat}{n}` and `\@char` all read their argument through it, so all three render the usual error markup under `throwOnError: false` instead of crashing the caller, and report a parse error rather than an internal failure under the default settings:

- `\begin{\pmatrix}`, `\begin{\text{a}}`, `\end{\pmatrix}` → `ParseError: Environment name should contain only text characters and spaces`
- `\begin{alignedat}{\text{2}}` → `ParseError: Number of columns should be a positive integer`
- `\@char{\error}` → `ParseError: \@char has non-numeric argument`

A literal space counts as a character, so `\begin{ma trix}` now reads the name and reports `No such environment: ma trix`. Only a literal space does: `~` and `\ ` parse to `spacing` nodes as well but are not spaces in a name, so they stay rejected.

Whether a space is a character is the caller's decision rather than the helper's, so only `\begin` and `\end` opt in. `\@char` is allowed in text mode, where `\text{\@char{6 5}}` would otherwise reach `parseInt` as `6 5` and silently render U+0006.

The column count of `\begin{alignedat}{n}` now has to be a positive integer, so `{2.5}` and `{0}` are reported instead of being taken as five columns and as no column count at all.

The `ordgroup` check above the environment name keeps its own `Invalid environment name` message: that is a different failure, the argument not being a group at all.

`test/errors-spec.ts` covers the cases that reach these guards under the default settings. `test/katex-spec.ts` covers `\begin{\pmatrix}`, `\begin{\error}`, `\end{\pmatrix}`, `\begin{alignedat}{\error}` and `\@char{\error}` under `throwOnError: false`, which is the path this escaped. All of them fail without the source change. Full Jest suite, `tsc` and lint pass.

Two more argument readers have the same plain `Error`, and I've left both for a follow-up because neither has the shape this helper reads: `\genfrac` looks at only the first node of its style group, so reading the whole group through the helper would change what `\genfrac{}{}{}{01}{a}{b}` means, and the column spec of `{array}` goes through `assertSymbolNodeType` per node, where the existing `Unknown column alignment` `ParseError` is the report to reach for instead.

Fixes #3760
