### PR TITLE
fix(copy-tex): copy every range of a multi-range selection

### DIFF
--- a/contrib/copy-tex/copy-tex.ts
+++ b/contrib/copy-tex/copy-tex.ts
@@ -16,21 +16,40 @@ document.addEventListener('copy', function(event: ClipboardEvent) {
         return; // default action OK if selection is empty or unchangeable
     }
     const clipboardData = event.clipboardData;
-    const range = selection.getRangeAt(0);
 
-    // When start point is within a formula, expand to entire formula.
-    const startKatex = closestKatex(range.startContainer);
-    if (startKatex) {
-        range.setStartBefore(startKatex);
+    // A selection can hold more than one range.  Firefox builds one range
+    // per Ctrl-click, and before Firefox 147 it also split a selection
+    // around `user-select: none` elements.  Reading only the first range
+    // drops everything after it.
+    const fragment = document.createDocumentFragment();
+    let copiedKatex: Element | null | undefined = null;
+    for (let i = 0; i < selection.rangeCount; i++) {
+        const range = selection.getRangeAt(i);
+
+        // When start point is within a formula, expand to entire formula,
+        // unless an earlier range already copied that formula: expanding
+        // again would repeat it.  Starting after it instead leaves a range
+        // wholly inside the formula collapsed, contributing nothing.
+        const startKatex = closestKatex(range.startContainer);
+        if (startKatex) {
+            if (startKatex === copiedKatex) {
+                range.setStartAfter(startKatex);
+            } else {
+                range.setStartBefore(startKatex);
+            }
+        }
+
+        // Similarly, when end point is within a formula, expand to entire
+        // formula.
+        const endKatex = closestKatex(range.endContainer);
+        if (endKatex) {
+            range.setEndAfter(endKatex);
+            copiedKatex = endKatex;
+        }
+
+        fragment.appendChild(range.cloneContents());
     }
 
-    // Similarly, when end point is within a formula, expand to entire formula.
-    const endKatex = closestKatex(range.endContainer);
-    if (endKatex) {
-        range.setEndAfter(endKatex);
-    }
-
-    const fragment = range.cloneContents();
     if (!fragment.querySelector('.katex-mathml')) {
         return; // default action OK if no .katex-mathml elements
     }

--- a/contrib/copy-tex/copy-tex.ts
+++ b/contrib/copy-tex/copy-tex.ts
@@ -22,17 +22,17 @@ document.addEventListener('copy', function(event: ClipboardEvent) {
     // around `user-select: none` elements.  Reading only the first range
     // drops everything after it.
     const fragment = document.createDocumentFragment();
-    let copiedKatex: Element | null | undefined = null;
+    const copied: Range[] = [];
     for (let i = 0; i < selection.rangeCount; i++) {
         const range = selection.getRangeAt(i);
 
-        // When start point is within a formula, expand to entire formula,
-        // unless an earlier range already copied that formula: expanding
-        // again would repeat it.  Starting after it instead leaves a range
-        // wholly inside the formula collapsed, contributing nothing.
+        // When start point is within a formula, expand to entire formula.
+        // If an earlier range already copied that formula, start after it
+        // instead, so the formula is not repeated; a range lying wholly
+        // inside it then collapses and contributes nothing.
         const startKatex = closestKatex(range.startContainer);
         if (startKatex) {
-            if (startKatex === copiedKatex) {
+            if (copied.some((r) => r.intersectsNode(startKatex))) {
                 range.setStartAfter(startKatex);
             } else {
                 range.setStartBefore(startKatex);
@@ -44,10 +44,10 @@ document.addEventListener('copy', function(event: ClipboardEvent) {
         const endKatex = closestKatex(range.endContainer);
         if (endKatex) {
             range.setEndAfter(endKatex);
-            copiedKatex = endKatex;
         }
 
         fragment.appendChild(range.cloneContents());
+        copied.push(range.cloneRange());
     }
 
     if (!fragment.querySelector('.katex-mathml')) {

--- a/contrib/copy-tex/test/copy-tex-spec.ts
+++ b/contrib/copy-tex/test/copy-tex-spec.ts
@@ -70,7 +70,7 @@ describe("copy-tex", () => {
         expect(text).toBe("first $x^2$ second  third");
     });
 
-    it("does not repeat a formula covered by two ranges", () => {
+    it("does not repeat a formula split across two ranges", () => {
         buildDocument();
         const math = document.querySelector(".katex")!;
         const parts = [
@@ -85,5 +85,19 @@ describe("copy-tex", () => {
         }));
 
         expect(text).toBe("$x^2$");
+    });
+
+    it("does not repeat a formula an earlier range already covered", () => {
+        const {beforeGap} = buildDocument();
+        const inner = document.createRange();
+        inner.selectNodeContents(document.querySelector(".katex-html")!);
+
+        const text = copy([
+            // Covers the whole formula without either endpoint inside it.
+            rangeOver(document.body.firstChild!, beforeGap),
+            inner,
+        ]);
+
+        expect(text).toBe("first $x^2$ second ");
     });
 });

--- a/contrib/copy-tex/test/copy-tex-spec.ts
+++ b/contrib/copy-tex/test/copy-tex-spec.ts
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment jsdom
+ */
+import katex from "katex";
+
+// Importing the module installs its global 'copy' handler.
+import "../copy-tex";
+
+// "first $x^2$ second <unselectable> third", the markup from
+// https://github.com/KaTeX/KaTeX/issues/3812.
+const buildDocument = () => {
+    document.body.innerHTML =
+        "first " + katex.renderToString("x^2", {}) + " second " +
+        '<span style="user-select: none">unselectable</span> third';
+    const nodes = document.body.childNodes;
+    return {
+        beforeGap: nodes[2] as Text,  // " second "
+        afterGap: nodes[4] as Text,   // " third"
+    };
+};
+
+const rangeOver = (start: Node, end: Node) => {
+    const range = document.createRange();
+    range.setStart(start, 0);
+    range.setEnd(end, end.textContent!.length);
+    return range;
+};
+
+// Dispatch a copy event over a selection holding the given ranges, and
+// return what the handler wrote to the clipboard.
+const copy = (ranges: Range[]) => {
+    const written: Record<string, string> = {};
+    const setData = (format: string, data: string) => {
+        written[format] = data;
+    };
+    jest.spyOn(window, "getSelection").mockReturnValue({
+        isCollapsed: false,
+        rangeCount: ranges.length,
+        getRangeAt: (i: number) => ranges[i],
+    } as unknown as Selection);
+
+    const event = new Event("copy", {bubbles: true, cancelable: true});
+    Object.defineProperty(event, "clipboardData", {value: {setData}});
+    document.dispatchEvent(event);
+
+    return written["text/plain"];
+};
+
+afterEach(() => {
+    jest.restoreAllMocks();
+});
+
+describe("copy-tex", () => {
+    it("replaces math with its TeX source", () => {
+        const {beforeGap} = buildDocument();
+        const text = copy([rangeOver(document.body.firstChild!, beforeGap)]);
+
+        expect(text).toBe("first $x^2$ second ");
+    });
+
+    it("copies every range of a multi-range selection", () => {
+        const {beforeGap, afterGap} = buildDocument();
+        const text = copy([
+            rangeOver(document.body.firstChild!, beforeGap),
+            rangeOver(afterGap, afterGap),
+        ]);
+
+        // Two spaces: the source has one on either side of the span, and
+        // only the span itself is skipped.
+        expect(text).toBe("first $x^2$ second  third");
+    });
+
+    it("does not repeat a formula covered by two ranges", () => {
+        buildDocument();
+        const math = document.querySelector(".katex")!;
+        const parts = [
+            math.querySelector(".katex-mathml")!,
+            math.querySelector(".katex-html")!,
+        ];
+
+        const text = copy(parts.map((part) => {
+            const range = document.createRange();
+            range.selectNodeContents(part);
+            return range;
+        }));
+
+        expect(text).toBe("$x^2$");
+    });
+});


### PR DESCRIPTION
**What is the previous behavior before this PR?**

The `copy` handler read only `selection.getRangeAt(0)`. When a selection held more than one range, everything after the first range was dropped from the clipboard.

This only surfaced when math was in the selection — without a `.katex-mathml` in the cloned fragment the handler returns early and the browser's own multi-range copy runs, so the text came out whole.

**What is the new behavior after this PR?**

Every range is cloned into one fragment. Single-range selections — which is every selection in Chromium and WebKit — are unchanged.

A range starting inside a formula that an earlier range already copied now starts *after* that formula, so a formula split across two ranges is copied once rather than twice.

---

Reported in #3812 for Firefox's `user-select: none` behaviour. That specific trigger is gone: Mozilla [bug 1998858](https://bugzilla.mozilla.org/show_bug.cgi?id=1998858) ("A single selection over unselectable elements produces multiple ranges") stopped Firefox splitting selections around unselectable nodes in Firefox 147.

Multiple ranges are still reachable, though — Ctrl-clicking builds one range per click, and [bug 753718](https://bugzilla.mozilla.org/show_bug.cgi?id=753718) to drop multi-range support entirely is still open — so the underlying bug stands. I have not marked this as closing #3812, since its exact repro behaves differently now.

`contrib/copy-tex` had no tests, so this adds `contrib/copy-tex/test/copy-tex-spec.ts` with three: the existing single-range behaviour, the multi-range fix, and the no-duplicate guard. Each one fails against the code it guards.
