### PR TITLE
fix(char): reject control, surrogate and noncharacter code points

### DIFF
--- a/docs/supported.md
+++ b/docs/supported.md
@@ -230,7 +230,7 @@ All unrecognized characters will be treated as if they appeared in text mode, an
 
 For Persian composite characters, a user-supplied [plug-in](https://github.com/HosseinAgha/persian-katex-plugin) is under development.
 
-Any character can be written with the `\char` function and the Unicode code in hex. For example `\char"263a` will render as $\char"263a$.
+Any character can be written with the `\char` function and the Unicode code in hex, except for surrogates, noncharacters, and control characters other than tab, line feed and carriage return. For example `\char"263a` will render as $\char"263a$.
 
 ## Layout
 

--- a/src/functions/char.ts
+++ b/src/functions/char.ts
@@ -2,6 +2,21 @@ import defineFunction from "../defineFunction";
 import ParseError from "../ParseError";
 import {assertNodeType} from "../parseNode";
 
+// A code point inside the Unicode codespace is not necessarily one the output
+// may contain.  Of those rejected below, the C0 controls, the surrogates and
+// U+FFFE/U+FFFF are outside XML's Char production, so emitting one would make
+// the MathML ill-formed; the rest are legal XML but are HTML parse errors.
+const isForbiddenInOutput = (code: number): boolean =>
+    // C0 controls; form feed is not exempted because it is not valid XML
+    (code < 0x20 && code !== 0x09 && code !== 0x0a && code !== 0x0d) ||
+    // DEL and the C1 controls
+    (code >= 0x7f && code <= 0x9f) ||
+    // surrogates
+    (code >= 0xd800 && code <= 0xdfff) ||
+    // noncharacters; the second test covers U+nFFFE and U+nFFFF in any plane
+    (code >= 0xfdd0 && code <= 0xfdef) ||
+    (code & 0xfffe) === 0xfffe;
+
 // \@char is an internal function that takes a grouped decimal argument like
 // {123} and converts into symbol with code 123.  It is used by the *macro*
 // \char defined in macros.js.
@@ -25,8 +40,11 @@ defineFunction({
             throw new ParseError(`\\@char has non-numeric argument ${number}`);
         // If we drop IE support, the following code could be replaced with
         // text = String.fromCodePoint(code)
-        } else if (code < 0 || code >= 0x10ffff) {
+        } else if (code < 0 || code > 0x10ffff) {
             throw new ParseError(`\\@char with invalid code point ${number}`);
+        } else if (isForbiddenInOutput(code)) {
+            throw new ParseError(
+                `\\@char code point ${number} is not allowed in the output`);
         } else if (code <= 0xffff) {
             text = String.fromCharCode(code);
         } else { // Astral code point; split into surrogate halves

--- a/test/errors-spec.ts
+++ b/test/errors-spec.ts
@@ -282,6 +282,51 @@ describe("functions.js:", function() {
         });
     });
 
+    describe("\\char", function() {
+        it("rejects code points outside Unicode", function() {
+            expect`\char1114112`.toFailWithParseError(
+                   "\\@char with invalid code point 1114112");
+        });
+        it("rejects control characters", function() {
+            expect`\char0`.toFailWithParseError(
+                   "\\@char code point 0 is not allowed in the output");
+            expect`\char12`.toFailWithParseError(
+                   "\\@char code point 12 is not allowed in the output");
+            expect`\char31`.toFailWithParseError(
+                   "\\@char code point 31 is not allowed in the output");
+            expect`\char127`.toFailWithParseError(
+                   "\\@char code point 127 is not allowed in the output");
+            expect`\char128`.toFailWithParseError(
+                   "\\@char code point 128 is not allowed in the output");
+            expect`\char159`.toFailWithParseError(
+                   "\\@char code point 159 is not allowed in the output");
+        });
+        it("rejects surrogate code points", function() {
+            expect`\char55296`.toFailWithParseError(
+                   "\\@char code point 55296 is not allowed in the output");
+            expect`\char57343`.toFailWithParseError(
+                   "\\@char code point 57343 is not allowed in the output");
+        });
+        it("rejects noncharacters", function() {
+            expect`\char64976`.toFailWithParseError(
+                   "\\@char code point 64976 is not allowed in the output");
+            expect`\char65007`.toFailWithParseError(
+                   "\\@char code point 65007 is not allowed in the output");
+            expect`\char65534`.toFailWithParseError(
+                   "\\@char code point 65534 is not allowed in the output");
+            expect`\char65535`.toFailWithParseError(
+                   "\\@char code point 65535 is not allowed in the output");
+            expect`\char131070`.toFailWithParseError(
+                   "\\@char code point 131070 is not allowed in the output");
+            expect`\char1114110`.toFailWithParseError(
+                   "\\@char code point 1114110 is not allowed in the output");
+            // U+10FFFF is a real code point, so it must be rejected here and
+            // not by the range check above.
+            expect`\char1114111`.toFailWithParseError(
+                   "\\@char code point 1114111 is not allowed in the output");
+        });
+    });
+
 });
 
 describe("Lexer:", function() {

--- a/test/katex-spec.ts
+++ b/test/katex-spec.ts
@@ -3859,6 +3859,33 @@ describe("A macro expander", function() {
         expect(parsed[0].text).toEqual("𝟙");
     });
 
+    // errors-spec.ts covers the rejected code points and their message; these
+    // pin the other side of each boundary.  toParse, not toBuild: the guard
+    // runs at parse time and most of these have no font metrics.
+    it("\\char accepts characters the output may contain", () => {
+        expect`\char9`.toParse();       // tab
+        expect`\char10`.toParse();      // line feed
+        expect`\char13`.toParse();      // carriage return
+        expect`\char32`.toParse();      // space, just above the C0 controls
+        expect`\char160`.toParse();     // U+00A0, just above the C1 controls
+        expect`\char55295`.toParse();   // U+D7FF, just below the surrogates
+        expect`\char57344`.toParse();   // U+E000, just above the surrogates
+        expect`\char64975`.toParse();   // U+FDCF, just below U+FDD0
+        expect`\char65008`.toParse();   // U+FDF0, just above U+FDEF
+        expect`\char65533`.toParse();   // U+FFFD, just below U+FFFE
+        expect`\char65536`.toParse();   // first astral code point
+        expect`\char1114109`.toParse(); // U+10FFFD, last code point that is a character
+    });
+
+    it("\\char does not emit invalid characters with throwOnError: false",
+        () => {
+            expect(katex.renderToString(r`\char0`, {throwOnError: false}))
+                .not.toContain(String.fromCharCode(0));
+            // A lone surrogate is the case that cannot be encoded as UTF-8.
+            expect(katex.renderToString(r`\char55296`, {throwOnError: false}))
+                .not.toContain(String.fromCharCode(0xd800));
+        });
+
     it("should build Unicode private area characters", function() {
         expect`\gvertneqq\lvertneqq\ngeqq\ngeqslant\nleqq`.toBuild();
         expect`\nleqslant\nshortmid\nshortparallel\varsubsetneq`.toBuild();


### PR DESCRIPTION
**What is the previous behavior before this PR?**

`\@char` checked only that its argument was inside the Unicode codespace, then wrote the resulting character straight into both the HTML and the MathML output. Being a code point is weaker than being a character that may appear in a document, so several ranges escaped into the markup:

| Input | Emitted |
|---|---|
| `\char0`, `\char12`, `\char127`, `\char128` | raw C0/C1 control bytes |
| `\char55296` | a lone surrogate |
| `\char64976`, `\char65534`, `\char1114110` | Unicode noncharacters |

All of it is reachable from user input, which is the case that matters for a site rendering untrusted LaTeX.

**What is the new behavior after this PR?**

Four groups are now rejected with a `ParseError`, for two distinct reasons.

*They cannot be represented.* The C0 controls other than tab, line feed and carriage return — form feed included — the surrogates, and `U+FFFE`/`U+FFFF` fall outside XML's `Char` production, so the emitted MathML was not well-formed and a strict XML consumer (EPUB, XHTML, a server-side pipeline) fails outright. A lone surrogate additionally has no UTF-8 encoding at all.

*Unicode does not permit them in interchange.* DEL, the C1 controls, `U+FDD0`–`U+FDEF`, and `U+nFFFE`/`U+nFFFF` for n ≥ 1 are legal XML 1.0, so the weaker claim is the honest one for these: HTML makes each of them a parse error, and a browser will not reproduce what was asked for.

```
\char0 → KaTeX parse error: \@char code point 0 is not allowed in the output
```

Because it is a `ParseError` rather than an assertion, `throwOnError: false` renders the usual error text instead of leaking the byte.

**This rejects input that previously rendered.** It is a visible behaviour change, so flagging it explicitly. I have left it as `fix:` rather than adding a `BREAKING CHANGE:` footer, on the grounds that the affected inputs never produced usable output — a browser substitutes U+FFFD or drops the character — so no working document should depend on them. Happy to add the footer if you would rather it went out as a major.

Still accepted, with tests now on **both** sides of every boundary: `\char9`, `\char10`, `\char13`, `\char32`, `\char160`, `\char55295`, `\char57344`, `\char64975`, `\char65008`, `\char65533`, `\char65536`, `\char1114109`, and the existing `\char"1d7d9`.

**Scope.** This guards `\@char` only, and is not an output-wide invariant. A literal C1 control or noncharacter placed directly in the input string still reaches the output, because `Lexer`'s `tokenRegex` admits them; literal C0 controls and lone surrogates are already rejected while lexing. `\char` is the path that lets plain ASCII input construct an arbitrary code point, which is why it is the one the issue reports, but enforcing the same invariant where the text node is serialized would cover the remaining cases. That is a larger change — happy to open a follow-up issue, or to widen this PR, whichever you prefer.

Two smaller notes:

- The bound on the existing range check was off by one (`code >= 0x10ffff` rejected `U+10FFFF`, which is a real code point). Corrected to `> 0x10ffff`. `U+10FFFF` is a noncharacter, so it is still rejected — only now with the accurate message, which a test pins.
- The issue also reports that "the number is interpreted modulo 65536, so `\char65536` also outputs a NUL character". That was true of 0.12.0 but is not true today — `\char65536` correctly produces `U+10000`, and there is now a test for it.

Docs updated, since `supported.md` promised that any character can be written with `\char`.

Fixes #2549
