### PR TITLE
fix(char): accept U+10FFFF

### DIFF
--- a/src/functions/char.ts
+++ b/src/functions/char.ts
@@ -21,7 +21,7 @@ defineFunction({
             throw new ParseError(`\\@char has non-numeric argument ${number}`);
         // If we drop IE support, the following code could be replaced with
         // text = String.fromCodePoint(code)
-        } else if (code < 0 || code >= 0x10ffff) {
+        } else if (code < 0 || code > 0x10ffff) {
             throw new ParseError(`\\@char with invalid code point ${number}`);
         } else if (code <= 0xffff) {
             text = String.fromCharCode(code);

--- a/test/katex-spec.ts
+++ b/test/katex-spec.ts
@@ -3898,7 +3898,14 @@ describe("A macro expander", function() {
         expect(parsed[0].text).toEqual("𝟙");
     });
 
-    it("\\char accepts the last code point of the Unicode codespace", () => {
+    it("\\char accepts the first and last code point of every plane", () => {
+        for (let plane = 0; plane <= 0x10; plane++) {
+            for (const code of [plane * 0x10000, plane * 0x10000 + 0xffff]) {
+                const parsed = getParsed(`\\char"${code.toString(16)}`);
+                expect(parsed[0].type).toEqual("textord");
+            }
+        }
+    });
         const parsed = getParsed`\char"10ffff`;
         expect(parsed[0].type).toEqual("textord");
         // Written as a surrogate pair, since U+10FFFF has no visible glyph

--- a/test/katex-spec.ts
+++ b/test/katex-spec.ts
@@ -3906,11 +3906,6 @@ describe("A macro expander", function() {
             }
         }
     });
-        const parsed = getParsed`\char"10ffff`;
-        expect(parsed[0].type).toEqual("textord");
-        // Written as a surrogate pair, since U+10FFFF has no visible glyph
-        expect(parsed[0].text).toEqual("\udbff\udfff");
-    });
 
     it("\\char rejects code points outside the Unicode codespace", () => {
         expect`\char"110000`.toFailWithParseError();

--- a/test/katex-spec.ts
+++ b/test/katex-spec.ts
@@ -3898,6 +3898,17 @@ describe("A macro expander", function() {
         expect(parsed[0].text).toEqual("𝟙");
     });
 
+    it("\\char accepts the last code point of the Unicode codespace", () => {
+        const parsed = getParsed`\char"10ffff`;
+        expect(parsed[0].type).toEqual("textord");
+        // Written as a surrogate pair, since U+10FFFF has no visible glyph
+        expect(parsed[0].text).toEqual("\udbff\udfff");
+    });
+
+    it("\\char rejects code points outside the Unicode codespace", () => {
+        expect`\char"110000`.toFailWithParseError();
+    });
+
     it("should build Unicode private area characters", function() {
         expect`\gvertneqq\lvertneqq\ngeqq\ngeqslant\nleqq`.toBuild();
         expect`\nleqslant\nshortmid\nshortparallel\varsubsetneq`.toBuild();


### PR DESCRIPTION
**What is the previous behavior before this PR?**

`\@char`'s range check was `code < 0 || code >= 0x10ffff`. The upper bound is off by one: U+10FFFF is inside the Unicode codespace, so `\char"10ffff` failed to parse while `\char"10fffe` parsed fine. U+10FFFF was the only code point the bound wrongly excluded.

**What is the new behavior after this PR?**

The bound becomes `> 0x10ffff`, and `\char"10ffff` parses.

U+10FFFF is a noncharacter, so it has no visible glyph and is of little use in a document. Whether `\char` should reject noncharacters as a class is a separate question, discussed in #2549 and in #4257; this PR takes no position on it — the bound is wrong either way. @edemaine agreed in [this review](https://github.com/KaTeX/KaTeX/pull/4257#pullrequestreview-4898604976) that this part should be extracted and merged on its own, so this is that extraction.

Tests cover both sides of the boundary — `\char"10ffff` parses and yields U+10FFFF, `\char"110000` does not parse. Neither side was covered before.
