### PR TITLE
fix(array): preserve tags on empty final rows

### DIFF
--- a/src/environments/array.ts
+++ b/src/environments/array.ts
@@ -210,12 +210,13 @@ function parseArray(
             endRow();
             // Arrays terminate newlines with `\crcr` which consumes a `\cr` if
             // the last line is empty.  However, AMS environments keep the
-            // empty row if it's the only one.
+            // empty row if it's the only one or has a manual tag.
             // NOTE: Currently, `cell` is the last item added into `row`.
             if (row.length === 1 && cell.type === "styling" &&
                 cell.body.length === 1 && cell.body[0].type === "ordgroup" &&
                 cell.body[0].body.length === 0 &&
-                (body.length > 1 || !emptySingleRow)) {
+                (body.length > 1 || !emptySingleRow) &&
+                !Array.isArray(tags?.[tags.length - 1])) {
                 body.pop();
             }
             if (hLinesBeforeRow.length < body.length + 1) {

--- a/test/katex-spec.ts
+++ b/test/katex-spec.ts
@@ -4248,6 +4248,14 @@ describe("\\tag support", function() {
         expect`\begin{align}\tag{1}x\\&+y\tag{2}\end{align}`.toParse(displayMode);
     });
 
+    it("should keep a manual tag on an empty final row", () => {
+        const markup = katex.renderToString(
+            r`\begin{align}\nonumber a\\\tag{1}\end{align}`,
+            {displayMode: true},
+        );
+        expect(markup).toContain("<span class=\"mord\">1</span>");
+    });
+
     it("should work with \\nonumber/\\notag", () => {
         expect`\begin{align}\tag{1}\nonumber x\\&+y\notag\end{align}`
         .toParseLike(r`\begin{align}\tag{1}x\\&+y\nonumber\end{align}`, displayMode);


### PR DESCRIPTION
**What is the previous behavior before this PR?**

An explicit `\tag` on an empty final row of an `align` environment is recorded, but the row is then removed as a trailing empty row. This leaves the row and tag arrays out of alignment, so the visible tag column is empty.

**What is the new behavior after this PR?**

Final empty rows are retained when they carry a manual tag. Automatic empty trailing rows and rows disabled with `\nonumber` continue to be removed.

The regression test fails on the previous implementation because the visible tag span is absent and passes with the fix.

Validation:

- ESLint
- Stylelint
- TypeScript (`tsc --noEmit`)
- Jest: 8 suites, 1306 tests, 125 snapshots
- Full production build
- `git diff --check`

Fixes #3898
