### PR TITLE
chore(deps): update dependency commander to v15

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "commander": "^8.3.0"
+    "commander": "^15.0.0"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       commander:
-        specifier: ^8.3.0
-        version: 8.3.0
+        specifier: ^15.0.0
+        version: 15.0.0
     devDependencies:
       '@babel/core':
         specifier: ^7.29.0
@@ -2604,16 +2604,16 @@ packages:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
 
+  commander@15.0.0:
+    resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
+    engines: {node: '>=22.12.0'}
+
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
   commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
     engines: {node: '>= 10'}
-
-  commander@8.3.0:
-    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
-    engines: {node: '>= 12'}
 
   commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
@@ -9274,11 +9274,11 @@ snapshots:
 
   commander@14.0.3: {}
 
+  commander@15.0.0: {}
+
   commander@2.20.3: {}
 
   commander@7.2.0: {}
-
-  commander@8.3.0: {}
 
   commondir@1.0.1: {}
 


### PR DESCRIPTION
**What is the previous behavior before this PR?**

KaTeX depends on `commander@^8.3.0` (last published in October 2021, now end-of-life).

**What is the new behavior after this PR?**

`commander@^15.0.0` (current latest major). Works on all supported versions of Node.

**Why this is safe**

`commander` is used in three places: `cli.js` (the published `bin`), and two dev-only scripts (`dockers/screenshotter/screenshotter.js`, `test/symgroups.ts`). I reviewed the breaking changes of every major from 9 through 15 against these usages, and verified empirically by running `cli.js` through the full option matrix on commander 8.3.0 vs 15.0.0. The output is byte-identical, including:

- repeated `-m` macro accumulation (custom `cliProcessor` with default `[]`)
- the negated flag `-t, --no-throw-on-error` (default stays `true`, `-t`/`--no-throw-on-error` set `false`)
- all `cliProcessor` coercions (`-c`, `-s`, `-e Infinity`, `--min-rule-thickness`)
- `--version`, error paths and exit codes
- the module export consumed by `website/lib/build.js` (`program.options` — flags/description/defaultValue unchanged), so `docs/cli.md` generation is unaffected
- the exact `.option()` calls used by the screenshotter and symgroups scripts

Only two observable differences:

1. **Excess positional arguments now error** (`allowExcessArguments` default changed in commander 13). E.g. `katex somefile` previously ignored the argument silently and waited on stdin; now it exits with `error: too many arguments`. Since the CLI takes no positional arguments, this turns a silent no-op into a clear error (e.g. catches forgetting `-i` before a filename).
2. `--help` output wraps at a slightly different column (cosmetic).

Validation on this branch: `pnpm test` (lint, tsc, 1303 jest tests) passes, and I built `dist/` and smoke-tested `cli.js` end-to-end against commander 15.

Side note: Renovate stopped proposing commander majors after #3536 was closed unmerged; once this manual upgrade lands, it resumes minor/patch updates for 15.x automatically.

Fixes #3857

🤖 Generated with [Claude Code](https://claude.com/claude-code)