### PR TITLE
fix(array): remove negative margin on edge vertical separators \hline

### DIFF
--- a/src/environments/array.ts
+++ b/src/environments/array.ts
@@ -438,6 +438,8 @@ const htmlBuilder: HtmlBuilder<"array"> = function(group, options) {
 
         let firstSeparator = true;
         while (colDescr?.type === "separator") {
+            const isAtArrayEdge = c === 0 || c >= nc;
+
             // If there is more than one separator in a row, add a space
             // between them.
             if (!firstSeparator) {
@@ -453,7 +455,11 @@ const htmlBuilder: HtmlBuilder<"array"> = function(group, options) {
                 separator.style.height = makeEm(totalHeight);
                 separator.style.borderRightWidth = makeEm(ruleThickness);
                 separator.style.borderRightStyle = lineType;
-                separator.style.margin = `0 ${makeEm(-ruleThickness / 2)}`;
+
+                if (!isAtArrayEdge) {
+                    separator.style.margin = `0 ${makeEm(-ruleThickness / 2)}`;
+                }
+
                 const shift = totalHeight - offset;
                 if (shift) {
                     separator.style.verticalAlign = makeEm(-shift);


### PR DESCRIPTION
fix(array): remove negative margin on edge vertical separators

**What is the previous behavior before this PR?**

When an array has vertical separators at the edges `\begin{array}{|c|} \hline x \\ \hline \end{array}`, the leftmost and rightmost column dividers have a negative margin applied. This shifts the vertical lines slightly inward, causing a misalignment where the `\hline` does not connect cleanly with the column dividers, breaking the rectangular bounding box around cells.

**What is the new behavior after this PR?**

Edge vertical separators no longer has the negative margin. This keeps the leftmost and rightmost vertical lines aligned with the `\hline`, so array cells form complete rectangles as expected. 

**Before Change:**
<img width="613" height="223" alt="Screenshot 2026-09-06 at 10 59 40 AM" src="https://github.com/user-attachments/assets/4182eef6-e843-401a-8d23-a20ca2b440f4" />

**After:**
<img width="634" height="233" alt="Screenshot 2026-09-06 at 10 59 26 AM" src="https://github.com/user-attachments/assets/98bd67f4-c8b0-4744-8dc6-5686475bf68c" />

**Fixes #4279**
